### PR TITLE
k8s: RetryOnConflict for resource mutations

### DIFF
--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -60,7 +60,7 @@ func (s *svc) UpdateDeployment(ctx context.Context, clientset, cluster, namespac
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err = cs.AppsV1().Deployments(cs.Namespace()).Patch(oldDeployment.Name, types.StrategicMergePatchType, patchBytes)
+		_, err := cs.AppsV1().Deployments(cs.Namespace()).Patch(oldDeployment.Name, types.StrategicMergePatchType, patchBytes)
 		return err
 	})
 	return retryErr

--- a/backend/service/k8s/hpa.go
+++ b/backend/service/k8s/hpa.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 
@@ -53,8 +54,12 @@ func (s *svc) ResizeHPA(ctx context.Context, clientset, cluster, namespace, name
 	}
 
 	normalizeHPAChanges(hpa, sizing)
-	_, err = cs.AutoscalingV1().HorizontalPodAutoscalers(cs.Namespace()).Update(hpa)
-	return err
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = cs.AutoscalingV1().HorizontalPodAutoscalers(cs.Namespace()).Update(hpa)
+		return err
+	})
+	return retryErr
 }
 
 func normalizeHPAChanges(hpa *autoscalingv1.HorizontalPodAutoscaler, sizing *k8sapiv1.ResizeHPARequest_Sizing) {

--- a/backend/service/k8s/hpa.go
+++ b/backend/service/k8s/hpa.go
@@ -56,7 +56,7 @@ func (s *svc) ResizeHPA(ctx context.Context, clientset, cluster, namespace, name
 	normalizeHPAChanges(hpa, sizing)
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err = cs.AutoscalingV1().HorizontalPodAutoscalers(cs.Namespace()).Update(hpa)
+		_, err := cs.AutoscalingV1().HorizontalPodAutoscalers(cs.Namespace()).Update(hpa)
 		return err
 	})
 	return retryErr


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This ensure that the k8s logic when mutating a resource has basic conflict retries as provided by upstream. Mutations of k8s objects happen very frequently this is important for the services reliability. We will use the default [retry policy](https://github.com/kubernetes/client-go/blob/3473491eeb2e22384b846a27f3dceb9aaa73dd76/util/retry/util.go#L26-L33).

### Testing Performed
<!-- Describe how you tested this change below. -->

Manual testing of both k8s endpoints on a local k8s cluster (v1.16.6).

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->
n/a
