### PR TITLE
ci: fix scaffolding SHA reference on main

### DIFF
--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: scaffold new app
-        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha }}
+        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
         run: make


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
According to

https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions

this should work...

Follow up to #101

### Testing Performed
Not possible :cry: 