### PR TITLE
api: regenerate for grpc-gateway v1.14.7

### DIFF
--- a/backend/api/assets/v1/assets.pb.gw.go
+++ b/backend/api/assets/v1/assets.pb.gw.go
@@ -52,6 +52,7 @@ func local_request_AssetsAPI_Fetch_0(ctx context.Context, marshaler runtime.Mars
 // RegisterAssetsAPIHandlerServer registers the http handlers for service AssetsAPI to "mux".
 // UnaryRPC     :call AssetsAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterAssetsAPIHandlerFromEndpoint instead.
 func RegisterAssetsAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server AssetsAPIServer) error {
 
 	mux.Handle("GET", pattern_AssetsAPI_Fetch_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/audit/v1/audit.pb.gw.go
+++ b/backend/api/audit/v1/audit.pb.gw.go
@@ -68,6 +68,7 @@ func local_request_AuditAPI_GetEvents_0(ctx context.Context, marshaler runtime.M
 // RegisterAuditAPIHandlerServer registers the http handlers for service AuditAPI to "mux".
 // UnaryRPC     :call AuditAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterAuditAPIHandlerFromEndpoint instead.
 func RegisterAuditAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server AuditAPIServer) error {
 
 	mux.Handle("POST", pattern_AuditAPI_GetEvents_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/authn/v1/authn.pb.gw.go
+++ b/backend/api/authn/v1/authn.pb.gw.go
@@ -106,6 +106,7 @@ func local_request_AuthnAPI_Callback_0(ctx context.Context, marshaler runtime.Ma
 // RegisterAuthnAPIHandlerServer registers the http handlers for service AuthnAPI to "mux".
 // UnaryRPC     :call AuthnAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterAuthnAPIHandlerFromEndpoint instead.
 func RegisterAuthnAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server AuthnAPIServer) error {
 
 	mux.Handle("GET", pattern_AuthnAPI_Login_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/authz/v1/authz.pb.gw.go
+++ b/backend/api/authz/v1/authz.pb.gw.go
@@ -68,6 +68,7 @@ func local_request_AuthzAPI_Check_0(ctx context.Context, marshaler runtime.Marsh
 // RegisterAuthzAPIHandlerServer registers the http handlers for service AuthzAPI to "mux".
 // UnaryRPC     :call AuthzAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterAuthzAPIHandlerFromEndpoint instead.
 func RegisterAuthzAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server AuthzAPIServer) error {
 
 	mux.Handle("POST", pattern_AuthzAPI_Check_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/aws/ec2/v1/ec2.pb.gw.go
+++ b/backend/api/aws/ec2/v1/ec2.pb.gw.go
@@ -136,6 +136,7 @@ func local_request_EC2API_ResizeAutoscalingGroup_0(ctx context.Context, marshale
 // RegisterEC2APIHandlerServer registers the http handlers for service EC2API to "mux".
 // UnaryRPC     :call EC2APIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterEC2APIHandlerFromEndpoint instead.
 func RegisterEC2APIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server EC2APIServer) error {
 
 	mux.Handle("POST", pattern_EC2API_GetInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/aws/kinesis/v1/kinesis.pb.gw.go
+++ b/backend/api/aws/kinesis/v1/kinesis.pb.gw.go
@@ -102,6 +102,7 @@ func local_request_KinesisAPI_UpdateShardCount_0(ctx context.Context, marshaler 
 // RegisterKinesisAPIHandlerServer registers the http handlers for service KinesisAPI to "mux".
 // UnaryRPC     :call KinesisAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterKinesisAPIHandlerFromEndpoint instead.
 func RegisterKinesisAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server KinesisAPIServer) error {
 
 	mux.Handle("POST", pattern_KinesisAPI_GetStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/chaos/experimentation/v1/experimentation.pb.gw.go
+++ b/backend/api/chaos/experimentation/v1/experimentation.pb.gw.go
@@ -136,6 +136,7 @@ func local_request_ExperimentsAPI_DeleteExperiments_0(ctx context.Context, marsh
 // RegisterExperimentsAPIHandlerServer registers the http handlers for service ExperimentsAPI to "mux".
 // UnaryRPC     :call ExperimentsAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterExperimentsAPIHandlerFromEndpoint instead.
 func RegisterExperimentsAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server ExperimentsAPIServer) error {
 
 	mux.Handle("POST", pattern_ExperimentsAPI_CreateExperiments_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/envoytriage/v1/envoytriage_api.pb.gw.go
+++ b/backend/api/envoytriage/v1/envoytriage_api.pb.gw.go
@@ -68,6 +68,7 @@ func local_request_EnvoyTriageAPI_Read_0(ctx context.Context, marshaler runtime.
 // RegisterEnvoyTriageAPIHandlerServer registers the http handlers for service EnvoyTriageAPI to "mux".
 // UnaryRPC     :call EnvoyTriageAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterEnvoyTriageAPIHandlerFromEndpoint instead.
 func RegisterEnvoyTriageAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server EnvoyTriageAPIServer) error {
 
 	mux.Handle("POST", pattern_EnvoyTriageAPI_Read_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/healthcheck/v1/healthcheck.pb.gw.go
+++ b/backend/api/healthcheck/v1/healthcheck.pb.gw.go
@@ -70,6 +70,7 @@ func local_request_HealthcheckAPI_Healthcheck_1(ctx context.Context, marshaler r
 // RegisterHealthcheckAPIHandlerServer registers the http handlers for service HealthcheckAPI to "mux".
 // UnaryRPC     :call HealthcheckAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterHealthcheckAPIHandlerFromEndpoint instead.
 func RegisterHealthcheckAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server HealthcheckAPIServer) error {
 
 	mux.Handle("GET", pattern_HealthcheckAPI_Healthcheck_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/k8s/v1/k8s.pb.gw.go
+++ b/backend/api/k8s/v1/k8s.pb.gw.go
@@ -170,6 +170,7 @@ func local_request_K8SAPI_UpdateDeployment_0(ctx context.Context, marshaler runt
 // RegisterK8SAPIHandlerServer registers the http handlers for service K8SAPI to "mux".
 // UnaryRPC     :call K8SAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterK8SAPIHandlerFromEndpoint instead.
 func RegisterK8SAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server K8SAPIServer) error {
 
 	mux.Handle("POST", pattern_K8SAPI_DescribePod_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/resolver/v1/resolver_api.pb.gw.go
+++ b/backend/api/resolver/v1/resolver_api.pb.gw.go
@@ -136,6 +136,7 @@ func local_request_ResolverAPI_Resolve_0(ctx context.Context, marshaler runtime.
 // RegisterResolverAPIHandlerServer registers the http handlers for service ResolverAPI to "mux".
 // UnaryRPC     :call ResolverAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterResolverAPIHandlerFromEndpoint instead.
 func RegisterResolverAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server ResolverAPIServer) error {
 
 	mux.Handle("POST", pattern_ResolverAPI_GetObjectSchemas_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/sourcecontrol/v1/sourcecontrol.pb.gw.go
+++ b/backend/api/sourcecontrol/v1/sourcecontrol.pb.gw.go
@@ -68,6 +68,7 @@ func local_request_SourceControlAPI_CreateRepository_0(ctx context.Context, mars
 // RegisterSourceControlAPIHandlerServer registers the http handlers for service SourceControlAPI to "mux".
 // UnaryRPC     :call SourceControlAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterSourceControlAPIHandlerFromEndpoint instead.
 func RegisterSourceControlAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server SourceControlAPIServer) error {
 
 	mux.Handle("POST", pattern_SourceControlAPI_CreateRepository_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/backend/api/topology/v1/topology_api.pb.gw.go
+++ b/backend/api/topology/v1/topology_api.pb.gw.go
@@ -68,6 +68,7 @@ func local_request_TopologyAPI_GetTopology_0(ctx context.Context, marshaler runt
 // RegisterTopologyAPIHandlerServer registers the http handlers for service TopologyAPI to "mux".
 // UnaryRPC     :call TopologyAPIServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterTopologyAPIHandlerFromEndpoint instead.
 func RegisterTopologyAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server TopologyAPIServer) error {
 
 	mux.Handle("POST", pattern_TopologyAPI_GetTopology_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Fixes API verification job failing on main due to #295.

### Testing Performed
CI.