### PR TITLE
housekeeping: hoist tsconfig excludes

### DIFF
--- a/frontend/api/tsconfig.json
+++ b/frontend/api/tsconfig.json
@@ -6,7 +6,4 @@
     "rootDir": "./src"
   },
   "include": ["src/*"],
-  "exclude": [
-    "node_modules",
-  ]
 }

--- a/frontend/packages/core/tsconfig.json
+++ b/frontend/packages/core/tsconfig.json
@@ -7,9 +7,5 @@
   },
   "include": [
     "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*",
   ]
 }

--- a/frontend/packages/data-layout/tsconfig.json
+++ b/frontend/packages/data-layout/tsconfig.json
@@ -7,9 +7,5 @@
   },
   "include": [
     "src/**/*",
-  ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
   ]
 }

--- a/frontend/packages/wizard/tsconfig.json
+++ b/frontend/packages/wizard/tsconfig.json
@@ -8,10 +8,6 @@
   "include": [
     "src/**/*",
   ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
-  ],
   "references": [
     {"path": "../core"},
     {"path": "../data-layout"},

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,4 +18,9 @@
     "target": "ES2018",
     "types": ["node", "long"]
   },
+  "exclude": [
+    "node_modules",
+    "**/*.test.jsx",
+    "**/*.test.tsx"
+  ],
 }

--- a/frontend/workflows/ec2/tsconfig.json
+++ b/frontend/workflows/ec2/tsconfig.json
@@ -7,10 +7,6 @@
   "include": [
     "src/**/*",
   ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
-  ],
   "references": [
     {"path": "../../packages/core"},
     {"path": "../../packages/data-layout"},

--- a/frontend/workflows/envoy/tsconfig.json
+++ b/frontend/workflows/envoy/tsconfig.json
@@ -7,10 +7,6 @@
   "include": [
     "src/**/*",
   ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
-  ],
   "references": [
     {"path": "../../api"},
     {"path": "../../packages/core"},

--- a/frontend/workflows/experimentation/tsconfig.json
+++ b/frontend/workflows/experimentation/tsconfig.json
@@ -7,10 +7,6 @@
   "include": [
     "src/**/*",
   ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
-  ],
   "references": [
     {"path": "../../api"},
     {"path": "../../packages/core"},

--- a/frontend/workflows/k8s/tsconfig.json
+++ b/frontend/workflows/k8s/tsconfig.json
@@ -7,10 +7,6 @@
   "include": [
     "src/**/*",
   ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
-  ],
   "references": [
     {"path": "../../api"},
     {"path": "../../packages/core"},

--- a/frontend/workflows/kinesis/tsconfig.json
+++ b/frontend/workflows/kinesis/tsconfig.json
@@ -7,10 +7,6 @@
   "include": [
     "src/**/*",
   ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
-  ],
   "references": [
     {"path": "../../packages/core"},
     {"path": "../../packages/data-layout"},

--- a/frontend/workflows/sourcecontrol/tsconfig.json
+++ b/frontend/workflows/sourcecontrol/tsconfig.json
@@ -7,10 +7,6 @@
   "include": [
     "src/**/*",
   ],
-  "exclude": [
-    "node_modules",
-    "src/tests/**/*"
-  ],
   "references": [
     {"path": "../../packages/core"},
     {"path": "../../packages/data-layout"},


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Pull exclude patterns to root TSConfig file to reduce duplication.