### PR TITLE
frontend: target ES2018 during typescript compilation

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,7 @@
       "@clutch-sh/*": ["api/*", "packages/*/src", "workflows/*/src"],
     },
     "preserveConstEnums": true,
-    "target": "ESNext",
+    "target": "ES2018",
     "types": ["node"]
   },
 }

--- a/tools/scaffolding/templates/frontend/tsconfig.json
+++ b/tools/scaffolding/templates/frontend/tsconfig.json
@@ -12,7 +12,7 @@
     "outDir": "./dist",
     "preserveConstEnums": true,
     "rootDir": "./src",
-    "target": "ESNext",
+    "target": "ES2018",
     "types": ["node"]
   },
   "include": [


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Target ES2018 for typescript package compilations. This removes relying on consumers to compile the packages.

### Testing Performed
Locally.
