### PR TITLE
auth: handle auth redirect on client

### DIFF
--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -110,7 +110,9 @@ func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, m runtime.Ma
 			runtime.DefaultHTTPProtoErrorHandler(ctx, mux, m, w, req, err)
 			return
 		}
-		redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, referer.Path)
+		if redirectPath != referer.Path {
+			redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, referer.Path)
+		}
 	}
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
 		http.Redirect(w, req, redirectPath, http.StatusFound)

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -102,19 +102,20 @@ func customResponseForwarder(ctx context.Context, w http.ResponseWriter, resp pr
 
 func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, m runtime.Marshaler, w http.ResponseWriter, req *http.Request, err error) {
 	//  TODO(maybe): once we have non-browser clients we probably want to avoid the redirect and directly return the error.
-	referer := req.Referer()
-	redirectPath := "/v1/authn/login"
-	if len(referer) != 0 {
-		referer, err := url.Parse(referer)
-		if err != nil {
-			runtime.DefaultHTTPProtoErrorHandler(ctx, mux, m, w, req, err)
-			return
-		}
-		if redirectPath != referer.Path {
-			redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, referer.Path)
-		}
-	}
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
+		referer := req.Referer()
+		redirectPath := "/v1/authn/login"
+		if len(referer) != 0 {
+			referer, err := url.Parse(referer)
+			if err != nil {
+				runtime.DefaultHTTPProtoErrorHandler(ctx, mux, m, w, req, err)
+				return
+			}
+			if redirectPath != referer.Path {
+				redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, referer.Path)
+			}
+		}
+
 		http.Redirect(w, req, redirectPath, http.StatusFound)
 		return
 	}

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -110,11 +110,9 @@ func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, m runtime.Ma
 			runtime.DefaultHTTPProtoErrorHandler(ctx, mux, m, w, req, err)
 			return
 		}
-		redirectURL := referer.Path
-		if redirectPath == referer.Path {
-			redirectURL = "/"
+		if redirectPath != referer.Path {
+			redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, referer.Path)
 		}
-		redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, redirectURL)
 	}
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
 		http.Redirect(w, req, redirectPath, http.StatusFound)

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -110,9 +110,11 @@ func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, m runtime.Ma
 			runtime.DefaultHTTPProtoErrorHandler(ctx, mux, m, w, req, err)
 			return
 		}
-		if redirectPath != referer.Path {
-			redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, referer.Path)
+		redirectURL := referer.Path
+		if redirectPath == referer.Path {
+			redirectURL = "/"
 		}
+		redirectPath = fmt.Sprintf("%s?redirect_url=%s", redirectPath, redirectURL)
 	}
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
 		http.Redirect(w, req, redirectPath, http.StatusFound)

--- a/backend/module/authn/authn.go
+++ b/backend/module/authn/authn.go
@@ -62,11 +62,6 @@ func (a *api) Login(ctx context.Context, request *authnv1.LoginRequest) (*authnv
 		return nil, err
 	}
 
-	md := metadata.Pairs("Location", authURL)
-	if err := grpc.SendHeader(ctx, md); err != nil {
-		return nil, err
-	}
-
 	return &authnv1.LoginResponse{
 		AuthUrl: authURL,
 	}, nil

--- a/backend/module/authn/authn.go
+++ b/backend/module/authn/authn.go
@@ -62,6 +62,13 @@ func (a *api) Login(ctx context.Context, request *authnv1.LoginRequest) (*authnv
 		return nil, err
 	}
 
+	if request.RedirectUrl == "" {
+		md := metadata.Pairs("Location", authURL)
+		if err := grpc.SendHeader(ctx, md); err != nil {
+			return nil, err
+		}
+	}
+
 	return &authnv1.LoginResponse{
 		AuthUrl: authURL,
 	}, nil

--- a/frontend/packages/core/src/network.ts
+++ b/frontend/packages/core/src/network.ts
@@ -97,6 +97,9 @@ const successInterceptor = (response: AxiosResponse<any>) => {
   // to prevent CORS issues from redirecting on the server.
   if (response?.data?.authUrl) {
     window.location = response.data.authUrl;
+    response.data.code = 401;
+    response.data.message = "Authentication Expired";
+    throw new ClientError(response)
   }
 
   return response;

--- a/frontend/packages/core/src/network.ts
+++ b/frontend/packages/core/src/network.ts
@@ -99,7 +99,7 @@ const successInterceptor = (response: AxiosResponse<any>) => {
     window.location = response.data.authUrl;
     response.data.code = 401;
     response.data.message = "Authentication Expired";
-    throw new ClientError(response)
+    throw new ClientError(response);
   }
 
   return response;

--- a/frontend/packages/core/src/network.ts
+++ b/frontend/packages/core/src/network.ts
@@ -92,6 +92,16 @@ class ClientError extends Error {
   }
 }
 
+const successInterceptor = (response: AxiosResponse<any>) => {
+  // n.b. this middleware handles authentication redirects
+  // to prevent CORS issues from redirecting on the server.
+  if (response?.data?.authUrl) {
+    window.location = response.data.authUrl;
+  }
+
+  return response;
+};
+
 const errorInterceptor = (error: AxiosError) => {
   const { response } = error;
 
@@ -110,7 +120,7 @@ const errorInterceptor = (error: AxiosError) => {
 const createClient = () => {
   const instance = axios.create();
   instance.interceptors.response.use(
-    success => success,
+    response => successInterceptor(response),
     error => errorInterceptor(error)
   );
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
At the moment, if the authentication token expires while a Clutch session is open any requests to the server will attempt to refresh this through a chain of redirects (`API endpoint` -> `/v1/authn/login` -> `Auth provider` -> `Clutch landing page`). However, some auth providers (such as Okta) will reject redirects that are initiated from a different origin (via the absence of a CORS policy). Okta intentionally does not support CORS on their authentication endpoints, asking instead that this be done from the server. Long term that is the best approach but Clutch does not currently have a datastore for this so this logic must be handled on the front-end.

This PR changes the authentication logic such that the authn module has two possible outcomes:

- If no `redirect_url` is specified (such as when the landing page is first loading) a redirect will occur by appending a Location header to the response. This is the same as the existing behavior.
- If a `redirect_url` is specified a redirect will still occur but instead of appending a Location header the redirect URL is returned directly and the frontend will handle the redirect in the success interceptor of network requests.

### Testing Performed
Deployed and tested manually.
