### PR TITLE
core: call function only if it's available

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -34,7 +34,9 @@ const TextField: React.FC<TextFieldProps & MuiTextFieldProps> = ({
   const onKeyDown = (
     e: React.KeyboardEvent<HTMLDivElement | HTMLTextAreaElement | HTMLInputElement>
   ) => {
-    onChange(e as React.ChangeEvent<any>);
+    if (onChange) {
+      onChange(e as React.ChangeEvent<any>);
+    }
     if (e.keyCode === KEY_ENTER && onReturn) {
       onReturn();
     }

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -34,7 +34,7 @@ const TextField: React.FC<TextFieldProps & MuiTextFieldProps> = ({
   const onKeyDown = (
     e: React.KeyboardEvent<HTMLDivElement | HTMLTextAreaElement | HTMLInputElement>
   ) => {
-    if (onChange) {
+    if (onChange !== undefined) {
       onChange(e as React.ChangeEvent<any>);
     }
     if (e.keyCode === KEY_ENTER && onReturn) {


### PR DESCRIPTION
Call `onChange` function only when it's passed by the caller (user of a `TextField`).