### PR TITLE
k8s: use ClusterName if available

### DIFF
--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -30,11 +30,12 @@ func (s *svc) DescribeDeployment(ctx context.Context, clientset, cluster, namesp
 }
 
 func ProtoForDeployment(cluster string, deployment *appsv1.Deployment) *k8sapiv1.Deployment {
-	if deployment.ClusterName == "" {
-		deployment.ClusterName = cluster
+	clusterName := deployment.ClusterName
+	if clusterName == "" {
+		clusterName = cluster
 	}
 	return &k8sapiv1.Deployment{
-		Cluster:     deployment.ClusterName,
+		Cluster:     clusterName,
 		Namespace:   deployment.Namespace,
 		Name:        deployment.Name,
 		Labels:      deployment.Labels,

--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -30,8 +30,11 @@ func (s *svc) DescribeDeployment(ctx context.Context, clientset, cluster, namesp
 }
 
 func ProtoForDeployment(cluster string, deployment *appsv1.Deployment) *k8sapiv1.Deployment {
+	if deployment.ClusterName == "" {
+		deployment.ClusterName = cluster
+	}
 	return &k8sapiv1.Deployment{
-		Cluster:     cluster,
+		Cluster:     deployment.ClusterName,
 		Namespace:   deployment.Namespace,
 		Name:        deployment.Name,
 		Labels:      deployment.Labels,

--- a/backend/service/k8s/deployment_test.go
+++ b/backend/service/k8s/deployment_test.go
@@ -227,3 +227,45 @@ func TestGenerateDeploymentStrategicPatch(t *testing.T) {
 		})
 	}
 }
+
+func TestProtoForDeploymentClusterName(t *testing.T) {
+	t.Parallel()
+
+	var deploymentTestCases = []struct {
+		id                  string
+		inputClusterName    string
+		expectedClusterName string
+		deployment          *appsv1.Deployment
+	}{
+		{
+			id:                  "clustername already set",
+			inputClusterName:    "notprod",
+			expectedClusterName: "production",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: "production",
+				},
+			},
+		},
+		{
+			id:                  "custername is not set",
+			inputClusterName:    "staging",
+			expectedClusterName: "staging",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range deploymentTestCases {
+		tt := tt
+		t.Run(tt.id, func(t *testing.T) {
+			t.Parallel()
+
+			deployment := ProtoForDeployment(tt.inputClusterName, tt.deployment)
+			assert.Equal(t, tt.expectedClusterName, deployment.Cluster)
+		})
+	}
+}

--- a/backend/service/k8s/hpa.go
+++ b/backend/service/k8s/hpa.go
@@ -26,11 +26,12 @@ func (s *svc) DescribeHPA(ctx context.Context, clientset, cluster, namespace, na
 }
 
 func ProtoForHPA(cluster string, autoscaler *autoscalingv1.HorizontalPodAutoscaler) *k8sapiv1.HPA {
-	if autoscaler.ClusterName == "" {
-		autoscaler.ClusterName = cluster
+	clusterName := autoscaler.ClusterName
+	if clusterName == "" {
+		clusterName = cluster
 	}
 	return &k8sapiv1.HPA{
-		Cluster:   autoscaler.ClusterName,
+		Cluster:   clusterName,
 		Namespace: autoscaler.Namespace,
 		Name:      autoscaler.Name,
 		Sizing: &k8sapiv1.HPA_Sizing{

--- a/backend/service/k8s/hpa.go
+++ b/backend/service/k8s/hpa.go
@@ -26,8 +26,11 @@ func (s *svc) DescribeHPA(ctx context.Context, clientset, cluster, namespace, na
 }
 
 func ProtoForHPA(cluster string, autoscaler *autoscalingv1.HorizontalPodAutoscaler) *k8sapiv1.HPA {
+	if autoscaler.ClusterName == "" {
+		autoscaler.ClusterName = cluster
+	}
 	return &k8sapiv1.HPA{
-		Cluster:   cluster,
+		Cluster:   autoscaler.ClusterName,
 		Namespace: autoscaler.Namespace,
 		Name:      autoscaler.Name,
 		Sizing: &k8sapiv1.HPA_Sizing{

--- a/backend/service/k8s/hpa_test.go
+++ b/backend/service/k8s/hpa_test.go
@@ -13,6 +13,10 @@ import (
 	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
 )
 
+var (
+	newInt32 = func(n int32) *int32 { return &n }
+)
+
 func testHPAClientset() k8s.Interface {
 	hpa := &autoscalingv1.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
@@ -28,10 +32,6 @@ func testHPAClientset() k8s.Interface {
 
 func TestNormalizeChanges(t *testing.T) {
 	t.Parallel()
-
-	var (
-		newInt32 = func(n int32) *int32 { return &n }
-	)
 
 	var applyScalingTestCases = []struct {
 		id         string
@@ -119,4 +119,54 @@ func TestResizeHPA(t *testing.T) {
 
 	err = s.ResizeHPA(context.Background(), "foo", "core-testing", "testing-namespace", "testing-hpa-name", nil)
 	assert.NoError(t, err)
+}
+
+func TestProtoForHPAClusterName(t *testing.T) {
+	t.Parallel()
+
+	var hpaTestCases = []struct {
+		id                  string
+		inputClusterName    string
+		expectedClusterName string
+		hpa                 *autoscalingv1.HorizontalPodAutoscaler
+	}{
+		{
+			id:                  "clustername already set",
+			inputClusterName:    "notprod",
+			expectedClusterName: "production",
+			hpa: &autoscalingv1.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: "production",
+				},
+				Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
+					MinReplicas: newInt32(1),
+					MaxReplicas: 2,
+				},
+			},
+		},
+		{
+			id:                  "custername is not set",
+			inputClusterName:    "staging",
+			expectedClusterName: "staging",
+			hpa: &autoscalingv1.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: "",
+				},
+				Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
+					MinReplicas: newInt32(1),
+					MaxReplicas: 2,
+				},
+			},
+		},
+	}
+
+	for _, tt := range hpaTestCases {
+		tt := tt
+		t.Run(tt.id, func(t *testing.T) {
+			t.Parallel()
+
+			hpa := ProtoForHPA(tt.inputClusterName, tt.hpa)
+			assert.Equal(t, tt.expectedClusterName, hpa.Cluster)
+		})
+	}
 }

--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -69,8 +69,12 @@ func podDescription(k8spod *corev1.Pod, cluster string) *k8sapiv1.Pod {
 	//if converted, err := ptypes.TimestampProto(k8spod.Status.StartTime.Time); err == nil {
 	//	launch = converted
 	//}
+	clusterName := k8spod.ClusterName
+	if clusterName == "" {
+		clusterName = cluster
+	}
 	return &k8sapiv1.Pod{
-		Cluster:    cluster,
+		Cluster:    clusterName,
 		Namespace:  k8spod.Namespace,
 		Name:       k8spod.Name,
 		Containers: makeContainers(k8spod.Status.ContainerStatuses),


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

We should defer to the k8s object `ClusterName` before falling back to what the clientset is configured for. We changed this behavior slightly in https://github.com/lyft/clutch/commit/ad118d0265aa4505f912da779f6edc12d74fce4d and this preserves the original intent but falling back to `cs.Cluster()` if `ClusterName` is not set.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
