### PR TITLE
core: avoid duplicated of packages

### DIFF
--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
-LINKED_PACKAGES=("react" "react-dom" "react-router" "react-router-dom")
+LINKED_PACKAGES=("react" "react-dom" "react-router" "react-router-dom" "styled-components" "@material-ui/styles")
 
 EXTERNAL_ROOT="${1}"
 YARN="${EXTERNAL_ROOT}/build/bin/yarn.sh"


### PR DESCRIPTION
Add `styled-components` and `@material-ui/styles` to the list of linked packages to avoid linking of both of these packages twice for when Clutch is set up to be a submodule of another git repository.
