### PR TITLE
core: fix outdated org paths

### DIFF
--- a/docs/_website/generator/go.mod
+++ b/docs/_website/generator/go.mod
@@ -1,4 +1,4 @@
-module github.com/clutch-sh/clutch/docs/website/generator
+module github.com/lyft/clutch/docs/website/generator
 
 go 1.14
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,13 +9,13 @@
     "infrastructure",
     "infra"
   ],
-  "homepage": "https://github.com/clutch-sh/clutch#readme",
+  "homepage": "https://clutch.sh",
   "bugs": {
-    "url": "https://github.com/clutch-sh/clutch/issues"
+    "url": "https://github.com/lyft/clutch/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/clutch-sh/clutch.git"
+    "url": "git+https://github.com/lyft/clutch.git"
   },
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
`s/clutch-sh/lyft/g` as it applies to repo owners.