### PR TITLE
kinesis: remove clean before build during compilation

### DIFF
--- a/frontend/workflows/kinesis/package.json
+++ b/frontend/workflows/kinesis/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "yarn clean && yarn compile",
     "clean": "rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
-    "compile": "yarn clean && tsc -b",
+    "compile": "tsc -b",
     "compile:dev": "tsc --sourceMap",
     "compile:watch": "BABEL_ENV=build babel src --out-dir dist --source-maps --extensions .js,.jsx,.ts,.tsx --ignore **/tests --watch",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Removes the clean call before building as it's not required.