### PR TITLE
ci: pin node to 12.8.2 to fix npx issue

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '12.8.2'
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Get yarn cache


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
This is a stopgap solution until https://github.com/npm/npx/pull/70 is merged.

### Testing Performed
CI

