### PR TITLE
scaffolding: improve workflow completion message

### DIFF
--- a/tools/scaffolding/scaffolder.go
+++ b/tools/scaffolding/scaffolder.go
@@ -211,8 +211,8 @@ func generateFrontend(args *args, tmpFolder, dest string) {
 	}
 
 	fmt.Println("*** All done!")
-	fmt.Println("\n*** Try the following command to get started developing the new workflow:")
-	fmt.Printf("cd %s && make frontend-dev\n", dest)
+	fmt.Printf("\n*** Your new workflow can be found here: %s\n", dest)
+	fmt.Println("For information on how to register this new workflow see our configuration guide: https://clutch.sh/docs/configuration")
 }
 
 type args struct {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The old message was confusing as it directed users to run a make target in the directory of the new workflow.

This improves the scaffolder by telling the user where the generated workflow is and points them to the configuration documentation since we aren't able to predict the destination's contents.