### PR TITLE
tools: fix cwd for workflow registrar to find installed workflows

### DIFF
--- a/frontend/packages/tools/workflow-registrar.js
+++ b/frontend/packages/tools/workflow-registrar.js
@@ -2,6 +2,7 @@ const childProcess = require("child_process");
 const fs = require("fs");
 
 const config = require(`${process.argv[2]}/clutch.config.js`); // eslint-disable-line import/no-dynamic-require
+const rootFrontendDir = `${process.argv[2]}/..`;
 
 const WORKFLOW_MODULE_PATH = `${process.argv[2]}/workflows.jsx`;
 
@@ -39,7 +40,7 @@ const discoverWorkflows = () => {
     return childProcess.exec(
       `yarn list --json --depth=0 --pattern '${packagePattern}'`,
       {
-        cwd: `${process.argv[2]}/..`,
+        cwd: rootFrontendDir,
       },
       (err, stdout) => {
         if (err) {

--- a/frontend/packages/tools/workflow-registrar.js
+++ b/frontend/packages/tools/workflow-registrar.js
@@ -39,7 +39,7 @@ const discoverWorkflows = () => {
     return childProcess.exec(
       `yarn list --json --depth=0 --pattern '${packagePattern}'`,
       {
-        cwd: ".",
+        cwd: `${process.argv[2]}/..`,
       },
       (err, stdout) => {
         if (err) {

--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -39,5 +39,5 @@ for package in "${LINKED_PACKAGES[@]}"; do
   "${YARN}" link "${package}"
 done
 
-"${YARN}" --pure-lockfile install
+"${YARN}" install
 "${YARN}" "${action}"

--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -39,5 +39,5 @@ for package in "${LINKED_PACKAGES[@]}"; do
   "${YARN}" link "${package}"
 done
 
-"${YARN}" --frozen-lockfile install
+"${YARN}" --pure-lockfile install
 "${YARN}" "${action}"

--- a/tools/scaffolding/templates/gateway/frontend/src/clutch.config.js
+++ b/tools/scaffolding/templates/gateway/frontend/src/clutch.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    "clutch-ec2": {
+    "@clutch-sh/ec2": {
         terminateInstance: {
             trending: true,
             componentProps: {
@@ -13,7 +13,7 @@ module.exports = {
             },
         },
     },
-    "clutch-envoy": {
+    "@clutch-sh/envoy": {
         remoteTriage: {
             trending: true,
             componentProps: {
@@ -27,7 +27,7 @@ module.exports = {
             },
         },
     },
-    "clutch-example": {
+    "@{{ .RepoName }}/echo": {
         echo: {
             trending: true,
         }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The workflow registrar script should use the root of the src directory containing the `clutch.config.js` file to determine which workflow packages are installed.

### Testing Performed
Local.
```bash
$ node workflow-registrar.js /Users/dschaller/go/src/github.com/lyft/clutch/frontend/packages/app/src
Registered ec2 workflow...
Registered envoy workflow...
Registered k8s workflow...
Generated Workflow imports!
```

### GitHub Issue

Partially fixes #87
