### PR TITLE
ci: publish beta versions of frontend packages

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -120,6 +120,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn --cwd frontend install
       - name: publish
-        run: yarn --cwd frontend publishAlpha
+        run: yarn --cwd frontend publishBeta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "lint:fix": "lerna run lint:fix --no-bail",
     "lint:packages": "npx sort-package-json package.json packages/**/package.json --check",
     "lint:packages:fix": "npx sort-package-json package.json packages/**/package.json",
-    "publishAlpha": "lerna run compile && lerna run publishAlpha --no-bail -- --no-git-tag-version",
+    "publishBeta": "lerna run compile && lerna run publishBeta --no-bail -- --no-git-tag-version",
     "start": "yarn compile:watch & yarn workspace @clutch-sh/app start",
     "test": "lerna run test --stream --no-bail --",
     "test:coverage": "lerna run test:coverage --stream --no-bail --",

--- a/frontend/packages/app/package.json
+++ b/frontend/packages/app/package.json
@@ -18,12 +18,12 @@
     "test:e2e": "cypress run"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
     "react": "^16.8",
     "react-dom": "^16.8.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   },
   "proxy": "http://localhost:8080"
 }

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
     "prepublishOnly": "yarn run build",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
@@ -46,6 +46,6 @@
     "yup": "^0.29.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/core",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Clutch Core Components",
   "homepage": "https://clutch.sh/docs/development/frontend#clutch-shcore",
   "license": "Apache-2.0",

--- a/frontend/packages/data-layout/package.json
+++ b/frontend/packages/data-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/data-layout",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Data Layout manager for clutch",
   "homepage": "https://clutch.sh/docs/development/frontend#clutch-shdata-layout",
   "license": "Apache-2.0",

--- a/frontend/packages/data-layout/package.json
+++ b/frontend/packages/data-layout/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
     "prepublishOnly": "yarn run build",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
@@ -31,6 +31,6 @@
     "react-hook-thunk-reducer": "^0.2.1"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/frontend/packages/tools/package.json
+++ b/frontend/packages/tools/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
   "scripts": {
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "registerWorkflows": "node workflow-registrar.js",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage"

--- a/frontend/packages/tools/package.json
+++ b/frontend/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/tools",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Tools for testing and building clutch components",
   "homepage": "https://clutch.sh/docs/development/frontend#clutch-shtools",
   "license": "Apache-2.0",

--- a/frontend/packages/wizard/package.json
+++ b/frontend/packages/wizard/package.json
@@ -19,14 +19,14 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
     "prepublishOnly": "yarn run build",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
-    "@clutch-sh/data-layout": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "clsx": "^1.1.1",
@@ -34,6 +34,6 @@
     "styled-components": "^5.0.1"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/frontend/packages/wizard/package.json
+++ b/frontend/packages/wizard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/wizard",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Wizard Components to drive frontend workflows",
   "homepage": "https://clutch.sh/docs/development/frontend#clutch-shwizard",
   "license": "Apache-2.0",

--- a/frontend/workflows/ec2/package.json
+++ b/frontend/workflows/ec2/package.json
@@ -17,15 +17,15 @@
     "compile:watch": "BABEL_ENV=build babel src --out-dir dist --source-maps --extensions .js,.jsx,.ts,.tsx --ignore **/tests --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
-    "@clutch-sh/data-layout": "^0.0.0",
-    "@clutch-sh/wizard": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "react": "^16.8",
     "react-dom": "^16.8.0",
@@ -36,6 +36,6 @@
     "yup": "^0.29.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "0.0.0-beta"
   }
 }

--- a/frontend/workflows/ec2/package.json
+++ b/frontend/workflows/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/ec2",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Clutch EC2 Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/envoy/package.json
+++ b/frontend/workflows/envoy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/envoy",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Clutch Envoy Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/envoy/package.json
+++ b/frontend/workflows/envoy/package.json
@@ -16,15 +16,15 @@
     "compile:watch": "yarn compile --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn test --collect-coverage",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
-    "@clutch-sh/data-layout": "^0.0.0",
-    "@clutch-sh/wizard": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "lodash": "^4.17.15",
     "react": "^16.8",
@@ -36,6 +36,6 @@
     "yup": "^0.29.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/frontend/workflows/experimentation/package.json
