### PR TITLE
auth: reload client on authentication errors

### DIFF
--- a/frontend/packages/core/src/network.ts
+++ b/frontend/packages/core/src/network.ts
@@ -1,5 +1,6 @@
 import type { AxiosError, AxiosResponse } from "axios";
 import axios from "axios";
+import querystring from "querystring";
 
 interface HttpStatus {
   code: number;
@@ -96,8 +97,11 @@ const errorInterceptor = (error: AxiosError) => {
   const { response } = error;
 
   if (response?.status === HTTP_STATUS_MAPPINGS.UNAUTHORIZED) {
-    const dest = encodeURIComponent(window.location.pathname);
-    window.location.href = `${window.location.origin}/v1/authn/login?redirect_url=${dest}`;
+    const href = window.location.href.split("?");
+    const queryParams = querystring.parse(href[href.length - 1]);
+    if (!queryParams.retry) {
+      window.location.href = `${window.location.href}?retry=true`;
+    }
   }
 
   if (response.data?.code && response.data?.message) {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Delegate authentication handling to the client. The client will attempt to reload the current workflow, in turn triggering a credential refresh. To prevent infinite redirects we set a query param to denote that we have retried.

Ideally we prevent progression if the second authorization attempt fails. That will come in a follow up PR.