### PR TITLE
experimentation: fix view experiment run details view

### DIFF
--- a/backend/service/chaos/experimentation/experimentstore/expriment_run_details.go
+++ b/backend/service/chaos/experimentation/experimentstore/expriment_run_details.go
@@ -24,11 +24,11 @@ func NewRunDetails(fetchedID uint64, startTime sql.NullTime, endTime sql.NullTim
 	}
 
 	if runConfigPair.Status == experimentation.Status_COMPLETED {
-		endTimeField := &experimentation.Property{Label: "Scheduled End Time", Value: timeToString(endTime)}
+		endTimeField := &experimentation.Property{Label: "End Time", Value: timeToString(endTime)}
 		runConfigPair.GetProperties().Items = append(runConfigPair.GetProperties().Items, endTimeField)
 	}
 
-	scheduledEndTimeField := &experimentation.Property{Label: "Scheduled End Time", Value: timeToString(endTime)}
+	scheduledEndTimeField := &experimentation.Property{Label: "Scheduled End Time", Value: timeToString(scheduledEndTime)}
 	runConfigPair.GetProperties().Items = append(runConfigPair.GetProperties().Items, scheduledEndTimeField)
 
 	anyConfig := &any.Any{}

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -29,12 +29,13 @@ const ViewExperimentRun: React.FC = () => {
       onClick: goBack,
     };
 
-    if (experiment.status === clutch.chaos.experimentation.v1.Status.COMPLETED) {
+    const statusValue = clutch.chaos.experimentation.v1.Status[experiment.status];
+    if (statusValue === clutch.chaos.experimentation.v1.Status.COMPLETED.toString()) {
       return [goBackButton];
     }
 
     const title =
-      experiment.status === clutch.chaos.experimentation.v1.Status.RUNNING
+      statusValue === clutch.chaos.experimentation.v1.Status.RUNNING.toString()
         ? "Stop Experiment Run"
         : "Cancel Experiment Run";
     const destructiveButton = {

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -29,7 +29,7 @@ const ViewExperimentRun: React.FC = () => {
       onClick: goBack,
     };
 
-    const statusValue = clutch.chaos.experimentation.v1.Status[experiment.status];
+    const statusValue = clutch.chaos.experimentation.v1.Status[experiment.status].toString();
     if (statusValue === clutch.chaos.experimentation.v1.Status.COMPLETED.toString()) {
       return [goBackButton];
     }


### PR DESCRIPTION
Changes:
- show one `End Time` and one `Scheduled End Time` fields instead of two `Scheduled End Time` fields
- populate `Scheduled End Time` field with the right value
- do not show `Cancel Experiment Run` button if experiment is in completed state

| Before | After |
|-----|------|
| <img width="629" alt="Screen Shot 2020-09-10 at 11 37 17 AM" src="https://user-images.githubusercontent.com/4410346/92784934-d9cebe80-f35b-11ea-9ad8-724d54a4a79c.png"> | <img width="607" alt="Screen Shot 2020-09-10 at 11 44 40 AM" src="https://user-images.githubusercontent.com/4410346/92783919-0afabf00-f35b-11ea-8c63-51ff7dbe7c83.png"> |

