### PR TITLE
kubernetes: getter for clientsets

### DIFF
--- a/backend/mock/service/k8smock/k8smock.go
+++ b/backend/mock/service/k8smock/k8smock.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
 
 	k8sv1 "github.com/lyft/clutch/backend/api/k8s/v1"
 	"github.com/lyft/clutch/backend/service"
@@ -105,6 +106,12 @@ func (s *svc) UpdatePod(ctx context.Context, clientset, cluster, namespace, name
 
 func (*svc) Clientsets() []string {
 	return []string{"fake-user@fake-cluster"}
+}
+
+func (s *svc) GetClientSets() map[string]k8sservice.ContextClientset {
+	return map[string]k8sservice.ContextClientset{
+		"fake-cluster": k8sservice.NewContextClientset("ns", "cluster", &kubernetes.Clientset{}),
+	}
 }
 
 func New() k8sservice.Service {

--- a/backend/mock/service/k8smock/k8smock.go
+++ b/backend/mock/service/k8smock/k8smock.go
@@ -108,7 +108,7 @@ func (*svc) Clientsets() []string {
 	return []string{"fake-user@fake-cluster"}
 }
 
-func (s *svc) GetClientSets() map[string]k8sservice.ContextClientset {
+func (s *svc) GetCacheableTopologyObjects() map[string]k8sservice.ContextClientset {
 	return map[string]k8sservice.ContextClientset{
 		"fake-cluster": k8sservice.NewContextClientset("ns", "cluster", &kubernetes.Clientset{}),
 	}

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -50,7 +50,9 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 type Service interface {
 	// All names of clientsets.
 	Clientsets() []string
-	GetClientSets() map[string]ContextClientset
+
+	// Used by the topology API to determin which clientsets to cache.
+	GetCacheableTopologyObjects() map[string]ContextClientset
 
 	// Pod management functions.
 	DescribePod(ctx context.Context, clientset, cluster, namespace, name string) (*k8sapiv1.Pod, error)
@@ -86,6 +88,7 @@ func (s *svc) Clientsets() []string {
 	return ret
 }
 
-func (s *svc) GetClientSets() map[string]ContextClientset {
+func (s *svc) GetCacheableTopologyObjects() map[string]ContextClientset {
+	// Cache all configured clusters
 	return s.manager.Clientsets()
 }

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -50,6 +50,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 type Service interface {
 	// All names of clientsets.
 	Clientsets() []string
+	GetClientSets() map[string]ContextClientset
 
 	// Pod management functions.
 	DescribePod(ctx context.Context, clientset, cluster, namespace, name string) (*k8sapiv1.Pod, error)
@@ -83,4 +84,8 @@ func (s *svc) Clientsets() []string {
 		ret = append(ret, name)
 	}
 	return ret
+}
+
+func (s *svc) GetClientSets() map[string]ContextClientset {
+	return s.manager.Clientsets()
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
While prototyping for the topology feature set https://github.com/lyft/clutch/issues/30, I needed to access all of the clientsets that were currently configured in the k8s service. This was so I could [setup informers](https://github.com/lyft/clutch/pull/362/files#diff-30185c438f5bbaf098b6a77eab58cf02R25-R28 ) for all configured clusters to populate the cache.

### Testing Performed
<!-- Describe how you tested this change below. -->
n/a

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

To unblock on https://github.com/lyft/clutch/issues/30.


