### PR TITLE
kubernetes: fallback to InClusterConfig if no kubeconfig available

### DIFF
--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -81,7 +81,6 @@ func newClientsetManager(rules *clientcmd.ClientConfigLoadingRules, logger *zap.
 		switch err {
 		case rest.ErrNotInCluster:
 			logger.Warn("not in a kubernetes cluster, unable to configure kube clientset")
-			lookup[inCluster] = &ctxClientsetImpl{Interface: nil, namespace: "default", cluster: inCluster}
 		case nil:
 			clientset, err := k8s.NewForConfig(restConfig)
 			if err != nil {

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	inCluster = "local"
+	inCluster = "in-cluster"
 )
 
 type ClientsetManager interface {

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -75,7 +75,7 @@ func newClientsetManager(rules *clientcmd.ClientConfigLoadingRules, logger *zap.
 
 	// If there is no configured cluster produced fallback to InClusterConfig
 	if len(lookup) == 0 {
-		logger.Warn("no kubeconfig was found, falling back to InClusterConfig")
+		logger.Info("no kubeconfig was found, falling back to InClusterConfig")
 
 		restConfig, err := rest.InClusterConfig()
 		switch err {

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -53,6 +54,13 @@ func newClientsetManager(rules *clientcmd.ClientConfigLoadingRules) (ClientsetMa
 		restConfig, err := contextConfig.ClientConfig()
 		if err != nil {
 			return nil, fmt.Errorf("could not load restconfig: %w", err)
+		}
+
+		if restConfig == nil {
+			restConfig, err = rest.InClusterConfig()
+			if err != nil {
+				return nil, fmt.Errorf("could not load InClusterConfig: %w", err)
+			}
 		}
 
 		clientset, err := k8s.NewForConfig(restConfig)

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -81,6 +81,7 @@ func newClientsetManager(rules *clientcmd.ClientConfigLoadingRules, logger *zap.
 		switch err {
 		case rest.ErrNotInCluster:
 			logger.Warn("not in a kubernetes cluster, unable to configure kube clientset")
+			lookup[inCluster] = &ctxClientsetImpl{Interface: nil, namespace: "default", cluster: inCluster}
 		case nil:
 			clientset, err := k8s.NewForConfig(restConfig)
 			if err != nil {

--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -26,12 +26,12 @@ func (s *svc) DescribeDeployment(ctx context.Context, clientset, cluster, namesp
 		return nil, err
 	}
 
-	return ProtoForDeployment(deployment), nil
+	return ProtoForDeployment(cs.Cluster(), deployment), nil
 }
 
-func ProtoForDeployment(deployment *appsv1.Deployment) *k8sapiv1.Deployment {
+func ProtoForDeployment(cluster string, deployment *appsv1.Deployment) *k8sapiv1.Deployment {
 	return &k8sapiv1.Deployment{
-		Cluster:     deployment.ClusterName,
+		Cluster:     cluster,
 		Namespace:   deployment.Namespace,
 		Name:        deployment.Name,
 		Labels:      deployment.Labels,

--- a/backend/service/k8s/hpa.go
+++ b/backend/service/k8s/hpa.go
@@ -22,12 +22,12 @@ func (s *svc) DescribeHPA(ctx context.Context, clientset, cluster, namespace, na
 	if err != nil {
 		return nil, err
 	}
-	return ProtoForHPA(hpa), nil
+	return ProtoForHPA(cs.Cluster(), hpa), nil
 }
 
-func ProtoForHPA(autoscaler *autoscalingv1.HorizontalPodAutoscaler) *k8sapiv1.HPA {
+func ProtoForHPA(cluster string, autoscaler *autoscalingv1.HorizontalPodAutoscaler) *k8sapiv1.HPA {
 	return &k8sapiv1.HPA{
-		Cluster:   autoscaler.ClusterName,
+		Cluster:   cluster,
 		Namespace: autoscaler.Namespace,
 		Name:      autoscaler.Name,
 		Sizing: &k8sapiv1.HPA_Sizing{

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -40,7 +40,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 		}
 	}
 
-	c, err := newClientsetManager(loadingRules)
+	c, err := newClientsetManager(loadingRules, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -21,7 +21,7 @@ func (s *svc) DescribePod(ctx context.Context, clientset, cluster, namespace, na
 	if err != nil {
 		return nil, err
 	}
-	return podDescription(pod, cluster), nil
+	return podDescription(pod, cs.Cluster()), nil
 }
 
 func (s *svc) DeletePod(ctx context.Context, clientset, cluster, namespace, name string) error {
@@ -56,7 +56,7 @@ func (s *svc) ListPods(ctx context.Context, clientset, cluster, namespace string
 	var pods []*k8sapiv1.Pod
 	for _, p := range podList.Items {
 		pod := p
-		pods = append(pods, podDescription(&pod, cluster))
+		pods = append(pods, podDescription(&pod, cs.Cluster()))
 	}
 
 	return pods, nil


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Currently if you deploy clutch to kubernetes without providing a `kubeconfig` file, the clutch kubernetes services does not configure it self for `InClusterConfig` if no other configuration is provided. This adds the ability to fall back to `InClusterConfig` when no other `kubeconfig` is available.

I also had to slightly modify the way we handle which k8s cluster clutch is currently operating on, normally this information is provided by the `kubeconfig`. But when using `InClusterConfig` there is currently no way to get a cluster identifier as reported upstream https://github.com/kubernetes/kubernetes/issues/44954. We also cant make use of `ClusterName` in `ObjectMeta` as it's [not currently being set](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L266-L270).

This also enables our kubernetes example to ship with a simple configuration https://github.com/lyft/clutch/pull/148.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

I deployed cluster to a local k8s cluster (v1.16.6) using the example manifest https://github.com/lyft/clutch/pull/148. Verified that in cluster config was working and executed all k8s workflows.

I also tested by running clutch locally and loaded cluster context's via a `kubeconfig` file. Ran through all k8s workflows against my local k8s cluster without issue.

EDIT:

local test
* with kubeconfig file
* without kubeconfig file. The k8s UI does load but not functional of course.

local k8s cluster deployment
* validate incluster config is working and can mutate the cluster with k8s workflows. 