### PR TITLE
ci: enable go mod tidy for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,8 @@
   ], 
   "labels": [
     "dependencies"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
So close, e.g. https://github.com/lyft/clutch/pull/167

Renovate updates go.sum (unlike dependabot) but doesn't tidy, which we lint for.

This should make mergeable go updates with no additional steps a reality.

### Testing Performed
None. Read the docs.