### PR TITLE
metadata table: remove validation on load

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -135,7 +135,6 @@ const MetadataTable: React.FC<MetadataTableProps> = ({
 
   React.useEffect(() => {
     setOnSubmit(handleSubmit);
-    validation.triggerValidation();
   }, []);
 
   return (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Validating on load can be a bit jarring for fields without default values. Since validation will happen on submit it's ok to delay this.