### PR TITLE
frontend: allow workflow routes to be private

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -29,9 +29,17 @@ interface ClutchAppProps {
 
 const ClutchApp: React.FC<ClutchAppProps> = ({ availableWorkflows, configuration }) => {
   const workflows = registeredWorkflows(availableWorkflows, configuration);
+
+  /** Filter out all of the workflows that are configured to be `hideNav: true`.
+   * This prevents the workflows from being discoverable by the user from the UI,
+   * both search and drawer navigation.
+   *
+   * The routes for all configured workflows will still be reachable
+   * by manually providing the full path in the URI.
+   */
   const publicWorkflows = _.cloneDeep(workflows).filter(workflow => {
     const publicRoutes = workflow.routes.filter(route => {
-      return !(route?.private !== undefined ? route.private : false);
+      return !(route?.hideNav !== undefined ? route.hideNav : false);
     });
     workflow.routes = publicRoutes; /* eslint-disable-line no-param-reassign */
     return publicRoutes.length !== 0;

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { BrowserRouter as Router, Outlet, Route, Routes } from "react-router-dom";
 import { CssBaseline, MuiThemeProvider } from "@material-ui/core";
+import _ from "lodash";
 import { ThemeProvider as StyledThemeProvider } from "styled-components";
 
 import AppLayout from "../AppLayout";
@@ -28,13 +29,21 @@ interface ClutchAppProps {
 
 const ClutchApp: React.FC<ClutchAppProps> = ({ availableWorkflows, configuration }) => {
   const workflows = registeredWorkflows(availableWorkflows, configuration);
+  const publicWorkflows = _.cloneDeep(workflows).filter(workflow => {
+    const publicRoutes = workflow.routes.filter(route => {
+      return !(route?.private !== undefined ? route.private : false);
+    });
+    workflow.routes = publicRoutes; /* eslint-disable-line no-param-reassign */
+    return publicRoutes.length !== 0;
+  });
+
   return (
     <Router>
       <MuiThemeProvider theme={getTheme()}>
         <StyledThemeProvider theme={getTheme()}>
           <CssBaseline />
           <div id="App">
-            <ApplicationContext.Provider value={{ workflows }}>
+            <ApplicationContext.Provider value={{ workflows: publicWorkflows }}>
               <Routes>
                 <Route path="/*" element={<AppLayout />}>
                   <Route key="landing" path="/" element={<Landing />} />

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -48,7 +48,7 @@ interface Route {
   /** Properties required by the Component that are set only via the config. */
   requiredConfigProps?: string[];
   /** Is the workflow discoverable via search and drawer navigation. This defaults to false. */
-  private?: boolean;
+  hideNav?: boolean;
 }
 
 export interface ConfiguredRoute extends Route {

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -47,6 +47,8 @@ interface Route {
   path: string;
   /** Properties required by the Component that are set only via the config. */
   requiredConfigProps?: string[];
+  /** Is the workflow discoverable via search and drawer navigation. This defaults to false. */
+  private?: boolean;
 }
 
 export interface ConfiguredRoute extends Route {

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -32,6 +32,7 @@ const register = (): WorkflowConfiguration => {
         description: "Terminate an EC2 instance.",
         component: TerminateInstance,
         requiredConfigProps: ["resolverType"],
+        private: true,
       },
       resizeAutoscalingGroup: {
         path: "asg/resize",

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -32,7 +32,6 @@ const register = (): WorkflowConfiguration => {
         description: "Terminate an EC2 instance.",
         component: TerminateInstance,
         requiredConfigProps: ["resolverType"],
-        private: true,
       },
       resizeAutoscalingGroup: {
         path: "asg/resize",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Allow workflows to define private routes. This will prevent the route from being discoverable via the drawer and search bar while still allowing them to be registered on the application.

**note**: this supersedes the trending property and will hide trending workflows.

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
