### PR TITLE
ci: execute yarn directly instead of from PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERSION := 0.0.0
 	@grep -E '^\.PHONY: [a-zA-Z_-]+ .*?# .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = "(: |#)"}; {printf "%-30s %s\n", $$2, $$3}'
 
 .PHONY: all # Generate API, Frontend, and backend assets.
-all: api frontend backend-with-assets
+all: yarn-ensure api frontend backend-with-assets
 
 .PHONY: api # Generate API assets.
 api:

--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,11 @@ frontend-verify: yarn-ensure
 	$(YARN) --cwd frontend lint:packages
 
 .PHONY: docs # Build all doc assets.
-docs: docs-generate
+docs: docs-generate yarn-ensure
 	$(YARN) --cwd docs/_website install --frozen-lockfile && $(YARN) --cwd docs/_website build
 
 .PHONY: docs-dev # Start the docs server in development mode.
-docs-dev: docs-generate
+docs-dev: docs-generate yarn-ensure
 	$(YARN) --cwd docs/_website install --frozen-lockfile && BROWSER=none $(YARN) --cwd docs/_website start
 
 .PHONY: docs-generate # Generate the documentation content.

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,17 @@ DOCS_DEPLOY_GIT_USER ?= git
 
 VERSION := 0.0.0
 
+YARN:=./build/bin/yarn.sh
+
 .PHONY: help # Print this help message.
  help:
 	@grep -E '^\.PHONY: [a-zA-Z_-]+ .*?# .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = "(: |#)"}; {printf "%-30s %s\n", $$2, $$3}'
 
 .PHONY: all # Generate API, Frontend, and backend assets.
-all: yarn-ensure api frontend backend-with-assets
+all: api frontend backend-with-assets
 
 .PHONY: api # Generate API assets.
-api:
+api: yarn-ensure
 	tools/compile-protos.sh
 
 .PHONY: api-lint # Lint the generated API assets.
@@ -74,27 +76,27 @@ backend-config-validation:
 
 .PHONY: frontend # Build production frontend assets.
 frontend: yarn-ensure
-	cd frontend && yarn install --frozen-lockfile && yarn build
+	$(YARN) --cwd frontend install --frozen-lockfile && $(YARN) --cwd frontend build
 
 .PHONY: frontend-dev-build # Build development frontend assets.
 frontend-dev-build: yarn-ensure
-	cd frontend && yarn install --frozen-lockfile && yarn build:dev
+	$(YARN) --cwd frontend install --frozen-lockfile && $(YARN) --cwd frontend build:dev
 
 .PHONY: frontend-dev # Start the frontend in development mode.
 frontend-dev: yarn-ensure
-	cd frontend && yarn install --frozen-lockfile && yarn start
+	$(YARN) --cwd frontend install --frozen-lockfile && $(YARN) --cwd frontend start
 
 .PHONY: frontend-lint # Lint the frontend code.
 frontend-lint: yarn-ensure
-	cd frontend && yarn lint
+	$(YARN) --cwd frontend lint
 
 .PHONY: frontend-lint-fix # Lint and fix the frontend code.
 frontend-lint-fix: yarn-ensure
-	cd frontend && yarn lint:fix
+	$(YARN) --cwd frontend lint:fix
 
 .PHONY: frontend-test # Run unit tests for the frontend code.
 frontend-test: yarn-ensure
-	cd frontend && yarn test
+	$(YARN) --cwd frontend test
 
 .PHONY: frontend-e2e # Run end-to-end tests for the frontend code.
 frontend-e2e: yarn-ensure
@@ -102,19 +104,15 @@ frontend-e2e: yarn-ensure
 
 .PHONY: frontend-verify # Verify frontend packages are sorted.
 frontend-verify: yarn-ensure
-	cd frontend && yarn lint:packages
+	$(YARN) --cwd frontend lint:packages
 
 .PHONY: docs # Build all doc assets.
 docs: docs-generate
-	cd docs/_website && yarn install --frozen-lockfile && yarn build
-
-.PHONY: docs-deploy # Deploy the documentation.
-docs-deploy: docs
-	cd docs/_website && GIT_USER=$(DOCS_DEPLOY_GIT_USER) USE_SSH=$(DOCS_DEPLOY_USE_SSH) yarn deploy
+	$(YARN) --cwd docs/_website install --frozen-lockfile && $(YARN) --cwd docs/_website build
 
 .PHONY: docs-dev # Start the docs server in development mode.
 docs-dev: docs-generate
-	cd docs/_website && yarn install --frozen-lockfile && BROWSER=none yarn start
+	$(YARN) --cwd docs/_website install --frozen-lockfile && BROWSER=none $(YARN) --cwd docs/_website start
 
 .PHONY: docs-generate # Generate the documentation content.
 docs-generate:

