### PR TITLE
resolver: handle empty results and failures gracefully

### DIFF
--- a/frontend/packages/core/src/Resolver/fetch.tsx
+++ b/frontend/packages/core/src/Resolver/fetch.tsx
@@ -45,7 +45,7 @@ const resolveFields = async (
     have: fields,
     limit,
   });
-  return { results: response.data?.results || [], failures: response.data?.partialFailures || []};
+  return { results: response.data?.results || [], failures: response.data?.partialFailures || [] };
 };
 
 const resolveResource = async (

--- a/frontend/packages/core/src/Resolver/fetch.tsx
+++ b/frontend/packages/core/src/Resolver/fetch.tsx
@@ -45,7 +45,7 @@ const resolveFields = async (
     have: fields,
     limit,
   });
-  return { results: response.data.results, failures: response.data.partialFailures };
+  return { results: response.data?.results || [], failures: response.data?.partialFailures || []};
 };
 
 const resolveResource = async (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Found this when testing the k8s example from #148. If the data does not contain results/partial failures we should fallback to an empty list.