+++ b/frontend/workflows/experimentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/experimentation",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Clutch Experimentation Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/experimentation/package.json
+++ b/frontend/workflows/experimentation/package.json
@@ -12,16 +12,16 @@
     "compile:watch": "yarn run compile --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch",
     "upgrade": "yarn upgrade"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
-    "@clutch-sh/data-layout": "^0.0.0",
-    "@clutch-sh/wizard": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "lodash": "^4.17.15",
     "react": "^16.8",
@@ -33,6 +33,6 @@
     "yup": "^0.29.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -16,15 +16,15 @@
     "compile:watch": "yarn run compile --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
-    "@clutch-sh/data-layout": "^0.0.0",
-    "@clutch-sh/wizard": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "enzyme": "^3.11.0",
     "lodash": "4.17.19",
@@ -37,6 +37,6 @@
     "yup": "^0.29.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/k8s",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Clutch K8s Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/kinesis/package.json
+++ b/frontend/workflows/kinesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/kinesis",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Clutch Kinesis Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/kinesis/package.json
+++ b/frontend/workflows/kinesis/package.json
@@ -17,15 +17,15 @@
     "compile:watch": "BABEL_ENV=build babel src --out-dir dist --source-maps --extensions .js,.jsx,.ts,.tsx --ignore **/tests --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
-    "@clutch-sh/data-layout": "^0.0.0",
-    "@clutch-sh/wizard": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "react": "^16.8",
     "react-dom": "^16.8.0",
@@ -37,6 +37,6 @@
     "yup": "^0.29.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/frontend/workflows/sourcecontrol/package.json
+++ b/frontend/workflows/sourcecontrol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/sourcecontrol",
-  "version": "0.0.0",
+  "version": "0.0.0-beta",
   "description": "Clutch Source Control Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/sourcecontrol/package.json
+++ b/frontend/workflows/sourcecontrol/package.json
@@ -16,15 +16,15 @@
     "compile:watch": "yarn run compile --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
-    "publishAlpha": "yarn publish --new-version=\"0.0.0-$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')-$(git rev-parse --short=12 HEAD)\" --access public",
+    "publishBeta": "yarn publish --new-version=\"0.0.0-beta.$(git log -1 --format=%cd --date=format:'%Y%m%d%H%M%S')\" --access public",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^0.0.0",
-    "@clutch-sh/data-layout": "^0.0.0",
-    "@clutch-sh/wizard": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "react": "^16.8",
     "react-dom": "^16.8.0",
@@ -36,6 +36,6 @@
     "yup": "^0.29.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/tools/scaffolding/templates/frontend/package.json
+++ b/tools/scaffolding/templates/frontend/package.json
@@ -18,11 +18,11 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/wizard": "^0.0.0",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "react": "^16.8",
     "react-dom": "^16.8.0"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^0.0.0"
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }

--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -22,9 +22,9 @@
   },
   "devDependencies": {
     "lerna": "^3.20.0",
-    "@clutch-sh/ec2": "^0.0.0",
+    "@clutch-sh/ec2": "^0.0.0-beta",
     "@{{ .RepoName }}/echo": "^0.0.0",
-    "@clutch-sh/core": "^0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
     "react": "^16.8",
     "react-dom": "^16.8.0",
     "react-scripts": "^3.4.0",

--- a/tools/scaffolding/templates/gateway/frontend/workflows/echo/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/workflows/echo/package.json
@@ -16,9 +16,9 @@
     "upgrade": "yarn upgrade"
   },
   "dependencies": {
-    "@clutch-sh/core": "0.0.0",
-    "@clutch-sh/data-layout": "0.0.0",
-    "@clutch-sh/wizard": "0.0.0",
+    "@clutch-sh/core": "^0.0.0-beta",
+    "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
     "react": "^16.8",
     "react-dom": "^16.8.0",
@@ -26,5 +26,8 @@
     "react-router": "^6.0.0-alpha",
     "react-router-dom": "^6.0.0-alpha.2",
     "styled-components": "^5.0.1"
+  },
+  "devDependencies": {
+    "@clutch-sh/tools": "^0.0.0-beta"
   }
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Publish and consume beta versions of clutch packages/workflows.

This allows us to still maintain some correlation between the frontend and backend versioning while also allowing us to use semantic version resolution during installations.