### PR TITLE
ci: fix codeowners team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @lyft/clutch-admins
+*       @lyft/clutch-admin


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The team name was wrong here.