### PR TITLE
frontend: include credentials in manifest fetch

### DIFF
--- a/frontend/packages/app/public/index.html
+++ b/frontend/packages/app/public/index.html
@@ -10,7 +10,7 @@
       name="description"
       content="Clutch will assist you in safely modifying resources."
     />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials"/>
     <!--
       %PUBLIC_URL% will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.

--- a/tools/scaffolding/templates/gateway/frontend/public/index.html
+++ b/tools/scaffolding/templates/gateway/frontend/public/index.html
@@ -10,7 +10,7 @@
             name="description"
             content="Clutch will assist you in safely modifying resources."
     />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials"/>
     <!--
       %PUBLIC_URL% will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Include credentials in manifest fetch. This prevents redirects if your domain sits behind an auth provider.