### PR TITLE
core: log configuration file being used

### DIFF
--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -33,7 +33,7 @@ type ComponentFactory struct {
 
 func Run(f *Flags, cf *ComponentFactory, assets http.FileSystem) {
 	// Use a temporary logger to parse the configuration and output.
-	tmpLogger := newTmpLogger().With(zap.String("filename", f.ConfigPath))
+	tmpLogger := newTmpLogger().With(zap.String("file", f.ConfigPath))
 
 	var cfg gatewayv1.Config
 	if err := parseFile(f.ConfigPath, &cfg, f.Template); err != nil {
@@ -48,6 +48,7 @@ func Run(f *Flags, cf *ComponentFactory, assets http.FileSystem) {
 		os.Exit(0)
 	}
 
+	tmpLogger.Info("Using configuration")
 	RunWithConfig(&cfg, cf, assets)
 }
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Informational logging about which configuration file clutch is using.

> {"level":"info","ts":1597875368.2666712,"caller":"gateway/gateway.go:51","msg":"Using configuration","file":"clutch-config.yaml"}

With full filepath
>{"level":"info","ts":1597874265.58532,"caller":"gateway/gateway.go:51","msg":"Using configuration","file":"/Users/mcutalo/Desktop/clutch-config.yaml"}

### Testing Performed
<!-- Describe how you tested this change below. -->

local
