### PR TITLE
tooling: backend-dev will now live reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,6 @@ backend-with-assets:
 
 .PHONY: backend-dev # Start the backend in development mode.
 backend-dev:
-	cd backend && go run .
-
-.PHONY: backend-watch # Start the backend in development mode with live code reloading.
-backend-watch:
 	tools/air.sh
 
 .PHONY: backend-dev-mock # Start the backend in development mode with mock responses.

--- a/tools/scaffolding/templates/gateway/.gitignore
+++ b/tools/scaffolding/templates/gateway/.gitignore
@@ -1,1 +1,2 @@
 build/
+backend/.air/

--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -22,6 +22,10 @@ backend:
 backend-dev:
 	cd backend && go run main.go -c clutch-config.yaml
 
+.PHONY: backend-watch # Start the backend in development mode with live code reloading.
+backend-watch:
+	REPO_ROOT=$(MY_ROOT_DIR) $(TOOLS_MODULE_DIR)/air.sh
+
 .PHONY: backend-test
 backend-test:
 	cd backend && go test -race -covermode=atomic ./...

--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -20,11 +20,7 @@ backend:
 
 .PHONY: backend-dev
 backend-dev:
-	cd backend && go run main.go -c clutch-config.yaml
-
-.PHONY: backend-watch # Start the backend in development mode with live code reloading.
-backend-watch:
-	REPO_ROOT=$(MY_ROOT_DIR) $(TOOLS_MODULE_DIR)/air.sh
+	REPO_ROOT=$(MY_ROOT_DIR) $(SHELL) $(TOOLS_MODULE_DIR)/air.sh
 
 .PHONY: backend-test
 backend-test:

--- a/tools/scaffolding/templates/gateway/backend/.air.toml
+++ b/tools/scaffolding/templates/gateway/backend/.air.toml
@@ -1,0 +1,47 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = ".air"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o .air/clutch ."
+# Binary file yields from `cmd`.
+bin = ".air/clutch"
+# Watch these filename extensions.
+include_ext = ["go"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["api"]
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = true
+# Delay after sending Interrupt signal
+kill_delay = 1000 # ms
+# Customize binary.
+# full_bin = "APP_ENV=dev APP_USER=air ./tmp/main"
+# Watch these directories if you specified.
+# include_dir = []
+# Exclude files.
+# exclude_file = []
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Removing the `make backend-watch` command and making this the default behavior of `make backend-dev`. This PR also adds the necessary configuration for live code reloading for a scaffolded gateway.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
manual.
`make backend-dev` works as expected as well as `make dev`.

Generated a custom gateway and tested the `make backend-dev` command
```
➜  clutch-custom-gateway make backend-dev
REPO_ROOT=/Users/mcutalo/gocode/src/github.com/mcutalo/clutch-custom-gateway /usr/bin/env bash /Users/mcutalo/gocode/pkg/mod/github.com/lyft/clutch/tools@v0.0.0-20200814040600-37c4a3407e78/air.sh
info: Downloading air v1.12.3 to build environment
  __    _   ___
 / /\  | | | |_)
/_/--\ |_| |_| \_ v1.12.3 // live reload for Go apps, with Go1.14.0
```