### PR TITLE
workflow: support notes in resize-hpa

### DIFF
--- a/frontend/workflows/k8s/src/resize-hpa.jsx
+++ b/frontend/workflows/k8s/src/resize-hpa.jsx
@@ -4,6 +4,7 @@ import {
   client,
   Confirmation,
   MetadataTable,
+  NotePanel,
   Resolver,
   useWizardContext,
 } from "@clutch-sh/core";
@@ -77,7 +78,7 @@ const HPADetails = () => {
   );
 };
 
-const Confirm = () => {
+const Confirm = ({ notes }) => {
   const hpa = useDataLayout("hpaData").displayValue();
   const resizeData = useDataLayout("resizeData");
 
@@ -93,11 +94,12 @@ const Confirm = () => {
           { name: "New Max Size", value: hpa.sizing.maxReplicas },
         ]}
       />
+      <NotePanel notes={notes} />
     </WizardStep>
   );
 };
 
-const ResizeHPA = ({ heading, resolverType }) => {
+const ResizeHPA = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     hpaData: {},
     inputData: {},
@@ -124,7 +126,7 @@ const ResizeHPA = ({ heading, resolverType }) => {
     <Wizard dataLayout={dataLayout} heading={heading}>
       <HPAIdentifier name="Lookup" resolverType={resolverType} />
       <HPADetails name="Modify" />
-      <Confirm name="Confirmation" />
+      <Confirm name="Confirmation" notes={notes} />
     </Wizard>
   );
 };

--- a/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.jsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.jsx.snap
@@ -4,6 +4,6 @@ exports[`Resize Autoscaling Group workflow renders correctly 1`] = `
 "<Wizard dataLayout={{...}} heading={[undefined]}>
   <HPAIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.k8s.v1.HPA\\" />
   <HPADetails name=\\"Modify\\" />
-  <Confirm name=\\"Confirmation\\" />
+  <Confirm name=\\"Confirmation\\" notes={{...}} />
 </Wizard>"
 `;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Supporting the notes field on resize hpa conformation panel.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

Locally against a local kubernetes cluster using this frontend configuration to test.
```
    resizeHPA: {
      trending: true,
      componentProps: {
        resolverType: "clutch.k8s.v1.HPA",
        notes: [
          {
            severity: "info",
            text: "This is a test note for resize hpa",
          },
        ],
      },
    },
```

![Screen Shot 2020-08-04 at 2 40 15 PM](https://user-images.githubusercontent.com/2250844/89347947-8f716800-d660-11ea-85b4-419c6fdce93a.png)


Also tested without and notes configured
```
resizeHPA: {
      trending: true,
      componentProps: {
        resolverType: "clutch.k8s.v1.HPA",
      },
    },
```
![Screen Shot 2020-08-04 at 2 50 15 PM](https://user-images.githubusercontent.com/2250844/89348753-f4798d80-d661-11ea-99f6-9e9a9f719b80.png)
