### PR TITLE
k8s: always use clientset's derived namespace

### DIFF
--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -17,7 +17,7 @@ func (s *svc) DescribePod(ctx context.Context, clientset, cluster, namespace, na
 		return nil, err
 	}
 	opts := metav1.GetOptions{}
-	pod, err := cs.CoreV1().Pods(namespace).Get(name, opts)
+	pod, err := cs.CoreV1().Pods(cs.Namespace()).Get(name, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (s *svc) ListPods(ctx context.Context, clientset, cluster, namespace string
 		opts.LabelSelector = k8slabels.FormatLabels(listPodsOpts.Labels)
 	}
 
-	podList, err := cs.CoreV1().Pods(namespace).List(opts)
+	podList, err := cs.CoreV1().Pods(cs.Namespace()).List(opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Small part of the overall strategy to address #257, where the freeform search will never function.

This will at least use the default namespace for the clientset when the resolver passes in the empty namespace as sentinel value.

### GitHub Issue
#257
