### PR TITLE
ci: limit aws sdk updates to weekly cadence

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,12 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "packageRules": [
+    {
+      "packageNames": ["github.com/aws/aws-sdk-go"],
+      "schedule": ["schedule:weekly"]
+    }
+  ],
   "postUpdateOptions": [
     "gomodTidy"
   ],


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The AWS SDK is released almost everyday. This will limit updates to once per week.

### Testing Performed
Read the docs.