### PR TITLE
ci: restructure e2e tests

### DIFF
--- a/frontend/packages/app/cypress/integration/navigation_spec.js
+++ b/frontend/packages/app/cypress/integration/navigation_spec.js
@@ -16,24 +16,17 @@ describe("Navigation drawer", () => {
     });
   });
 
-  it("displays routes", () => {
+  it("displays and hides routes", () => {
     cy.element(WORKFLOW_GROUP).each((_, idx) => {
-      cy.element(WORKFLOW_GROUP).eq(idx).descendent(TOGGLE).click();
+      cy.element(WORKFLOW_GROUP).eq(idx).descendent(TOGGLE).children().first().click();
       cy.element(WORKFLOW_GROUP)
         .eq(idx)
         .find("a")
         .each(link => {
           cy.wrap(link).should("have.attr", "href");
         });
-      cy.element(WORKFLOW_GROUP).eq(idx).descendent(TOGGLE).click();
-    });
-  });
-
-  it("hides routes", () => {
-    cy.element(WORKFLOW_GROUP).each((_, idx) => {
-      cy.element(WORKFLOW_GROUP).eq(idx).descendent(TOGGLE).click();
+      cy.element(WORKFLOW_GROUP).eq(idx).descendent(TOGGLE).children().first().click();
       cy.element(WORKFLOW_GROUP).eq(idx).find("a").should("not.be.visible");
-      cy.element(WORKFLOW_GROUP).eq(idx).descendent(TOGGLE).click();
     });
   });
 
@@ -58,7 +51,7 @@ describe("Navigation drawer", () => {
 
     it("can route correctly", () => {
       return cy.element(WORKFLOW_GROUP).each((_, groupIdx) => {
-        cy.element(WORKFLOW_GROUP).eq(groupIdx).descendent(TOGGLE).click();
+        cy.element(WORKFLOW_GROUP).eq(groupIdx).descendent(TOGGLE).children().first().click();
         cy.element(WORKFLOW_GROUP)
           .eq(groupIdx)
           .descendent(groupItemId)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Restructured E2E tests to consolidate the assertion of drawer links being displayed and hidden into one. Before this was causing random failures since there was a dependency between the two tests executing in the correct order.

Additionally, this scoped the menu expansion and collapse click to the icon to prevent drawer resizing from causing issues.

### Testing Performed
CI
