### PR TITLE
gateway: move to protojson marshaler

### DIFF
--- a/backend/gateway/mux/marshaler.go
+++ b/backend/gateway/mux/marshaler.go
@@ -1,0 +1,35 @@
+package mux
+
+import (
+	"io"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	runtimev2 "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+)
+
+// protojsonShim is a simple struct that allow us to move to the protojson marshaler of grpc-gateway v2 without fully migrating to v2.
+// This replaces the original jsonpb-based marshaler which has a number of bugs.
+// TODO: delete once migrated to grpc-gateway v2.
+type protojsonShim struct {
+	marshalerv2 *runtimev2.JSONPb
+}
+
+func (p *protojsonShim) Marshal(v interface{}) ([]byte, error) {
+	return p.marshalerv2.Marshal(v)
+}
+
+func (p *protojsonShim) Unmarshal(data []byte, v interface{}) error {
+	return p.marshalerv2.Unmarshal(data, v)
+}
+
+func (p *protojsonShim) NewDecoder(r io.Reader) runtime.Decoder {
+	return p.marshalerv2.NewDecoder(r)
+}
+
+func (p *protojsonShim) NewEncoder(w io.Writer) runtime.Encoder {
+	return p.marshalerv2.NewEncoder(w)
+}
+
+func (p *protojsonShim) ContentType() string {
+	return p.marshalerv2.ContentType(nil)
+}

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	runtimev2 "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var apiPattern = regexp.MustCompile(`^/v\d+/`)
@@ -129,12 +131,10 @@ func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem
 		runtime.WithProtoErrorHandler(customErrorHandler),
 		runtime.WithMarshalerOption(
 			runtime.MIMEWildcard,
-			&runtime.JSONPb{
-				// Use camelCase for the JSON version.
-				OrigName: false,
-				// Transmit zero-values over the wire.
-				EmitDefaults: true,
-			},
+			&protojsonShim{marshalerv2: &runtimev2.JSONPb{
+				MarshalOptions:   protojson.MarshalOptions{},
+				UnmarshalOptions: protojson.UnmarshalOptions{},
+			}},
 		),
 	)
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/googleapis/gnostic v0.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/grpc-ecosystem/grpc-gateway v1.14.8
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.0-beta.4
 	github.com/iancoleman/strcase v0.1.1
 	github.com/jhump/protoreflect v1.7.1-0.20200723220026-11eaaf73e0ec
 	github.com/lib/pq v1.8.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -476,6 +476,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.2/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.14.8 h1:hXClj+iFpmLM8i3lkO6i4Psli4P2qObQuQReiII26U8=
 github.com/grpc-ecosystem/grpc-gateway v1.14.8/go.mod h1:NZE8t6vs6TnwLL/ITkaK8W3ecMLGAbh2jXTclvpiwYo=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.0-beta.4 h1:kRpp+ClfBl/d8iVxPucnXtvmdDc8J6OfsUX+A8dv1oE=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.0-beta.4/go.mod h1:s6Y2jFmY4W++kYQudXl97XtztCcIhvEp869VVvHFpfs=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -1187,6 +1189,7 @@ google.golang.org/genproto v0.0.0-20200720141249-1244ee217b7e/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200808173500-a06252235341/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d h1:92D1fum1bJLKSdr11OJ+54YeCMCGYIygTA7R/YZxH5M=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1208,6 +1211,8 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200527211525-6c9e30c09db2 h1:KNluVV5ay+orsSPJ6XTpwJQ8qBhrBkOTmtBFGeDlBcY=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200527211525-6c9e30c09db2/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
### Description
`jsonpb` has a bug where deserializing a map with `null` messages results in an empty message with empty values. This is fixed in `protojson`. The signature changed for the ContentType() method of the marshaler interface from v1 to v2 of grpc-gateway so a simple 1:1 shim is needed to use the new marshaler.