### PR TITLE
docs: update some broken links

### DIFF
--- a/docs/about/architecture.md
+++ b/docs/about/architecture.md
@@ -73,7 +73,7 @@ Services are always exposed as an interface, so they can easily be replaced with
 
 Most workflows start with the need to locate one or more resources. Resources such as nodes, services, and databases can be found in any organization, but are rarely referred to in the same way or by the same common name. This can be due to team or service structure, migration from another system, legacy systems, individual requirements, or many other reasons.
 
-In addition to locating resources, resolvers also describe how they locate resources by producing schemas for user input. These schemas can be rendered by the frontend or other clients dynamically so that workflows can remain agnostic to resource location. See [Frontend Resolver Component](#resolver-component) for more information.
+In addition to locating resources, resolvers also describe how they locate resources by producing schemas for user input. These schemas can be rendered by the frontend or other clients dynamically so that workflows can remain agnostic to resource location. See [Frontend Resolver Component](/docs/development/frontend#using-the-resolver-component) for more information.
 
 #### `have` and `want`
 

--- a/docs/about/what-is-clutch.md
+++ b/docs/about/what-is-clutch.md
@@ -35,20 +35,20 @@ Stop putting your team through an endless stream of high-friction tools and user
 - 🔍 **Built for discovery.**
   - Resources have many common names. Clutch's Resolver pattern makes it easier than ever to locate resources.
   - The Resolver provides server-generated forms with one-line of frontend code, ensuring the API and frontend are always in sync.
-- ⚛️ **Easy to develop, run, and maintain.** 
+- ⚛️ **Easy to develop, run, and maintain.**
   - Developed with Go and Typescript, plus Protobuf for generated interfaces throughout.
   - Back-end abstractions ensure loose coupling and put feature development on rails.
   - Frontend components make it simple for developers with limited frontend experience to ship features.
   - Deployable as a single binary containing both backend and frontend resources.
   - Basic auditing, authorization, stats, and logging come for free with every endpoint.
-- 🔒 **Secure and observable.** 
+- 🔒 **Secure and observable.**
   - Single sign-on support.
   - Role-based access control (RBAC) engine for granular access control beyond what vendor IAM policies support.
   - Built-in auditing with sinks for Slack and more.
   - Extensive logging and stats capabilities.
 
 ## Vision
-- 💡 **Get smart(er).** 
+- 💡 **Get smart(er).**
   - Present relevant information on the homepage based on context such as user identity, ownership, and ongoing incidents.
   - Additional core integrations with cloud-native infrastructure.
   - Fully-customizable heuristic support. Safety is based on the current context and design of the overall system.
@@ -59,7 +59,7 @@ Stop putting your team through an endless stream of high-friction tools and user
   - Command-line gateway, e.g. `clutchctl`, for those times when `grep` is just faster than anything else.
   - Code-generated SDK for polyglot automation support.
 
-For more concrete items, see the [Roadmap](/docs/roadmap).
+For more concrete items, see the [Roadmap](/docs/about/roadmap).
 
 ## Why Clutch?
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -42,7 +42,7 @@ To have pull requests merged, contributors must sign the [Contributor License Ag
 
 ### Core
 
-The core project, hosted in [`lyft/clutch`](https://github.com/lyft/clutch), is designed to be universal and broadly applicable to a large variety of organizations. Code that is overly-specific to a single organization will not be accepted into the core. However, Clutch was designed to allow custom code without having to fork. See [Custom Extensions](/docs/usage/extensions) for more details.
+The core project, hosted in [`lyft/clutch`](https://github.com/lyft/clutch), is designed to be universal and broadly applicable to a large variety of organizations. Code that is overly-specific to a single organization will not be accepted into the core. However, Clutch was designed to allow custom code without having to fork. See [Custom Gateway](/docs/development/custom-gateway) for more details.
 
 It's also possible to contribute features incrementally to the core. For example, you can contribute an API definition but keep the implementation private.
 


### PR DESCRIPTION
Fix some broken links found clicking around the docs. Trim whitespace from the
doc pages as well.

Fixes #54