### PR TITLE
ec2: display tags during termination flow

### DIFF
--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -31,19 +31,25 @@ const InstanceDetails: React.FC<WizardChild> = () => {
   const resourceData = useDataLayout("resourceData");
   const instance = resourceData.displayValue();
 
+  const data = [
+    { name: "Instance ID", value: instance.instanceId },
+    { name: "Region", value: instance.region },
+    { name: "State", value: instance.state },
+    { name: "Instance Type", value: instance.instanceType },
+    { name: "Public IP Address", value: instance.publicIpAddress },
+    { name: "Private IP Address", value: instance.privateIpAddress },
+    { name: "Availability Zone", value: instance.availabilityZone },
+  ];
+
+  if (instance.tags) {
+    Object.keys(instance.tags).forEach(key => {
+      data.push({ name: key, value: instance.tags[key] });
+    });
+  }
+
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
-      <MetadataTable
-        data={[
-          { name: "Instance ID", value: instance.instanceId },
-          { name: "Region", value: instance.region },
-          { name: "State", value: instance.state },
-          { name: "Instance Type", value: instance.instanceType },
-          { name: "Public IP Address", value: instance.publicIpAddress },
-          { name: "Private IP Address", value: instance.privateIpAddress },
-          { name: "Availability Zone", value: instance.availabilityZone },
-        ]}
-      />
+      <MetadataTable data={data} />
       <ButtonGroup
         buttons={[
           {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Appends all available tags for the instance, as they are secondary information I opted to display them below our original data set.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

Before
![Screen Shot 2020-07-23 at 10 12 39 AM](https://user-images.githubusercontent.com/2250844/88316808-381ce080-cccd-11ea-9a7f-49bd1a4bd6c5.png)

After
![Screen Shot 2020-07-23 at 10 10 12 AM](https://user-images.githubusercontent.com/2250844/88316818-39e6a400-cccd-11ea-8d54-6ef0616fd90b.png)

### Testing Performed
<!-- Describe how you tested this change below. -->

Local testing.

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

n/a

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->