--- a/tools/compile-protos.sh
+++ b/tools/compile-protos.sh
@@ -194,7 +194,7 @@ install_protobufjs() {
   if [[ ! -f "${PROTOBUFJS_DIR}/node_modules/.bin/pbjs" ]]; then
     echo "info: Downloading protobufjs to build environment"
     mkdir -p "${PROTOBUFJS_DIR}"
-    "${REPO_ROOT} yarn" --cwd "${PROTOBUFJS_DIR}" add --frozen-lockfile "${PROTOBUFJS_FORK}#${PROTOBUFJS_SHA}"
+    "${BUILD_ROOT}/bin/yarn.sh" --cwd "${PROTOBUFJS_DIR}" add --frozen-lockfile "${PROTOBUFJS_FORK}#${PROTOBUFJS_SHA}"
   fi
 }
 

--- a/tools/compile-protos.sh
+++ b/tools/compile-protos.sh
@@ -194,7 +194,7 @@ install_protobufjs() {
   if [[ ! -f "${PROTOBUFJS_DIR}/node_modules/.bin/pbjs" ]]; then
     echo "info: Downloading protobufjs to build environment"
     mkdir -p "${PROTOBUFJS_DIR}"
-    yarn --cwd "${PROTOBUFJS_DIR}" add --frozen-lockfile "${PROTOBUFJS_FORK}#${PROTOBUFJS_SHA}"
+    "${REPO_ROOT} yarn" --cwd "${PROTOBUFJS_DIR}" add --frozen-lockfile "${PROTOBUFJS_FORK}#${PROTOBUFJS_SHA}"
   fi
 }
 

--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
 LINKED_PACKAGES=("react" "react-dom" "react-router" "react-router-dom")
 
-DEST_DIR="${1}/frontend"
+EXTERNAL_ROOT="${1}"
+YARN="${EXTERNAL_ROOT}/build/bin/yarn.sh"
+
+DEST_DIR="${EXTERNAL_ROOT}/frontend"
 
 # ensure consistent yarn versioning
- cd "${REPO_ROOT}"
+cd "${REPO_ROOT}"
 tools/install-yarn.sh
 
 # default to build, can pass in start as second argument if dev is desired
@@ -16,25 +19,25 @@ action="${2:-build}"
 ln -sf "${REPO_ROOT}" "${DEST_DIR}"
 
 cd "${REPO_ROOT}/frontend"
-yarn --frozen-lockfile install
+"${YARN}" --frozen-lockfile install
 
 # Link deps from core repo.
 cd node_modules
 for package in "${LINKED_PACKAGES[@]}"; do
   cd "${package}"
-  yarn link
+  "${YARN}" link
   cd ..
 done
 
 # Ensure yarn in destination directory
-cd "${1}"
+cd "${EXTERNAL_ROOT}"
 "${REPO_ROOT}"/tools/install-yarn.sh
 
 # Use linked deps in consuming repo.
 cd "${DEST_DIR}"
 for package in "${LINKED_PACKAGES[@]}"; do
-  yarn link "${package}"
+  "${YARN}" link "${package}"
 done
 
-yarn --frozen-lockfile install
-yarn "${action}"
+"${YARN}" --frozen-lockfile install
+"${YARN}" "${action}"

--- a/tools/install-yarn.sh
+++ b/tools/install-yarn.sh
@@ -18,9 +18,9 @@ if [[ ! -f "${DEST_FILE}" ]]; then
     "https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-${YARN_VERSION}.js"
 fi
 
-# Install a wrapper script in build/ that executes yarn.
-WRAPPER_SCRIPT="#!/bin/bash\nnode \"${DEST_FILE}\" \"\$@\""
-if [[ ! -f "${WRAPPER_DEST}" ]]; then
-  printf "%b\n" "${WRAPPER_SCRIPT}" > "${WRAPPER_DEST}"
+# Install a wrapper script in build/ that executes yarn if it doesn't exist already.
+WRAPPER_SCRIPT="#!/bin/bash\nnode \"${DEST_FILE}\" \"\$@\"\n"
+if [[ ! -f "${WRAPPER_DEST}" || $(< "${WRAPPER_DEST}") != $(printf "%b" "${WRAPPER_SCRIPT}") ]]; then
+  printf "%b" "${WRAPPER_SCRIPT}" > "${WRAPPER_DEST}"
   chmod +x "${WRAPPER_DEST}"
 fi

--- a/tools/install-yarn.sh
+++ b/tools/install-yarn.sh
@@ -4,7 +4,8 @@ YARN_VERSION="1.22.4"
 ROOT_DEST_DIR="$PWD/frontend"
 DEST_DIR="$ROOT_DEST_DIR/.yarn/releases"
 DEST_FILE="${DEST_DIR}/yarn-${YARN_VERSION}.js"
-WRAPPER_DEST_FILE="${PWD}/build/bin/yarn.sh"
+WRAPPER_DEST_DIR="${PWD}/build/bin/"
+WRAPPER_DEST_FILE="${WRAPPER_DEST_DIR}/yarn.sh"
 
 if [[ ! -d "${ROOT_DEST_DIR}" ]]; then
   echo "Could not find frontend directory. Ensure you're running this script from the root of your project."
