### PR TITLE
gateway: disable stack for warns when using pretty logger

### DIFF
--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -121,8 +121,10 @@ func duration(p *durpb.Duration) time.Duration {
 
 func newLogger(msg *gatewayv1.Logger) (*zap.Logger, error) {
 	var c zap.Config
+	var opts []zap.Option
 	if msg.GetPretty() {
 		c = zap.NewDevelopmentConfig()
+		opts = append(opts, zap.AddStacktrace(zap.ErrorLevel))
 	} else {
 		c = zap.NewProductionConfig()
 	}
@@ -139,7 +141,7 @@ func newLogger(msg *gatewayv1.Logger) (*zap.Logger, error) {
 	}
 	c.Level = level
 
-	return c.Build()
+	return c.Build(opts...)
 }
 
 func newTmpLogger() *zap.Logger {

--- a/backend/gateway/config_test.go
+++ b/backend/gateway/config_test.go
@@ -1,8 +1,11 @@
 package gateway
 
 import (
+	"fmt"
 	"os"
 	"testing"
+
+	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -39,4 +42,26 @@ use: shoes
 	out, err = executeTemplate([]byte(config))
 	assert.NoError(t, err)
 	assert.Contains(t, string(out), "use: shoes")
+}
+
+func TestNewLogger(t *testing.T) {
+	testConfigs := []*gatewayv1.Logger{
+		{
+			Level:  gatewayv1.Logger_INFO,
+			Format: &gatewayv1.Logger_Pretty{Pretty: true},
+		},
+		{
+			Level: gatewayv1.Logger_WARN,
+		},
+	}
+
+	for idx, tc := range testConfigs {
+		tc := tc
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			t.Parallel()
+			l, err := newLogger(tc)
+			assert.NotNil(t, l)
+			assert.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Disable stack for warns when using pretty logger.

This is default behavior that is not desirable.

### Testing Performed
Unit.