### PR TITLE
k8s: null coalesce clientset on pod delete

### DIFF
--- a/frontend/workflows/k8s/src/delete-pod.jsx
+++ b/frontend/workflows/k8s/src/delete-pod.jsx
@@ -83,8 +83,9 @@ const DeletePod = ({ heading, resolverType }) => {
     deletionData: {
       deps: ["resourceData", "resolverInput"],
       hydrator: (resourceData, resolverInput) => {
+        const clientset = resolverInput.clientset ?? "undefined";
         return client.post("/v1/k8s/deletePod", {
-          clientset: resolverInput.clientset,
+          clientset,
           cluster: resourceData.cluster,
           namespace: resourceData.namespace,
           name: resourceData.name,


### PR DESCRIPTION
Our internal resolver deduces the clientset based on the user and clusters
passed. Coalescing this to `"undefined"` matches the HPA frontend as well.
