### PR TITLE
workflow: notes for terminate instance

### DIFF
--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -4,6 +4,10 @@ module.exports = {
       trending: true,
       componentProps: {
         resolverType: "clutch.aws.ec2.v1.Instance",
+        // notes: [{
+        //   severity: "info",
+        //   text: "This is a test note for terminate instance.",
+        // }, ],
       },
     },
     resizeAutoscalingGroup: {

--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -4,10 +4,6 @@ module.exports = {
       trending: true,
       componentProps: {
         resolverType: "clutch.aws.ec2.v1.Instance",
-        // notes: [{
-        //   severity: "info",
-        //   text: "This is a test note for terminate instance.",
-        // }, ],
       },
     },
     resizeAutoscalingGroup: {

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -4,6 +4,7 @@ import {
   client,
   Confirmation,
   MetadataTable,
+  NotePanel,
   Resolver,
   useWizardContext,
 } from "@clutch-sh/core";
@@ -11,7 +12,7 @@ import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
 
-import type { ResolverChild, WorkflowProps } from ".";
+import type { ConfirmChild, ResolverChild, WorkflowProps } from ".";
 
 const InstanceIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
   const { onSubmit } = useWizardContext();
@@ -67,23 +68,18 @@ const InstanceDetails: React.FC<WizardChild> = () => {
   );
 };
 
-/*
-TODO: Need information boxes for
-  These changes are not permanent, and will be overwritten on your next deploy. Adjust your manifest.yaml to persist changes across deploys.
-and
-  Note: the HPA should take just a few minutes to scale in either direction.
-*/
-const Confirm: React.FC<WizardChild> = () => {
+const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const terminationData = useDataLayout("terminationData");
 
   return (
     <WizardStep error={terminationData.error} isLoading={terminationData.isLoading}>
       <Confirmation action="Termination" />
+      <NotePanel notes={notes} />
     </WizardStep>
   );
 };
 
-const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
+const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     resourceData: {},
     terminationData: {
@@ -101,7 +97,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType }) =
     <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Modify" />
-      <Confirm name="Confirmation" />
+      <Confirm name="Confirmation" notes={notes} />
     </Wizard>
   );
 };

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.jsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.jsx.snap
@@ -4,6 +4,6 @@ exports[`Terminate Instance workflow renders correctly 1`] = `
 "<Wizard dataLayout={{...}} heading={[undefined]}>
   <InstanceIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.ec2.v1.Instance\\" />
   <InstanceDetails name=\\"Modify\\" />
-  <Confirm name=\\"Confirmation\\" />
+  <Confirm name=\\"Confirmation\\" notes={{...}} />
 </Wizard>"
 `;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Add conformation notes for terminate instance workflow.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

Tested locally against the mock backend.


With a note.
```
    terminateInstance: {
      trending: true,
      componentProps: {
        resolverType: "clutch.aws.ec2.v1.Instance",
        notes: [
          {
          severity: "info",
          text: "This is a test note for terminate instance.",
          }, 
        ],
      },
    },
```
![Screen Shot 2020-08-04 at 4 30 19 PM](https://user-images.githubusercontent.com/2250844/89355421-33aedb00-d670-11ea-93da-682d85e0c592.png)

Without a note.
```
    terminateInstance: {
      trending: true,
      componentProps: {
        resolverType: "clutch.aws.ec2.v1.Instance",
      },
    },
```
![Screen Shot 2020-08-04 at 4 33 48 PM](https://user-images.githubusercontent.com/2250844/89355522-6e187800-d670-11ea-87af-1be7d7eba63c.png)
