### PR TITLE
header: persist theme through global class overrides

### DIFF
--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -17,7 +17,17 @@ import SearchField from "./search";
 import { UserInformation } from "./user";
 
 const AppBar = styled(MuiAppBar)`
+  ${({ theme }) => `
   min-width: fit-content;
+  background-color: ${theme.palette.secondary.main};
+  color: ${theme.palette.primary.main};
+  min-width: fit-content;
+  `}
+`;
+
+const MenuButton = styled(IconButton)`
+  padding: 12px;
+  margin-left: -12px;
 `;
 
 const Title = styled(Typography)`
@@ -58,11 +68,11 @@ const Header: React.FC = () => {
 
   return (
     <>
-      <AppBar position="static" color="secondary" style={{ minWidth: "fit-content" }}>
+      <AppBar position="static" color="secondary">
         <Toolbar>
-          <IconButton onClick={openDrawer} edge="start" color="primary" data-qa="menuBtn">
+          <MenuButton onClick={openDrawer} edge="start" color="primary" data-qa="menuBtn">
             <MenuIcon />
-          </IconButton>
+          </MenuButton>
           <Link to="/">
             <Logo />
           </Link>
@@ -75,7 +85,7 @@ const Header: React.FC = () => {
         </Toolbar>
       </AppBar>
       <Drawer open={drawerOpen} onClose={onDrawerClose} />
-    </>
+      </>
   );
 };
 

--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -85,7 +85,7 @@ const Header: React.FC = () => {
         </Toolbar>
       </AppBar>
       <Drawer open={drawerOpen} onClose={onDrawerClose} />
-      </>
+    </>
   );
 };
 

--- a/frontend/packages/core/src/AppLayout/user.tsx
+++ b/frontend/packages/core/src/AppLayout/user.tsx
@@ -16,8 +16,8 @@ import styled from "styled-components";
 
 const UserPhoto = styled(IconButton)`
   ${({ theme }) => `
-  padding-top: 1px;
-  padding-bottom: ${theme.spacing(0.5)}px;
+  padding: 1px 0 ${theme.spacing(0.5)}px 12px;
+  margin-right: ${theme.spacing(0.5)}px;
   `}
 `;
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Persist theme using CSS instead of relying on inferred CSS via the global theme. This fixes an issue where Material UI would change the global styles and any styles that were inferred (e.g. `color="secondary"` when a select menu was opened) would update.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2020-09-10 at 1 15 12 PM](https://user-images.githubusercontent.com/1004789/92798727-0d174a80-f368-11ea-94d4-b8985b3771d2.png)

### Testing Performed
Manual
