### PR TITLE
example: fix kubernetes clutch.yaml url

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -10,7 +10,7 @@ To deploy a working clutch deployment on an existing Kubernetes cluster:
 1. Run the following command to create a clutch namespace and all the necessary clutch components
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/lyft/clutch/tree/main/examples/kubernetes/clutch.yaml
+    kubectl apply -f https://raw.githubusercontent.com/lyft/clutch/main/examples/kubernetes/clutch.yaml
     
     # OR
     # if you are working off a local copy of this repo


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
The `clutch.yaml`url was not correct.
