### PR TITLE
ci: make tools its own module

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,3 @@
+module github.com/lyft/clutch/tools
+
+go 1.14

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,3 +1,3 @@
 module github.com/lyft/clutch/tools
 
-go 1.14
+go 1.13


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Makes tools a module so it can be vendored with go modules tooling for custom gateways.

### Testing Performed
Manual

### GitHub Issue
First step in addressing #88 
