### PR TITLE
ci: add ignored dependencies to renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,5 +30,11 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "yarnrc": ""
+  "yarnrc": "",
+  "ignoreDeps": [
+    "@date-io/core",
+    "babel-jest",
+    "eslint",
+    "jest"
+  ]
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
Adding dependencies for renovatebot to ignore:

@date-io/core - incompatible with material-table
babel-jest - react-scripts pins this
eslint - react-scripts pins this
jest - react-scripts pins this
