### PR TITLE
ci: pass correct repo owner to scaffolding

### DIFF
--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: scaffold new app
-        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.context.repo.owner }}
+        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.pull_request.owner.login }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
         run: make

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: scaffold new app
-        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.repository_owner }}
+        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.context.repo.owner }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
         run: make

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: scaffold new app
-        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.pull_request.head.repo.owner.login }}
+        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
         run: make

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: scaffold new app
-        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.repository.owner.name }}
+        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.pull_request.head.repo.owner.login }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
         run: make

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: scaffold new app
-        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.pull_request.owner.login }}
+        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.repository.owner.name }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
         run: make


### PR DESCRIPTION
### Description
Follow up to #140. This should correctly pass the fork owner instead of always passing `lyft`.

### Testing Performed
None.