### PR TITLE
ci: only test scaffolding on main

### DIFF
--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -5,11 +5,6 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - 'docs/**'
 env:
   GOPATH: ${{ github.workspace }}/go
   GOBIN: ${{ github.workspace }}/go/bin
@@ -28,7 +23,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: scaffold new app
-        run: yes | go run scaffolder.go -m gateway -p ${{ github.event.pull_request.head.sha || github.sha }} -o ${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+        run: yes | go run scaffolder.go -m gateway -p ${{ github.sha }} -o ${{ github.repository_owner }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
         run: make


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Testing on forks is complicated. Tests are slow.

For now we will only run on main and fix after the fact. If frequent breakage becomes a problem we can do the work to get it running on each PR.

### Testing Performed
N/A