### PR TITLE
core: add new select component

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -36,7 +36,7 @@ const StyledSelect = styled(MuiSelect)`
 
 interface SelectOption {
   label: string;
-  value: string;
+  value?: string;
 }
 
 interface SelectProps {
@@ -60,21 +60,29 @@ const Select: React.FC<SelectProps> = ({
     return null;
   }
 
-  const [selectedIdx, setSelectedIdx] = React.useState(defaultOption);
+  const defaultIdx = defaultOption < options.length ? defaultOption : 0;
+  const [selectedIdx, setSelectedIdx] = React.useState(defaultIdx);
 
   const updateSelectedOption = (event: React.ChangeEvent<{ name?: string; value: string }>) => {
     const { value } = event.target;
-    const optionValues = options.map(o => o.value);
+    const optionValues = options.map(o => o.value || o.label);
     setSelectedIdx(optionValues.indexOf(value));
     onChange(value);
   };
 
+  React.useEffect(() => {
+    onChange(options[selectedIdx].value || options[selectedIdx].label);
+  }, []);
+
   return (
     <FormControl key={name} data-max-width={maxWidth}>
       <InputLabel color="secondary">{label}</InputLabel>
-      <StyledSelect value={options[selectedIdx].label} onChange={updateSelectedOption}>
+      <StyledSelect
+        value={options[selectedIdx].value || options[selectedIdx].label}
+        onChange={updateSelectedOption}
+      >
         {options.map(option => (
-          <MenuItem key={option.label} value={option.value}>
+          <MenuItem key={option.label} value={option.value || option.label}>
             {option.label}
           </MenuItem>
         ))}

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -34,17 +34,22 @@ const StyledSelect = styled(MuiSelect)`
   `}
 `;
 
+interface SelectOption {
+  label: string;
+  value: string;
+}
+
 interface SelectProps {
-  defaultOption?: string;
+  defaultOption?: number;
   label: string;
   maxWidth?: string;
   name: string;
-  options: string[];
+  options: SelectOption[];
   onChange: (value: string) => void;
 }
 
 const Select: React.FC<SelectProps> = ({
-  defaultOption,
+  defaultOption = 0,
   label,
   maxWidth,
   name,
@@ -55,21 +60,22 @@ const Select: React.FC<SelectProps> = ({
     return null;
   }
 
-  const defaultIdx = (options || []).indexOf(defaultOption);
-  const [selectedValue, setSelectedValue] = React.useState(options[defaultIdx] || options[0]);
+  const [selectedIdx, setSelectedIdx] = React.useState(defaultOption);
 
   const updateSelectedOption = (event: React.ChangeEvent<{ name?: string; value: string }>) => {
-    setSelectedValue(event.target.value);
-    onChange(event.target.value);
+    const { value } = event.target;
+    const optionValues = options.map(o => o.value);
+    setSelectedIdx(optionValues.indexOf(value));
+    onChange(value);
   };
 
   return (
     <FormControl key={name} data-max-width={maxWidth}>
       <InputLabel color="secondary">{label}</InputLabel>
-      <StyledSelect value={selectedValue} onChange={updateSelectedOption}>
+      <StyledSelect value={options[selectedIdx].label} onChange={updateSelectedOption}>
         {options.map(option => (
-          <MenuItem key={option} value={option}>
-            {option}
+          <MenuItem key={option.label} value={option.value}>
+            {option.label}
           </MenuItem>
         ))}
       </StyledSelect>

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import {
+  FormControl as MuiFormControl,
+  InputLabel as MuiInputLabel,
+  MenuItem,
+  Select as MuiSelect,
+} from "@material-ui/core";
+import styled from "styled-components";
+
+const InputLabel = styled(MuiInputLabel)`
+  ${({ theme }) => `
+  && {
+    color: ${theme.palette.text.primary};
+  }
+  `}
+`;
+
+const FormControl = styled(MuiFormControl)`
+  ${({ theme, ...props }) => `
+  display: flex;
+  width: 100%;
+  max-width: ${props["data-max-width"] || "500px"};
+  .MuiInput-underline:after {
+    border-bottom: 2px solid ${theme.palette.accent.main};
+  }
+  `}
+`;
+
+const StyledSelect = styled(MuiSelect)`
+  ${({ ...props }) => `
+  display: flex;
+  width: 100%;
+  max-width: ${props["data-max-width"] || "500px"};
+  `}
+`;
+
+interface SelectProps {
+  defaultOption?: string;
+  label: string;
+  maxWidth?: string;
+  name: string;
+  options: string[];
+  onChange: (value: string) => void;
+}
+
+const Select: React.FC<SelectProps> = ({
+  defaultOption,
+  label,
+  maxWidth,
+  name,
+  options,
+  onChange,
+}) => {
+  if (options.length === 0) {
+    return null;
+  }
+
+  const defaultIdx = (options || []).indexOf(defaultOption);
+  const [selectedValue, setSelectedValue] = React.useState(options[defaultIdx] || options[0]);
+
+  const updateSelectedOption = (event: React.ChangeEvent<{ name?: string; value: string }>) => {
+    setSelectedValue(event.target.value);
+    onChange(event.target.value);
+  };
+
+  return (
+    <FormControl key={name} data-max-width={maxWidth}>
+      <InputLabel color="secondary">{label}</InputLabel>
+      <StyledSelect value={selectedValue} onChange={updateSelectedOption}>
+        {options.map(option => (
+          <MenuItem key={option} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </StyledSelect>
+    </FormControl>
+  );
+};
+
+export default Select;

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -1,6 +1,7 @@
 // @ts-ignore
 import { BaseWorkflowProps, WorkflowConfiguration } from "./AppProvider/workflow";
 import CheckboxPanel from "./Input/checkbox";
+import Select from "./Input/select";
 import TextField from "./Input/text-field";
 import ClutchApp from "./AppProvider";
 import { AdvanceButton, Button, ButtonGroup, ButtonProps, DestructiveButton } from "./button";
@@ -47,6 +48,7 @@ export {
   NotePanel,
   Resolver,
   Row,
+  Select,
   Status,
   StatusRow,
   Table,


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Add a select component to @clutch/core.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2020-09-10 at 5 01 31 PM](https://user-images.githubusercontent.com/1004789/92827966-5a56e480-f387-11ea-9f33-061276dfb617.png)

![Screen Shot 2020-09-10 at 5 01 27 PM](https://user-images.githubusercontent.com/1004789/92827978-5d51d500-f387-11ea-8643-a43148e5ae54.png)

This is just a first pass at adding a basic select. In follow up PRs we can add validation and error messaging.
