### PR TITLE
github: adding GetCommit method to service

### DIFF
--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -43,6 +43,10 @@ func (s svc) CompareCommits(ctx context.Context, ref *github.RemoteRef, compareS
 	panic("implement me")
 }
 
+func (s svc) GetCommit(ctx context.Context, ref *github.RemoteRef) (*github.Commit, error) {
+	panic("implement me")
+}
+
 func NewAsService(*any.Any, *zap.Logger, tally.Scope) (service.Service, error) {
 	return New(), nil
 }

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -73,6 +73,7 @@ type Client interface {
 	CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRepositoryRequest) (*sourcecontrolv1.CreateRepositoryResponse, error)
 	CreateIssueComment(ctx context.Context, ref *RemoteRef, number int, body string) error
 	CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*scgithubv1.CommitComparison, error)
+	GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error)
 }
 
 // This func can be used to create comments for PRs or Issues
@@ -289,5 +290,19 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
 
 	return &scgithubv1.CommitComparison{
 		Status: scgithubv1.CommitCompareStatus(status),
+	}, nil
+}
+
+type Commit struct {
+	Files []*githubv3.CommitFile
+}
+
+func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
+	commit, _, err := s.rest.Repositories.GetCommit(ctx, ref.RepoOwner, ref.RepoName, ref.Ref)
+	if err != nil {
+		return nil, err
+	}
+	return &Commit{
+		Files: commit.Files,
 	}, nil
 }

--- a/backend/service/github/iface.go
+++ b/backend/service/github/iface.go
@@ -23,6 +23,7 @@ type v3repositories interface {
 	Create(ctx context.Context, org string, repo *githubv3.Repository) (*githubv3.Repository, *githubv3.Response, error)
 	GetContents(ctx context.Context, owner, repo, path string, opt *githubv3.RepositoryContentGetOptions) (*githubv3.RepositoryContent, []*githubv3.RepositoryContent, *githubv3.Response, error)
 	CompareCommits(ctx context.Context, owner, repo string, base, head string) (*githubv3.CommitsComparison, *githubv3.Response, error)
+	GetCommit(ctx context.Context, owner, repo, sha string) (*githubv3.RepositoryCommit, *githubv3.Response, error)
 }
 
 // Interface for struct defined in https://github.com/google/go-github/blob/master/github/pulls.go.


### PR DESCRIPTION
Description
Adds the GitCommit method into the v3repositories interface and a service method to get commit details for a given repository.  

### Testing Performed
`make backend-test` :+1:
`make backend-verify` :+1:
`make backend` :+1:

## Open Questions
In github.go, I've added a [Commit object](https://github.com/lyft/clutch/pull/313/files#diff-1b9746ee0afeded06f610fd4fb017a3fR296) exposing only the data that I'll need to access (files and their filenames), but the GetCommit method could just as easily return a [githubv3.RepositoryCommit](https://github.com/google/go-github/blob/master/github/repos_commits.go#L18) object. Not sure which is the preferable option in this case, but went with this for the time being. Let me know if you have a preference.

