### PR TITLE
ci: use node 14

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: build and verify
         run: make api-verify
   lint:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.5.x'
+          node-version: '14.x'
       - name: build and verify
         run: make api-verify
   lint:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '14.5.x'
       - name: build and verify
         run: make api-verify
   lint:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '14.5.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '14.5.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '14.5.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '14.'
           registry-url: 'https://registry.npmjs.org'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.5.x'
+          node-version: '14.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.5.x'
+          node-version: '14.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.5.x'
+          node-version: '14.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.14.4
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: scaffold new app
         run: yes | go run scaffolder.go -m gateway -p ${{ github.sha }} -o ${{ github.repository_owner }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.14.4
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.5.x'
+          node-version: '14.x'
       - name: scaffold new app
         run: yes | go run scaffolder.go -m gateway -p ${{ github.sha }} -o ${{ github.repository_owner }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.14.4
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '14.5.x'
       - name: scaffold new app
         run: yes | go run scaffolder.go -m gateway -p ${{ github.sha }} -o ${{ github.repository_owner }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Use Node 14 instead of 12 in CI.

Should be marginally faster, also it's the current release.

Trying to fix
```
$ make frontend-verify
lint:packages
yarn run v1.22.4
$ npx sort-package-json package.json packages/**/package.json --check
npm ERR! cb.apply is not a function

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/dhochman/.npm/_logs/2020-07-30T18_20_46_594Z-debug.log
Install for [ 'sort-package-json@latest' ] failed with code 1
error Command failed with exit code 1.
```

### Testing Performed
CI