### PR TITLE
ci: add dependency groups to renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,11 @@
     ":rebaseStalePrs",
     ":separateMajorReleases",
     ":separateMultipleMajorReleases",
-    ":unpublishSafe"
+    ":unpublishSafe",
+    "group:definitelyTyped",
+    "group:materialMonorepo",
+    "group:reactMonorepo",
+    "group:reactrouterMonorepo"
   ],
   "commitMessagePrefix": "housekeeping:",
   "labels": [


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
This adds a few group presets to renovatebot