### PR TITLE
ci: add codeowners to js/ts files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 *                                            @lyft/clutch-admin
+/frontend/api/src/                           @lyft/resilience
+/frontend/api/src/                           @lyft/resilience
 /api/chaos/                                  @lyft/resilience
 /backend/**/chaos/                           @lyft/resilience
 /frontend/workflows/experimentation/         @lyft/resilience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 *                                            @lyft/clutch-admin
 /frontend/api/src/                           @lyft/resilience
-/frontend/api/src/                           @lyft/resilience
 /api/chaos/                                  @lyft/resilience
 /backend/**/chaos/                           @lyft/resilience
 /frontend/workflows/experimentation/         @lyft/resilience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 *                                            @lyft/clutch-admin
-/frontend/api/src/                           @lyft/resilience
 /api/chaos/                                  @lyft/resilience
 /backend/**/chaos/                           @lyft/resilience
+/frontend/api/src/                           @lyft/resilience
 /frontend/workflows/experimentation/         @lyft/resilience
 /frontend/workflows/serverexperimentation/   @lyft/resilience


### PR DESCRIPTION
While working on https://github.com/lyft/clutch/pull/366 I noticed that some of the generated JS files are outside of the scope of the directories that resilience owns even though the generated changes are due to change in `experimentation` specific code.

Adding `frontend/api/src/index.js` to the list of directories owner by resilience to allow us to make changes that result in the change in the generated code without a need for an 'external' approval.
