### PR TITLE
scaffolding: add frontend-dev make target

### DIFF
--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -41,3 +41,7 @@ yarn-install: yarn-ensure
 .PHONY: yarn-ensure
 yarn-ensure:
 	@$(SHELL) $(TOOLS_MODULE_DIR)/install-yarn.sh
+
+.PHONY: frontend-dev # Start the frontend in development mode.
+frontend-dev: yarn-ensure
+	yarn --cwd frontend install --frozen-lockfile && yarn --cwd frontend start


### PR DESCRIPTION
The tuturial is built around trying to start a frontend on port 3000,
but the `frontend-dev` target that would start that isn't present
in the template directory that creates a scaffolding directory.

This adds that target

<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Add the `frontend-dev` target to the scaffolding `Makefile`.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

Unfortunately, since it seems like by creating a commit in my local checkout of the clutch repo, I can't seem to completely create a new scaffold project to test this, but it looks like this is doing the right thing:

```spacey@bagpig:~/dvcs/github/clutch (add-scaffolding-frontend-dev-target)$ make scaffold-gateway
cd tools/scaffolding && go run scaffolder.go -m gateway -p 72c70a2
2020/08/03 22:37:25 Welcome!
*** Analyzing environment...
> GOPATH: /home/spacey/go
> User: spacey

*** Based on your environment, we've picked the following destination for your new repo:
> /home/spacey/go/src/github.com/spacey/clutch-custom-gateway

Note: please pay special attention to see if the username matches your provider's username.
Is this okay? [Y/n]: n
Enter the name of the source control provider [github.com]: github.com
Enter the name of the repository owner or org [spacey]: pcn
Enter the desired repository name [clutch-custom-gateway]: foo-custom-gateway
Enter the destination folder [/home/spacey/go/src/github.com/pcn/foo-custom-gateway]: 

*** Generating...
2020/08/03 22:37:49 Using templates in /home/spacey/dvcs/github/clutch/tools/scaffolding/templates/gateway
2020/08/03 22:37:49 Using tmpdir /tmp/clutch-scaffolding-006769989
2020/08/03 22:37:49 .gitattributes
2020/08/03 22:37:49 .gitignore
2020/08/03 22:37:49 Makefile
2020/08/03 22:37:49 api/echo/v1/echo.proto
2020/08/03 22:37:49 backend/clutch-config.yaml
2020/08/03 22:37:49 backend/cmd/assets/placeholder.go
2020/08/03 22:37:49 backend/go.mod
2020/08/03 22:37:49 backend/main.go
2020/08/03 22:37:49 backend/module/echo/echo.go
2020/08/03 22:37:49 backend/module/echo/echo_test.go
2020/08/03 22:37:49 backend/tools.go
2020/08/03 22:37:49 frontend/lerna.json
2020/08/03 22:37:49 frontend/package.json
2020/08/03 22:37:49 frontend/public/index.html
2020/08/03 22:37:49 frontend/src/clutch.config.js
2020/08/03 22:37:49 frontend/src/index.css
2020/08/03 22:37:49 frontend/src/index.jsx
2020/08/03 22:37:49 frontend/workflows/echo/.eslintrc.js
2020/08/03 22:37:49 frontend/workflows/echo/babel.config.js
2020/08/03 22:37:49 frontend/workflows/echo/jest.config.js
2020/08/03 22:37:49 frontend/workflows/echo/package.json
2020/08/03 22:37:49 frontend/workflows/echo/prettier.config.js
2020/08/03 22:37:49 frontend/workflows/echo/src/echo.jsx
2020/08/03 22:37:49 frontend/workflows/echo/src/index.jsx
2020/08/03 22:37:49 Adding clutch dependencies to go.mod...
go: finding github.com 72c70a2
go: finding github.com/lyft/clutch 72c70a2
go: finding github.com/lyft 72c70a2
go: finding github.com/lyft/clutch/backend 72c70a2
go: finding github.com/lyft/clutch/backend 72c70a2
go: finding github.com/lyft/clutch 72c70a2
go get github.com/lyft/clutch/backend@72c70a2: github.com/lyft/clutch/backend@72c70a2: invalid version: unknown revision 72c70a2

2020/08/03 22:37:55 `go get` backend in the destination dir returned the above error
exit status 1
make: *** [Makefile:138: scaffold-gateway] Error 1
spacey@bagpig:~/dvcs/github/clutch (add-scaffolding-frontend-dev-target)$ ls /tmp/clutch-scaffolding-006769989/
api/            backend/        frontend/       .gitattributes  .gitignore      Makefile        
spacey@bagpig:~/dvcs/github/clutch (add-scaffolding-frontend-dev-target)$ ls /tmp/clutch-scaffolding-006769989/Makefile 
/tmp/clutch-scaffolding-006769989/Makefile
spacey@bagpig:~/dvcs/github/clutch (add-scaffolding-frontend-dev-target)$ tail -3 /tmp/clutch-scaffolding-006769989/Makefile 
.PHONY: frontend-dev # Start the frontend in development mode.
frontend-dev: yarn-ensure
	yarn --cwd frontend install --frozen-lockfile && yarn --cwd frontend start
```

Based on the above, I think that if I was sitting on a valid git hash based off of `lyft/clutch` that this would have worked.


### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
