### PR TITLE
frontend: add children param to NotePanel

### DIFF
--- a/frontend/packages/core/src/Feedback/note.tsx
+++ b/frontend/packages/core/src/Feedback/note.tsx
@@ -24,10 +24,10 @@ export interface NoteConfig extends NoteProps {
 
 interface NotePanelProps {
   direction?: "row" | "column";
-  notes: NoteConfig[];
+  notes?: NoteConfig[];
 }
 
-const NotePanel: React.FC<NotePanelProps> = ({ direction = "column", notes }) => {
+const NotePanel: React.FC<NotePanelProps> = ({ direction = "column", notes, children }) => {
   const isColumnLayout = direction === "column";
   const maxWidth = isColumnLayout ? "100%" : "300px";
   const noteDirection = isColumnLayout ? "row" : "column";
@@ -39,7 +39,7 @@ const NotePanel: React.FC<NotePanelProps> = ({ direction = "column", notes }) =>
       alignContent="space-between"
       wrap="nowrap"
     >
-      {notes.map((note: NoteConfig) => (
+      {notes?.map((note: NoteConfig) => (
         <Note
           key={note.text}
           severity={note.severity}
@@ -49,6 +49,7 @@ const NotePanel: React.FC<NotePanelProps> = ({ direction = "column", notes }) =>
           {note.text}
         </Note>
       ))}
+      {children}
     </Grid>
   );
 };


### PR DESCRIPTION
### Description
This change adds a `children` parameter to the `NotePanel` frontend component.

This makes it possible to create a note panel that contains complex notes.

### Testing Performed
Manual testing using a private workflow.