### PR TITLE
resolver: fix duplicate options bug

### DIFF
--- a/backend/resolver/resolver.go
+++ b/backend/resolver/resolver.go
@@ -122,20 +122,23 @@ func InputsToSchemas(typeSchemas map[string][]descriptor.Message) (TypeURLToSche
 					return nil, err
 				}
 
-				FieldMeta := fext.(*resolverv1.FieldMetadata)
+				fieldMeta := fext.(*resolverv1.FieldMetadata)
+
+				// Clone the fieldMeta since it's mutable (i.e. dynamic options).
+				fieldMeta = proto.Clone(fieldMeta).(*resolverv1.FieldMetadata)
 
 				// TODO(maybe): this should probably respond with Name instead of JsonName for gRPC clients.
 				// Would need to check context and add a flag.
 				name := *field.JsonName
 
 				// Use default display name of field name if none was provided.
-				if FieldMeta.DisplayName == "" {
-					FieldMeta.DisplayName = name
+				if fieldMeta.DisplayName == "" {
+					fieldMeta.DisplayName = name
 				}
 
 				schema.Fields[j] = &resolverv1.Field{
 					Name:     name,
-					Metadata: FieldMeta,
+					Metadata: fieldMeta,
 				}
 			}
 

--- a/backend/resolver/resolver_test.go
+++ b/backend/resolver/resolver_test.go
@@ -3,7 +3,6 @@ package resolver
 import (
 	"testing"
 
-
 	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Fixes a bug where a schema used for two different `want`ed types would get duplicates of any dynamic options.

This is due to option extensions always returning the same object with same pointer. We clone the meta object so if it's ever modified in different contexts it doesn't happen twice.

The long term fix to avoid these issues, as well as fully realize the benefit of dynamic options, is to move dynamic option hydration to the request path in the resolver module.

### Testing Performed
Unit