### PR TITLE
ci: have renovate rebase only on conflicts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
     ":combinePatchMinorReleases",
     ":enableVulnerabilityAlerts",
     ":preserveSemverRanges",
-    ":rebaseStalePrs",
     ":separateMajorReleases",
     ":separateMultipleMajorReleases",
     ":unpublishSafe",
@@ -15,6 +14,7 @@
     "group:reactrouterMonorepo"
   ],
   "commitMessagePrefix": "housekeeping:",
+  "rebaseWhen": "conflicted",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Manual rebasing still possible. This prevents a long rebase chain when dealing with several housekeeping PRs.

### Testing Performed
Read the docs.
