### PR TITLE
tools/scaffolding: fix walkfunc error

### DIFF
--- a/tools/scaffolding/scaffolder.go
+++ b/tools/scaffolding/scaffolder.go
@@ -291,6 +291,9 @@ func main() {
 
 	// Walk files and template them.
 	err = filepath.Walk(templateRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		relpath, err := filepath.Rel(templateRoot, path)
 		if err != nil {
 			return err


### PR DESCRIPTION
This fixes a `filepath.WalkFunc` that wasn't handling its incoming error.

https://golang.org/pkg/path/filepath/#WalkFunc