### PR TITLE
ci: customize renovatebot & add validate job

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,23 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":automergeLinters",
+    ":combinePatchMinorReleases",
+    ":enableVulnerabilityAlerts",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
+    ":separateMajorReleases",
+    ":separateMultipleMajorReleases",
+    ":unpublishSafe"
   ], 
   "labels": [
     "dependencies"
   ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "postUpdateOptions": [
     "gomodTidy"
-  ]
+  ],
+  "yarnrc": ""
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Install renovate-config-validator
-        run: yarn install renovate
+        run: yarn add renovate
         working-directory: build
       - name: Validate renovate.json
         run: yarn renovate-config-validator ../.github/renovate.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: ci
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+    paths:
+    - .github/renovate.json
+jobs:
+  renovate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Enforce consistent Yarn version
+        run: ./tools/install-yarn.sh
+      - name: Install renovate-config-validator
+        run: yarn install renovate
+        working-directory: build
+      - name: Validate renovate.json
+        run: yarn renovate-config-validator ../.github/renovate.json
+        working-directory: build


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Adding some configuration options to renovatebot and a CI job to validate the file when it changes. The job is important since we won't know the if the configuration is bad until PRs fail to open.

- [`automergeLinters`](https://docs.renovatebot.com/presets-default/#automergelinters)
- [`combinePatchMinorReleases`](https://docs.renovatebot.com/presets-default/#combinepatchminorreleases)
- [`enableVulnerabilityAlerts`](https://docs.renovatebot.com/presets-default/#enablevulnerabilityalerts)
- [`preserveSemverRanges`](https://docs.renovatebot.com/presets-default/#preservesemverranges)
- [`rebaseStalePrs`](https://docs.renovatebot.com/presets-default/#rebasestaleprs)
- [`separateMajorReleases`](https://docs.renovatebot.com/presets-default/#separatemajorreleases)
- [`separateMultipleMajorReleases`](https://docs.renovatebot.com/presets-default/#separatemultiplemajorreleases)
- [`unpublishSafe`](https://docs.renovatebot.com/presets-default/#unpublishsafe)
- [`lockFileMaintenance`](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)
- [`yarnrc`](https://docs.renovatebot.com/configuration-options/#yarnrc): This is to fix the dependency on running the install-yarn script before installing dependencies. It looks like renovatebot does not support pre-upgrade hooks.

### Testing Performed
Added a CI job to ensure the config is valid. Will have to wait for PRs to be open in order to know if the values are working as expected.

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

- [ ] Once npx is working again we can simplify the CI job to not install into the build directory.