### PR TITLE
resolver: display non-client errors

### DIFF
--- a/frontend/packages/core/src/Resolver/fetch.tsx
+++ b/frontend/packages/core/src/Resolver/fetch.tsx
@@ -73,7 +73,7 @@ const resolveResource = async (
         return;
       }
 
-      onError(err.response.displayText);
+      onError(err.response.displayText || err.response.statusText);
     });
 };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Show users error details when the error is not a `ClientError`.

![Screen Shot 2020-08-05 at 3 18 12 PM](https://user-images.githubusercontent.com/1004789/89469783-09702280-d72f-11ea-86ef-a29cc513fdd1.png)
