### PR TITLE
tools: use destination lockfile in gateway linker if present

### DIFF
--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -39,5 +39,11 @@ for package in "${LINKED_PACKAGES[@]}"; do
   "${YARN}" link "${package}"
 done
 
-"${YARN}" install
+if [[ -f "yarn.lock" ]]; then
+  echo "Found lockfile..."
+  "${YARN}" install --frozen-lockfile
+else
+  echo "No lockfile. Generating one..."
+  "${YARN}" install
+fi
 "${YARN}" "${action}"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Fixes undesired behavior where using the linker in a project with an existing lockfile upgrades dependencies unintentionally.