### PR TITLE
ci: prepend dependency updates with housekeeping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
     ":separateMultipleMajorReleases",
     ":unpublishSafe"
   ],
-  "commitMessagePrefix": "housekeeping:"
+  "commitMessagePrefix": "housekeeping:",
   "labels": [
     "dependencies"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
     ":separateMultipleMajorReleases",
     ":unpublishSafe"
   ],
-  "commitMessagePrefix": "housekeeping: "
+  "commitMessagePrefix": "housekeeping:"
   "labels": [
     "dependencies"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,8 @@
     ":separateMajorReleases",
     ":separateMultipleMajorReleases",
     ":unpublishSafe"
-  ], 
+  ],
+  "commitMessagePrefix": "housekeeping: "
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
This should prepend the renovate PRs with `housekeeping: `