### PR TITLE
wizard: fix overwrite issue on update

### DIFF
--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -141,12 +141,14 @@ const Wizard: React.FC<WizardProps> = ({ heading, dataLayout, children }) => {
   const dataLayoutManager = useDataLayoutManager(dataLayout);
 
   const updateStepData = (stepName: string, data: object) => {
-    const updatedData = {
-      ...setWizardStepData?.[stepName],
-      ...data,
-    };
-    const stepData = { [stepName]: updatedData };
-    setWizardStepData({ ...wizardStepData, ...stepData });
+    setWizardStepData(prevState => {
+      const updatedData = {
+        ...prevState?.[stepName] || {},
+        ...data,
+      };
+      const stepData = { [stepName]: updatedData };
+      return {...prevState, ...stepData }
+    });
   };
 
   const handleNext = () => {

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -143,11 +143,11 @@ const Wizard: React.FC<WizardProps> = ({ heading, dataLayout, children }) => {
   const updateStepData = (stepName: string, data: object) => {
     setWizardStepData(prevState => {
       const updatedData = {
-        ...prevState?.[stepName] || {},
+        ...(prevState?.[stepName] || {}),
         ...data,
       };
       const stepData = { [stepName]: updatedData };
-      return {...prevState, ...stepData }
+      return { ...prevState, ...stepData };
     });
   };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Fix an issue where updating step data would overwrite previously set data. E.g. if a custom submit handler was set via `setOnSubmit` and a subsequent call to `setIsLoading` occurred a wizard' step data would only contain the data from the subsequent `setIsLoading` call.

![wizardFix](https://user-images.githubusercontent.com/1004789/88960238-120cb880-d258-11ea-9fc6-421c5833f7b1.gif)

### Testing Performed
Found this issue when testing submissions of an editable metadata table with validation attached. Manually confirmed this works.
