### PR TITLE
github: add CompareCommits function to service

### DIFF
--- a/api/sourcecontrol/github/v1/github.proto
+++ b/api/sourcecontrol/github/v1/github.proto
@@ -35,3 +35,11 @@ message UpdateRepositoryOptions {
   // Pass true to archive this repository. Note: You cannot unarchive repositories through the API.
   bool archived = 2;
 }
+
+enum CommitCompareStatus {
+  UNSPECIFIED = 0;
+  UNKNOWN =1;
+  BEHIND = 2;
+  AHEAD = 3;
+  IDENTICAL = 4;
+}

--- a/api/sourcecontrol/github/v1/github.proto
+++ b/api/sourcecontrol/github/v1/github.proto
@@ -38,7 +38,7 @@ message UpdateRepositoryOptions {
 
 enum CommitCompareStatus {
   UNSPECIFIED = 0;
-  UNKNOWN =1;
+  UNKNOWN = 1;
   BEHIND = 2;
   AHEAD = 3;
   IDENTICAL = 4;

--- a/api/sourcecontrol/github/v1/github.proto
+++ b/api/sourcecontrol/github/v1/github.proto
@@ -43,3 +43,7 @@ enum CommitCompareStatus {
   AHEAD = 3;
   IDENTICAL = 4;
 }
+
+message CommitComparison {
+  CommitCompareStatus status = 1;
+}

--- a/backend/api/sourcecontrol/github/v1/github.pb.go
+++ b/backend/api/sourcecontrol/github/v1/github.pb.go
@@ -317,6 +317,53 @@ func (x *UpdateRepositoryOptions) GetArchived() bool {
 	return false
 }
 
+type CommitComparison struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Status CommitCompareStatus `protobuf:"varint,1,opt,name=status,proto3,enum=clutch.sourcecontrol.github.v1.CommitCompareStatus" json:"status,omitempty"`
+}
+
+func (x *CommitComparison) Reset() {
+	*x = CommitComparison{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_sourcecontrol_github_v1_github_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *CommitComparison) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommitComparison) ProtoMessage() {}
+
+func (x *CommitComparison) ProtoReflect() protoreflect.Message {
+	mi := &file_sourcecontrol_github_v1_github_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommitComparison.ProtoReflect.Descriptor instead.
+func (*CommitComparison) Descriptor() ([]byte, []int) {
+	return file_sourcecontrol_github_v1_github_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *CommitComparison) GetStatus() CommitCompareStatus {
+	if x != nil {
+		return x.Status
+	}
+	return CommitCompareStatus_UNSPECIFIED
+}
+
 var File_sourcecontrol_github_v1_github_proto protoreflect.FileDescriptor
 
 var file_sourcecontrol_github_v1_github_proto_rawDesc = []byte{
@@ -371,14 +418,20 @@ var file_sourcecontrol_github_v1_github_proto_rawDesc = []byte{
 	0x73, 0x69, 0x74, 0x6f, 0x72, 0x79, 0x50, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73,
 	0x52, 0x0a, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73, 0x12, 0x1a, 0x0a, 0x08,
 	0x61, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08,
-	0x61, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x64, 0x2a, 0x59, 0x0a, 0x13, 0x43, 0x6f, 0x6d, 0x6d,
-	0x69, 0x74, 0x43, 0x6f, 0x6d, 0x70, 0x61, 0x72, 0x65, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12,
-	0x0f, 0x0a, 0x0b, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00,
-	0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a,
-	0x06, 0x42, 0x45, 0x48, 0x49, 0x4e, 0x44, 0x10, 0x02, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x48, 0x45,
-	0x41, 0x44, 0x10, 0x03, 0x12, 0x0d, 0x0a, 0x09, 0x49, 0x44, 0x45, 0x4e, 0x54, 0x49, 0x43, 0x41,
-	0x4c, 0x10, 0x04, 0x42, 0x0a, 0x5a, 0x08, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x76, 0x31, 0x62,
-	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x61, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x64, 0x22, 0x5f, 0x0a, 0x10, 0x43, 0x6f, 0x6d, 0x6d,
+	0x69, 0x74, 0x43, 0x6f, 0x6d, 0x70, 0x61, 0x72, 0x69, 0x73, 0x6f, 0x6e, 0x12, 0x4b, 0x0a, 0x06,
+	0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x33, 0x2e, 0x63,
+	0x6c, 0x75, 0x74, 0x63, 0x68, 0x2e, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x63, 0x6f, 0x6e, 0x74,
+	0x72, 0x6f, 0x6c, 0x2e, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x6f,
+	0x6d, 0x6d, 0x69, 0x74, 0x43, 0x6f, 0x6d, 0x70, 0x61, 0x72, 0x65, 0x53, 0x74, 0x61, 0x74, 0x75,
+	0x73, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x2a, 0x59, 0x0a, 0x13, 0x43, 0x6f, 0x6d,
+	0x6d, 0x69, 0x74, 0x43, 0x6f, 0x6d, 0x70, 0x61, 0x72, 0x65, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73,
+	0x12, 0x0f, 0x0a, 0x0b, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10,
+	0x00, 0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x01, 0x12, 0x0a,
+	0x0a, 0x06, 0x42, 0x45, 0x48, 0x49, 0x4e, 0x44, 0x10, 0x02, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x48,
+	0x45, 0x41, 0x44, 0x10, 0x03, 0x12, 0x0d, 0x0a, 0x09, 0x49, 0x44, 0x45, 0x4e, 0x54, 0x49, 0x43,
+	0x41, 0x4c, 0x10, 0x04, 0x42, 0x0a, 0x5a, 0x08, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x76, 0x31,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -394,27 +447,29 @@ func file_sourcecontrol_github_v1_github_proto_rawDescGZIP() []byte {
 }
 
 var file_sourcecontrol_github_v1_github_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_sourcecontrol_github_v1_github_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_sourcecontrol_github_v1_github_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_sourcecontrol_github_v1_github_proto_goTypes = []interface{}{
 	(CommitCompareStatus)(0),             // 0: clutch.sourcecontrol.github.v1.CommitCompareStatus
 	(RepositoryParameters_Visibility)(0), // 1: clutch.sourcecontrol.github.v1.RepositoryParameters.Visibility
 	(*RepositoryParameters)(nil),         // 2: clutch.sourcecontrol.github.v1.RepositoryParameters
 	(*CreateRepositoryOptions)(nil),      // 3: clutch.sourcecontrol.github.v1.CreateRepositoryOptions
 	(*UpdateRepositoryOptions)(nil),      // 4: clutch.sourcecontrol.github.v1.UpdateRepositoryOptions
-	(*wrappers.BoolValue)(nil),           // 5: google.protobuf.BoolValue
+	(*CommitComparison)(nil),             // 5: clutch.sourcecontrol.github.v1.CommitComparison
+	(*wrappers.BoolValue)(nil),           // 6: google.protobuf.BoolValue
 }
 var file_sourcecontrol_github_v1_github_proto_depIdxs = []int32{
 	1, // 0: clutch.sourcecontrol.github.v1.RepositoryParameters.visibility:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters.Visibility
-	5, // 1: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_merge_commit:type_name -> google.protobuf.BoolValue
-	5, // 2: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_rebase_merge:type_name -> google.protobuf.BoolValue
-	5, // 3: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_squash_merge:type_name -> google.protobuf.BoolValue
+	6, // 1: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_merge_commit:type_name -> google.protobuf.BoolValue
+	6, // 2: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_rebase_merge:type_name -> google.protobuf.BoolValue
+	6, // 3: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_squash_merge:type_name -> google.protobuf.BoolValue
 	2, // 4: clutch.sourcecontrol.github.v1.CreateRepositoryOptions.parameters:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters
 	2, // 5: clutch.sourcecontrol.github.v1.UpdateRepositoryOptions.parameters:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	0, // 6: clutch.sourcecontrol.github.v1.CommitComparison.status:type_name -> clutch.sourcecontrol.github.v1.CommitCompareStatus
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_sourcecontrol_github_v1_github_proto_init() }
@@ -459,6 +514,18 @@ func file_sourcecontrol_github_v1_github_proto_init() {
 				return nil
 			}
 		}
+		file_sourcecontrol_github_v1_github_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CommitComparison); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -466,7 +533,7 @@ func file_sourcecontrol_github_v1_github_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_sourcecontrol_github_v1_github_proto_rawDesc,
 			NumEnums:      2,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/backend/api/sourcecontrol/github/v1/github.pb.go
+++ b/backend/api/sourcecontrol/github/v1/github.pb.go
@@ -27,6 +27,61 @@ const (
 // of the legacy proto package is being used.
 const _ = proto.ProtoPackageIsVersion4
 
+type CommitCompareStatus int32
+
+const (
+	CommitCompareStatus_UNSPECIFIED CommitCompareStatus = 0
+	CommitCompareStatus_UNKNOWN     CommitCompareStatus = 1
+	CommitCompareStatus_BEHIND      CommitCompareStatus = 2
+	CommitCompareStatus_AHEAD       CommitCompareStatus = 3
+	CommitCompareStatus_IDENTICAL   CommitCompareStatus = 4
+)
+
+// Enum value maps for CommitCompareStatus.
+var (
+	CommitCompareStatus_name = map[int32]string{
+		0: "UNSPECIFIED",
+		1: "UNKNOWN",
+		2: "BEHIND",
+		3: "AHEAD",
+		4: "IDENTICAL",
+	}
+	CommitCompareStatus_value = map[string]int32{
+		"UNSPECIFIED": 0,
+		"UNKNOWN":     1,
+		"BEHIND":      2,
+		"AHEAD":       3,
+		"IDENTICAL":   4,
+	}
+)
+
+func (x CommitCompareStatus) Enum() *CommitCompareStatus {
+	p := new(CommitCompareStatus)
+	*p = x
+	return p
+}
+
+func (x CommitCompareStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CommitCompareStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_sourcecontrol_github_v1_github_proto_enumTypes[0].Descriptor()
+}
+
+func (CommitCompareStatus) Type() protoreflect.EnumType {
+	return &file_sourcecontrol_github_v1_github_proto_enumTypes[0]
+}
+
+func (x CommitCompareStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CommitCompareStatus.Descriptor instead.
+func (CommitCompareStatus) EnumDescriptor() ([]byte, []int) {
+	return file_sourcecontrol_github_v1_github_proto_rawDescGZIP(), []int{0}
+}
+
 type RepositoryParameters_Visibility int32
 
 const (
@@ -60,11 +115,11 @@ func (x RepositoryParameters_Visibility) String() string {
 }
 
 func (RepositoryParameters_Visibility) Descriptor() protoreflect.EnumDescriptor {
-	return file_sourcecontrol_github_v1_github_proto_enumTypes[0].Descriptor()
+	return file_sourcecontrol_github_v1_github_proto_enumTypes[1].Descriptor()
 }
 
 func (RepositoryParameters_Visibility) Type() protoreflect.EnumType {
-	return &file_sourcecontrol_github_v1_github_proto_enumTypes[0]
+	return &file_sourcecontrol_github_v1_github_proto_enumTypes[1]
 }
 
 func (x RepositoryParameters_Visibility) Number() protoreflect.EnumNumber {
@@ -316,8 +371,14 @@ var file_sourcecontrol_github_v1_github_proto_rawDesc = []byte{
 	0x73, 0x69, 0x74, 0x6f, 0x72, 0x79, 0x50, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73,
 	0x52, 0x0a, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73, 0x12, 0x1a, 0x0a, 0x08,
 	0x61, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x08, 0x52, 0x08,
-	0x61, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x64, 0x42, 0x0a, 0x5a, 0x08, 0x67, 0x69, 0x74, 0x68,
-	0x75, 0x62, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x61, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x64, 0x2a, 0x59, 0x0a, 0x13, 0x43, 0x6f, 0x6d, 0x6d,
+	0x69, 0x74, 0x43, 0x6f, 0x6d, 0x70, 0x61, 0x72, 0x65, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12,
+	0x0f, 0x0a, 0x0b, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00,
+	0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x01, 0x12, 0x0a, 0x0a,
+	0x06, 0x42, 0x45, 0x48, 0x49, 0x4e, 0x44, 0x10, 0x02, 0x12, 0x09, 0x0a, 0x05, 0x41, 0x48, 0x45,
+	0x41, 0x44, 0x10, 0x03, 0x12, 0x0d, 0x0a, 0x09, 0x49, 0x44, 0x45, 0x4e, 0x54, 0x49, 0x43, 0x41,
+	0x4c, 0x10, 0x04, 0x42, 0x0a, 0x5a, 0x08, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x76, 0x31, 0x62,
+	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -332,22 +393,23 @@ func file_sourcecontrol_github_v1_github_proto_rawDescGZIP() []byte {
 	return file_sourcecontrol_github_v1_github_proto_rawDescData
 }
 
-var file_sourcecontrol_github_v1_github_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_sourcecontrol_github_v1_github_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_sourcecontrol_github_v1_github_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_sourcecontrol_github_v1_github_proto_goTypes = []interface{}{
-	(RepositoryParameters_Visibility)(0), // 0: clutch.sourcecontrol.github.v1.RepositoryParameters.Visibility
-	(*RepositoryParameters)(nil),         // 1: clutch.sourcecontrol.github.v1.RepositoryParameters
-	(*CreateRepositoryOptions)(nil),      // 2: clutch.sourcecontrol.github.v1.CreateRepositoryOptions
-	(*UpdateRepositoryOptions)(nil),      // 3: clutch.sourcecontrol.github.v1.UpdateRepositoryOptions
-	(*wrappers.BoolValue)(nil),           // 4: google.protobuf.BoolValue
+	(CommitCompareStatus)(0),             // 0: clutch.sourcecontrol.github.v1.CommitCompareStatus
+	(RepositoryParameters_Visibility)(0), // 1: clutch.sourcecontrol.github.v1.RepositoryParameters.Visibility
+	(*RepositoryParameters)(nil),         // 2: clutch.sourcecontrol.github.v1.RepositoryParameters
+	(*CreateRepositoryOptions)(nil),      // 3: clutch.sourcecontrol.github.v1.CreateRepositoryOptions
+	(*UpdateRepositoryOptions)(nil),      // 4: clutch.sourcecontrol.github.v1.UpdateRepositoryOptions
+	(*wrappers.BoolValue)(nil),           // 5: google.protobuf.BoolValue
 }
 var file_sourcecontrol_github_v1_github_proto_depIdxs = []int32{
-	0, // 0: clutch.sourcecontrol.github.v1.RepositoryParameters.visibility:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters.Visibility
-	4, // 1: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_merge_commit:type_name -> google.protobuf.BoolValue
-	4, // 2: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_rebase_merge:type_name -> google.protobuf.BoolValue
-	4, // 3: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_squash_merge:type_name -> google.protobuf.BoolValue
-	1, // 4: clutch.sourcecontrol.github.v1.CreateRepositoryOptions.parameters:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters
-	1, // 5: clutch.sourcecontrol.github.v1.UpdateRepositoryOptions.parameters:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters
+	1, // 0: clutch.sourcecontrol.github.v1.RepositoryParameters.visibility:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters.Visibility
+	5, // 1: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_merge_commit:type_name -> google.protobuf.BoolValue
+	5, // 2: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_rebase_merge:type_name -> google.protobuf.BoolValue
+	5, // 3: clutch.sourcecontrol.github.v1.RepositoryParameters.allow_squash_merge:type_name -> google.protobuf.BoolValue
+	2, // 4: clutch.sourcecontrol.github.v1.CreateRepositoryOptions.parameters:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters
+	2, // 5: clutch.sourcecontrol.github.v1.UpdateRepositoryOptions.parameters:type_name -> clutch.sourcecontrol.github.v1.RepositoryParameters
 	6, // [6:6] is the sub-list for method output_type
 	6, // [6:6] is the sub-list for method input_type
 	6, // [6:6] is the sub-list for extension type_name
@@ -403,7 +465,7 @@ func file_sourcecontrol_github_v1_github_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_sourcecontrol_github_v1_github_proto_rawDesc,
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/backend/api/sourcecontrol/github/v1/github.pb.validate.go
+++ b/backend/api/sourcecontrol/github/v1/github.pb.validate.go
@@ -308,3 +308,70 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = UpdateRepositoryOptionsValidationError{}
+
+// Validate checks the field values on CommitComparison with the rules defined
+// in the proto definition for this message. If any rules are violated, an
+// error is returned.
+func (m *CommitComparison) Validate() error {
+	if m == nil {
+		return nil
+	}
+
+	// no validation rules for Status
+
+	return nil
+}
+
+// CommitComparisonValidationError is the validation error returned by
+// CommitComparison.Validate if the designated constraints aren't met.
+type CommitComparisonValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e CommitComparisonValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e CommitComparisonValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e CommitComparisonValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e CommitComparisonValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e CommitComparisonValidationError) ErrorName() string { return "CommitComparisonValidationError" }
+
+// Error satisfies the builtin error interface
+func (e CommitComparisonValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sCommitComparison.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = CommitComparisonValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = CommitComparisonValidationError{}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/jhump/protoreflect v1.7.0
 	github.com/lib/pq v1.8.0
+	github.com/lyft/gostats v0.4.2
 	github.com/lyft/protoc-gen-star v0.4.14 // indirect
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/shurcooL/githubv4 v0.0.0-20200802174311-f27d2ca7f6d5

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/jhump/protoreflect v1.7.0
 	github.com/lib/pq v1.8.0
-	github.com/lyft/gostats v0.4.2
 	github.com/lyft/protoc-gen-star v0.4.14 // indirect
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/shurcooL/githubv4 v0.0.0-20200802174311-f27d2ca7f6d5

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -342,6 +342,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
@@ -377,6 +378,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/goreleaser/goreleaser v0.134.0/go.mod h1:ZT6Y2rSYa6NxQzIsdfWWNWAlYGXGbreo66NmE+3X3WQ=
 github.com/goreleaser/nfpm v1.2.1/go.mod h1:TtWrABZozuLOttX2uDlYyECfQX7x5XYkVxhjYcR6G9w=
+github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -397,6 +399,7 @@ github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -412,6 +415,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.6.1-0.20200325015804-c1f7119c9306/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
@@ -443,6 +447,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
@@ -456,10 +461,13 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6Fm
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lyft/gostats v0.4.2 h1:XcnUy5/xxTEzfVlRL/79osAy2h7hgiJblViwT1dSZ0E=
+github.com/lyft/gostats v0.4.2/go.mod h1:Tpx2xRzz4t+T2Tx0xdVgIoBdR2UMVz+dKnE3X01XSd8=
 github.com/lyft/protoc-gen-star v0.4.10/go.mod h1:mE8fbna26u7aEA2QCVvvfBU/ZrPgocG1206xAFPcs94=
 github.com/lyft/protoc-gen-star v0.4.14 h1:HUkD4H4dYFIgu3Bns/3N6J5GmKHCEGnhYBwNu3fvXgA=
 github.com/lyft/protoc-gen-star v0.4.14/go.mod h1:mE8fbna26u7aEA2QCVvvfBU/ZrPgocG1206xAFPcs94=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -467,6 +475,7 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
@@ -485,6 +494,7 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -514,6 +524,7 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -559,6 +570,7 @@ github.com/shurcooL/vfsgen v0.0.0-20200627165143-92b8a710ab6c/go.mod h1:TrYk7fJV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/slack-go/slack v0.6.5 h1:IkDKtJ2IROJNoe3d6mW870/NRKvq2fhLB/Q5XmzWk00=
 github.com/slack-go/slack v0.6.5/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
@@ -573,20 +585,24 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -595,6 +611,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
@@ -602,6 +619,7 @@ github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eN
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
 github.com/uber-go/tally v3.3.17+incompatible h1:nFHIuW3VQ22wItiE9kPXic8dEgExWOsVOHwpmoIvsMw=
 github.com/uber-go/tally v3.3.17+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
@@ -624,6 +642,7 @@ go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.3.0/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
+go.mongodb.org/mongo-driver v1.3.1 h1:op56IfTQiaY2679w922KVWa3qcHdml2K/Io8ayAOUEQ=
 go.mongodb.org/mongo-driver v1.3.1/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -932,6 +951,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.4.1 h1:H0TmLt7/KmzlrDOpa1F+zr0Tk90PbJYBfsVUmRLrf9Y=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -342,7 +342,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
@@ -461,8 +460,6 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6Fm
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lyft/gostats v0.4.2 h1:XcnUy5/xxTEzfVlRL/79osAy2h7hgiJblViwT1dSZ0E=
-github.com/lyft/gostats v0.4.2/go.mod h1:Tpx2xRzz4t+T2Tx0xdVgIoBdR2UMVz+dKnE3X01XSd8=
 github.com/lyft/protoc-gen-star v0.4.10/go.mod h1:mE8fbna26u7aEA2QCVvvfBU/ZrPgocG1206xAFPcs94=
 github.com/lyft/protoc-gen-star v0.4.14 h1:HUkD4H4dYFIgu3Bns/3N6J5GmKHCEGnhYBwNu3fvXgA=
 github.com/lyft/protoc-gen-star v0.4.14/go.mod h1:mE8fbna26u7aEA2QCVvvfBU/ZrPgocG1206xAFPcs94=

--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -38,6 +38,7 @@ func (s svc) CreateIssueComment(ctx context.Context, ref *github.RemoteRef, numb
 func (s svc) CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRepositoryRequest) (*sourcecontrolv1.CreateRepositoryResponse, error) {
 	return &sourcecontrolv1.CreateRepositoryResponse{Url: "https://github.com/lyft/clutch"}, nil
 }
+
 func (s svc) CompareCommits(ctx context.Context, ref *github.RemoteRef, compareSHA string) (*githubv1.CommitComparison, error) {
 	panic("implement me")
 }

--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -7,6 +7,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
+	githubv1 "github.com/lyft/clutch/backend/api/sourcecontrol/github/v1"
 	sourcecontrolv1 "github.com/lyft/clutch/backend/api/sourcecontrol/v1"
 	"github.com/lyft/clutch/backend/service"
 	"github.com/lyft/clutch/backend/service/github"
@@ -36,6 +37,9 @@ func (s svc) CreateIssueComment(ctx context.Context, ref *github.RemoteRef, numb
 
 func (s svc) CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRepositoryRequest) (*sourcecontrolv1.CreateRepositoryResponse, error) {
 	return &sourcecontrolv1.CreateRepositoryResponse{Url: "https://github.com/lyft/clutch"}, nil
+}
+func (s svc) CompareCommits(ctx context.Context, ref *github.RemoteRef, compareSHA string) (githubv1.CommitCompareStatus, error) {
+	panic("implement me")
 }
 
 func NewAsService(*any.Any, *zap.Logger, tally.Scope) (service.Service, error) {

--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -38,7 +38,7 @@ func (s svc) CreateIssueComment(ctx context.Context, ref *github.RemoteRef, numb
 func (s svc) CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRepositoryRequest) (*sourcecontrolv1.CreateRepositoryResponse, error) {
 	return &sourcecontrolv1.CreateRepositoryResponse{Url: "https://github.com/lyft/clutch"}, nil
 }
-func (s svc) CompareCommits(ctx context.Context, ref *github.RemoteRef, compareSHA string) (githubv1.CommitCompareStatus, error) {
+func (s svc) CompareCommits(ctx context.Context, ref *github.RemoteRef, compareSHA string) (*githubv1.CommitComparison, error) {
 	panic("implement me")
 }
 

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -277,7 +277,6 @@ func (s *svc) GetFile(ctx context.Context, ref *RemoteRef, path string) (*File, 
 }
 
 func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*scgithubv1.CommitComparison, error) {
-
 	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
 	if err != nil {
 		return nil, fmt.Errorf("Could not get compare status for %s and %s. %+v", ref.Ref, compareSHA, err)

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -277,19 +277,18 @@ func (s *svc) GetFile(ctx context.Context, ref *RemoteRef, path string) (*File, 
 }
 
 func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*scgithubv1.CommitComparison, error) {
-	cc := &scgithubv1.CommitComparison{
-		Status: scgithubv1.CommitCompareStatus_UNKNOWN,
-	}
 
 	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
 	if err != nil {
-		return cc, fmt.Errorf("Could not get compare status for %s and %s. %+v", ref.Ref, compareSHA, err)
+		return nil, fmt.Errorf("Could not get compare status for %s and %s. %+v", ref.Ref, compareSHA, err)
 	}
 
 	status, ok := scgithubv1.CommitCompareStatus_value[strings.ToUpper(comp.GetStatus())]
 	if !ok {
-		return cc, fmt.Errorf("unknown status %s", comp.GetStatus())
+		return nil, fmt.Errorf("unknown status %s", comp.GetStatus())
 	}
-	cc.Status = scgithubv1.CommitCompareStatus(status)
-	return cc, nil
+
+	return &scgithubv1.CommitComparison{
+		Status: scgithubv1.CommitCompareStatus(status),
+	}, nil
 }

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -156,11 +155,9 @@ func (m *mockRepositories) Create(ctx context.Context, org string, repo *githubv
 }
 
 func (m *mockRepositories) GetContents(_ context.Context, _, _, _ string, _ *githubv3.RepositoryContentGetOptions) (*githubv3.RepositoryContent, []*githubv3.RepositoryContent, *githubv3.Response, error) {
-	fmt.Fprintf(os.Stdout, "Made it here\n")
 	if m.generalError == true {
 		return nil, nil, nil, errors.New(problem)
 	}
-	fmt.Fprintf(os.Stdout, "Made it here2\n")
 	if m.malformedEncodingError {
 		encoding := "unsupported"
 		return &githubv3.RepositoryContent{Encoding: &encoding}, nil, nil, nil
@@ -264,7 +261,7 @@ func TestCompareCommits(t *testing.T) {
 				Repositories: tt.mockRepo,
 			}}
 
-			status, err := s.CompareCommits(
+			comp, err := s.CompareCommits(
 				context.Background(),
 				&RemoteRef{
 					RepoOwner: "owner",
@@ -282,7 +279,7 @@ func TestCompareCommits(t *testing.T) {
 				a.FailNowf("unexpected error: %s", err.Error())
 				return
 			}
-			a.Equal(status, tt.status)
+			a.Equal(comp.GetStatus(), tt.status)
 			a.Nil(err)
 		})
 	}

--- a/backend/service/github/iface.go
+++ b/backend/service/github/iface.go
@@ -21,6 +21,8 @@ type v3client struct {
 type v3repositories interface {
 	// Create a new repository. If an org is specified, the new repository will be created under that org. If the empty string is specified, it will be created for the authenticated user.
 	Create(ctx context.Context, org string, repo *githubv3.Repository) (*githubv3.Repository, *githubv3.Response, error)
+	GetContents(ctx context.Context, owner, repo, path string, opt *githubv3.RepositoryContentGetOptions) (*githubv3.RepositoryContent, []*githubv3.RepositoryContent, *githubv3.Response, error)
+	CompareCommits(ctx context.Context, owner, repo string, base, head string) (*githubv3.CommitsComparison, *githubv3.Response, error)
 }
 
 // Interface for struct defined in https://github.com/google/go-github/blob/master/github/pulls.go.

--- a/frontend/api/src/index.d.ts
+++ b/frontend/api/src/index.d.ts
@@ -8917,6 +8917,15 @@ export namespace clutch {
                      */
                     public toJSON(): { [k: string]: any };
                 }
+
+                /** CommitCompareStatus enum. */
+                enum CommitCompareStatus {
+                    UNSPECIFIED = 0,
+                    UNKNOWN = 1,
+                    BEHIND = 2,
+                    AHEAD = 3,
+                    IDENTICAL = 4
+                }
             }
         }
 

--- a/frontend/api/src/index.d.ts
+++ b/frontend/api/src/index.d.ts
@@ -8926,6 +8926,54 @@ export namespace clutch {
                     AHEAD = 3,
                     IDENTICAL = 4
                 }
+
+                /** Properties of a CommitComparison. */
+                interface ICommitComparison {
+
+                    /** CommitComparison status */
+                    status?: (clutch.sourcecontrol.github.v1.CommitCompareStatus|null);
+                }
+
+                /** Represents a CommitComparison. */
+                class CommitComparison implements ICommitComparison {
+
+                    /**
+                     * Constructs a new CommitComparison.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: clutch.sourcecontrol.github.v1.ICommitComparison);
+
+                    /** CommitComparison status. */
+                    public status: clutch.sourcecontrol.github.v1.CommitCompareStatus;
+
+                    /**
+                     * Verifies a CommitComparison message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a CommitComparison message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns CommitComparison
+                     */
+                    public static fromObject(object: { [k: string]: any }): clutch.sourcecontrol.github.v1.CommitComparison;
+
+                    /**
+                     * Creates a plain object from a CommitComparison message. Also converts values to other types if specified.
+                     * @param message CommitComparison
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: clutch.sourcecontrol.github.v1.CommitComparison, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this CommitComparison to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
             }
         }
 

--- a/frontend/api/src/index.js
+++ b/frontend/api/src/index.js
@@ -21290,6 +21290,134 @@ export const clutch = $root.clutch = (() => {
                     return values;
                 })();
 
+                v1.CommitComparison = (function() {
+
+                    /**
+                     * Properties of a CommitComparison.
+                     * @memberof clutch.sourcecontrol.github.v1
+                     * @interface ICommitComparison
+                     * @property {clutch.sourcecontrol.github.v1.CommitCompareStatus|null} [status] CommitComparison status
+                     */
+
+                    /**
+                     * Constructs a new CommitComparison.
+                     * @memberof clutch.sourcecontrol.github.v1
+                     * @classdesc Represents a CommitComparison.
+                     * @implements ICommitComparison
+                     * @constructor
+                     * @param {clutch.sourcecontrol.github.v1.ICommitComparison=} [properties] Properties to set
+                     */
+                    function CommitComparison(properties) {
+                        if (properties)
+                            for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * CommitComparison status.
+                     * @member {clutch.sourcecontrol.github.v1.CommitCompareStatus} status
+                     * @memberof clutch.sourcecontrol.github.v1.CommitComparison
+                     * @instance
+                     */
+                    CommitComparison.prototype.status = 0;
+
+                    /**
+                     * Verifies a CommitComparison message.
+                     * @function verify
+                     * @memberof clutch.sourcecontrol.github.v1.CommitComparison
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    CommitComparison.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        if (message.status != null && message.hasOwnProperty("status"))
+                            switch (message.status) {
+                            default:
+                                return "status: enum value expected";
+                            case 0:
+                            case 1:
+                            case 2:
+                            case 3:
+                            case 4:
+                                break;
+                            }
+                        return null;
+                    };
+
+                    /**
+                     * Creates a CommitComparison message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof clutch.sourcecontrol.github.v1.CommitComparison
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {clutch.sourcecontrol.github.v1.CommitComparison} CommitComparison
+                     */
+                    CommitComparison.fromObject = function fromObject(object) {
+                        if (object instanceof $root.clutch.sourcecontrol.github.v1.CommitComparison)
+                            return object;
+                        let message = new $root.clutch.sourcecontrol.github.v1.CommitComparison();
+                        switch (object.status) {
+                        case "UNSPECIFIED":
+                        case 0:
+                            message.status = 0;
+                            break;
+                        case "UNKNOWN":
+                        case 1:
+                            message.status = 1;
+                            break;
+                        case "BEHIND":
+                        case 2:
+                            message.status = 2;
+                            break;
+                        case "AHEAD":
+                        case 3:
+                            message.status = 3;
+                            break;
+                        case "IDENTICAL":
+                        case 4:
+                            message.status = 4;
+                            break;
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from a CommitComparison message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof clutch.sourcecontrol.github.v1.CommitComparison
+                     * @static
+                     * @param {clutch.sourcecontrol.github.v1.CommitComparison} message CommitComparison
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    CommitComparison.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        let object = {};
+                        if (options.defaults)
+                            object.status = options.enums === String ? "UNSPECIFIED" : 0;
+                        if (message.status != null && message.hasOwnProperty("status"))
+                            object.status = options.enums === String ? $root.clutch.sourcecontrol.github.v1.CommitCompareStatus[message.status] : message.status;
+                        return object;
+                    };
+
+                    /**
+                     * Converts this CommitComparison to JSON.
+                     * @function toJSON
+                     * @memberof clutch.sourcecontrol.github.v1.CommitComparison
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    CommitComparison.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    return CommitComparison;
+                })();
+
                 return v1;
             })();
 

--- a/frontend/api/src/index.js
+++ b/frontend/api/src/index.js
@@ -21270,6 +21270,26 @@ export const clutch = $root.clutch = (() => {
                     return UpdateRepositoryOptions;
                 })();
 
+                /**
+                 * CommitCompareStatus enum.
+                 * @name clutch.sourcecontrol.github.v1.CommitCompareStatus
+                 * @enum {number}
+                 * @property {number} UNSPECIFIED=0 UNSPECIFIED value
+                 * @property {number} UNKNOWN=1 UNKNOWN value
+                 * @property {number} BEHIND=2 BEHIND value
+                 * @property {number} AHEAD=3 AHEAD value
+                 * @property {number} IDENTICAL=4 IDENTICAL value
+                 */
+                v1.CommitCompareStatus = (function() {
+                    const valuesById = {}, values = Object.create(valuesById);
+                    values[valuesById[0] = "UNSPECIFIED"] = 0;
+                    values[valuesById[1] = "UNKNOWN"] = 1;
+                    values[valuesById[2] = "BEHIND"] = 2;
+                    values[valuesById[3] = "AHEAD"] = 3;
+                    values[valuesById[4] = "IDENTICAL"] = 4;
+                    return values;
+                })();
+
                 return v1;
             })();
 


### PR DESCRIPTION
### Description
Internally at Lyft, we're using clutch to display the status of some deployment pipelines. To do this, we need some additional functionality exposed in the github service to adequately compare commits.

Adding two methods to the github service.
`GetContents` is a wrapper around [Repositories.GetContents] (https://godoc.org/github.com/google/go-github/github#RepositoriesService.GetContents) and returns the contents of the file at the requested path. 

`CompareCommits` is a wrapper around [Repositories.CompareCommits] (https://godoc.org/github.com/google/go-github/github#RepositoriesService.CompareCommits) and indicates if a given sha comes before/after a reference sha. 

### Testing Performed
````
make backend-test
cd backend && go test -race -covermode=atomic ./...
?       github.com/lyft/clutch/backend  [no test files]
?       github.com/lyft/clutch/backend/api/api/v1       [no test files]
?       github.com/lyft/clutch/backend/api/assets/v1    [no test files]
?       github.com/lyft/clutch/backend/api/audit/v1     [no test files]
?       github.com/lyft/clutch/backend/api/authn/v1     [no test files]
?       github.com/lyft/clutch/backend/api/authz/v1     [no test files]
?       github.com/lyft/clutch/backend/api/aws/ec2/v1   [no test files]
?       github.com/lyft/clutch/backend/api/aws/kinesis/v1       [no test files]
?       github.com/lyft/clutch/backend/api/chaos/experimentation/v1     [no test files]
?       github.com/lyft/clutch/backend/api/config/gateway/v1    [no test files]
?       github.com/lyft/clutch/backend/api/config/module/chaos/experimentation/rtds/v1  [no test files]
?       github.com/lyft/clutch/backend/api/config/service/audit/v1      [no test files]
?       github.com/lyft/clutch/backend/api/config/service/auditsink/slack/v1    [no test files]
?       github.com/lyft/clutch/backend/api/config/service/authn/v1      [no test files]
?       github.com/lyft/clutch/backend/api/config/service/authz/v1      [no test files]
?       github.com/lyft/clutch/backend/api/config/service/aws/v1        [no test files]
?       github.com/lyft/clutch/backend/api/config/service/db/postgres/v1        [no test files]
?       github.com/lyft/clutch/backend/api/config/service/envoyadmin/v1 [no test files]
?       github.com/lyft/clutch/backend/api/config/service/github/v1     [no test files]
?       github.com/lyft/clutch/backend/api/config/service/k8s/v1        [no test files]
?       github.com/lyft/clutch/backend/api/envoytriage/v1       [no test files]
?       github.com/lyft/clutch/backend/api/healthcheck/v1       [no test files]
?       github.com/lyft/clutch/backend/api/k8s/v1       [no test files]
?       github.com/lyft/clutch/backend/api/resolver/aws/v1      [no test files]
?       github.com/lyft/clutch/backend/api/resolver/k8s/v1      [no test files]
?       github.com/lyft/clutch/backend/api/resolver/v1  [no test files]
?       github.com/lyft/clutch/backend/api/sourcecontrol/github/v1      [no test files]
?       github.com/lyft/clutch/backend/api/sourcecontrol/v1     [no test files]
?       github.com/lyft/clutch/backend/api/topology/v1  [no test files]
?       github.com/lyft/clutch/backend/cmd/assets       [no test files]
ok      github.com/lyft/clutch/backend/gateway  (cached)        coverage: 11.1% of statements
ok      github.com/lyft/clutch/backend/gateway/meta     (cached)        coverage: 87.0% of statements
ok      github.com/lyft/clutch/backend/gateway/mux      (cached)        coverage: 10.2% of statements
ok      github.com/lyft/clutch/backend/gateway/stats    (cached)        coverage: 43.2% of statements
ok      github.com/lyft/clutch/backend/id       (cached)        coverage: 89.4% of statements
ok      github.com/lyft/clutch/backend/middleware       (cached)        coverage: 90.0% of statements
?       github.com/lyft/clutch/backend/middleware/audit [no test files]
ok      github.com/lyft/clutch/backend/middleware/authn (cached)        coverage: 29.8% of statements
ok      github.com/lyft/clutch/backend/middleware/authz (cached)        coverage: 70.6% of statements
?       github.com/lyft/clutch/backend/middleware/stats [no test files]
ok      github.com/lyft/clutch/backend/middleware/timeouts      (cached)        coverage: 28.0% of statements
?       github.com/lyft/clutch/backend/middleware/validate      [no test files]
?       github.com/lyft/clutch/backend/mock     [no test files]
?       github.com/lyft/clutch/backend/mock/service/auditmock   [no test files]
?       github.com/lyft/clutch/backend/mock/service/authzmock   [no test files]
?       github.com/lyft/clutch/backend/mock/service/awsmock     [no test files]
?       github.com/lyft/clutch/backend/mock/service/chaos/experimentation/experimentstoremock   [no test files]
?       github.com/lyft/clutch/backend/mock/service/envoyadminmock      [no test files]
?       github.com/lyft/clutch/backend/mock/service/githubmock  [no test files]
?       github.com/lyft/clutch/backend/mock/service/k8smock     [no test files]
?       github.com/lyft/clutch/backend/module   [no test files]
?       github.com/lyft/clutch/backend/module/assets    [no test files]
?       github.com/lyft/clutch/backend/module/audit     [no test files]
?       github.com/lyft/clutch/backend/module/authn     [no test files]
ok      github.com/lyft/clutch/backend/module/authz     (cached)        coverage: 70.0% of statements
ok      github.com/lyft/clutch/backend/module/aws       (cached)        coverage: 52.2% of statements
?       github.com/lyft/clutch/backend/module/chaos/experimentation/api [no test files]
ok      github.com/lyft/clutch/backend/module/chaos/experimentation/rtds        (cached)        coverage: 37.7% of statements
?       github.com/lyft/clutch/backend/module/envoytriage       [no test files]
ok      github.com/lyft/clutch/backend/module/healthcheck       (cached)        coverage: 100.0% of statements
ok      github.com/lyft/clutch/backend/module/k8s       (cached)        coverage: 55.6% of statements
ok      github.com/lyft/clutch/backend/module/kinesis   (cached)        coverage: 63.2% of statements
?       github.com/lyft/clutch/backend/module/moduletest        [no test files]
ok      github.com/lyft/clutch/backend/module/resolver  (cached)        coverage: 6.2% of statements
ok      github.com/lyft/clutch/backend/module/sourcecontrol     (cached)        coverage: 80.0% of statements
ok      github.com/lyft/clutch/backend/resolver (cached)        coverage: 52.6% of statements
?       github.com/lyft/clutch/backend/resolver/aws     [no test files]
?       github.com/lyft/clutch/backend/resolver/k8s     [no test files]
?       github.com/lyft/clutch/backend/service  [no test files]
ok      github.com/lyft/clutch/backend/service/audit    (cached)        coverage: 1.0% of statements
ok      github.com/lyft/clutch/backend/service/auditsink        (cached)        coverage: 73.7% of statements
?       github.com/lyft/clutch/backend/service/auditsink/logger [no test files]
ok      github.com/lyft/clutch/backend/service/auditsink/slack  (cached)        coverage: 42.3% of statements
ok      github.com/lyft/clutch/backend/service/authn    (cached)        coverage: 22.6% of statements
ok      github.com/lyft/clutch/backend/service/authz    (cached)        coverage: 57.5% of statements
ok      github.com/lyft/clutch/backend/service/aws      (cached)        coverage: 64.8% of statements
ok      github.com/lyft/clutch/backend/service/chaos/experimentation/experimentstore    (cached)        coverage: 75.4% of statements
ok      github.com/lyft/clutch/backend/service/db/postgres      (cached)        coverage: 91.3% of statements
?       github.com/lyft/clutch/backend/service/envoyadmin       [no test files]
ok      github.com/lyft/clutch/backend/service/github   (cached)        coverage: 48.4% of statements
ok      github.com/lyft/clutch/backend/service/k8s      (cached)        coverage: 76.1% of statements
````