### PR TITLE
docs: fix unnecessary build cancellation

### DIFF
--- a/docs/_website/netlify.toml
+++ b/docs/_website/netlify.toml
@@ -1,0 +1,3 @@
+# Fix for https://community.netlify.com/t/builds-cancelled-for-a-new-branch-due-to-no-content-change/17169/2
+[build]
+   ignore = "/bin/false"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Because the docs are generated, but not from a nested folder in _website, netlify never sees changes to the markdown.

This means that all builds that only modify markdown are cancelled.

Per the help community, here's one way of solving the problem:
https://community.netlify.com/t/builds-cancelled-for-a-new-branch-due-to-no-content-change/17169/2

### Testing Performed
CI.