@@ -21,6 +22,7 @@ fi
 # Install a wrapper script in build/ that executes yarn if it doesn't exist already.
 WRAPPER_SCRIPT="#!/bin/bash\nnode \"${DEST_FILE}\" \"\$@\"\n"
 if [[ ! -f "${WRAPPER_DEST_FILE}" || $(< "${WRAPPER_DEST_FILE}") != $(printf "%b" "${WRAPPER_SCRIPT}") ]]; then
+  mkdir -p "${WRAPPER_DEST_DIR}"
   printf "%b" "${WRAPPER_SCRIPT}" > "${WRAPPER_DEST_FILE}"
   chmod +x "${WRAPPER_DEST_FILE}"
 fi

--- a/tools/install-yarn.sh
+++ b/tools/install-yarn.sh
@@ -4,6 +4,7 @@ YARN_VERSION="1.22.4"
 ROOT_DEST_DIR="$PWD/frontend"
 DEST_DIR="$ROOT_DEST_DIR/.yarn/releases"
 DEST_FILE="${DEST_DIR}/yarn-${YARN_VERSION}.js"
+WRAPPER_DEST="${PWD}/build/bin/yarn.sh"
 
 if [[ ! -d "${ROOT_DEST_DIR}" ]]; then
   echo "Could not find frontend directory. Ensure you're running this script from the root of your project."
@@ -15,4 +16,11 @@ if [[ ! -f "${DEST_FILE}" ]]; then
   mkdir -p "${DEST_DIR}"
   curl -sSL -o "${DEST_FILE}" \
     "https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-${YARN_VERSION}.js"
+fi
+
+# Install a wrapper script in build/ that executes yarn.
+WRAPPER_SCRIPT="#!/bin/bash\nnode \"${DEST_FILE}\" \"\$@\""
+if [[ ! -f "${WRAPPER_DEST}" ]]; then
+  printf "%b\n" "${WRAPPER_SCRIPT}" > "${WRAPPER_DEST}"
+  chmod +x "${WRAPPER_DEST}"
 fi

--- a/tools/install-yarn.sh
+++ b/tools/install-yarn.sh
@@ -4,7 +4,7 @@ YARN_VERSION="1.22.4"
 ROOT_DEST_DIR="$PWD/frontend"
 DEST_DIR="$ROOT_DEST_DIR/.yarn/releases"
 DEST_FILE="${DEST_DIR}/yarn-${YARN_VERSION}.js"
-WRAPPER_DEST="${PWD}/build/bin/yarn.sh"
+WRAPPER_DEST_FILE="${PWD}/build/bin/yarn.sh"
 
 if [[ ! -d "${ROOT_DEST_DIR}" ]]; then
   echo "Could not find frontend directory. Ensure you're running this script from the root of your project."
@@ -20,7 +20,7 @@ fi
 
 # Install a wrapper script in build/ that executes yarn if it doesn't exist already.
 WRAPPER_SCRIPT="#!/bin/bash\nnode \"${DEST_FILE}\" \"\$@\"\n"
-if [[ ! -f "${WRAPPER_DEST}" || $(< "${WRAPPER_DEST}") != $(printf "%b" "${WRAPPER_SCRIPT}") ]]; then
-  printf "%b" "${WRAPPER_SCRIPT}" > "${WRAPPER_DEST}"
-  chmod +x "${WRAPPER_DEST}"
+if [[ ! -f "${WRAPPER_DEST_FILE}" || $(< "${WRAPPER_DEST_FILE}") != $(printf "%b" "${WRAPPER_SCRIPT}") ]]; then
+  printf "%b" "${WRAPPER_SCRIPT}" > "${WRAPPER_DEST_FILE}"
+  chmod +x "${WRAPPER_DEST_FILE}"
 fi

--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -10,7 +10,7 @@ MY_ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 all: api frontend backend-with-assets
 
 .PHONY: api
-api:
+api: yarn-ensure
 	$(PRIMARY_MODULE_DIR)/../tools/compile-protos.sh $(MY_ROOT_DIR)
 
 .PHONY: backend
@@ -30,5 +30,9 @@ backend-with-assets: frontend
 	cd backend && go run cmd/assets/generate.go ../frontend/packages/app/build && go build -tags withAssets -o ../build/clutch -ldflags="-X main.version=$(VERSION)"
 
 .PHONY: frontend
-frontend:
+frontend: yarn-ensure
 	$(PRIMARY_MODULE_DIR)/../tools/frontend-gateway-linker.sh $(MY_ROOT_DIR) build
+
+.PHONY: yarn-ensure
+yarn-ensure:
+	@$(PRIMARY_MODULE_DIR)/../tools/install-yarn.sh


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
We were already downloading yarn as a js file in order to pin it.

Then we would call the system yarn which would read the yarnrc and then call into the downloaded yarn.

Instead of relying on system yarn, provide a script that calls the downloaded yarn directly.

### Testing Performed
Manual + CI.

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #60 

### TODOs
- [x] update frontend-linker
