### PR TITLE
housekeeping: fix dependencies in various packages

### DIFF
--- a/frontend/api/package.json
+++ b/frontend/api/package.json
@@ -8,5 +8,8 @@
   "types": "src/index.d.ts",
   "scripts": {
     "publishBeta": "../../tools/publish-frontend.sh api"
+  },
+  "dependencies": {
+    "protobufjs": "6.10.1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,9 +57,6 @@
       "last 1 safari version"
     ]
   },
-  "dependencies": {
-    "protobufjs": "6.10.1"
-  },
   "devDependencies": {
     "lerna": "^3.22.1",
     "license-checker": "^25.0.1",

--- a/frontend/workflows/experimentation/package.json
+++ b/frontend/workflows/experimentation/package.json
@@ -16,12 +16,14 @@
     "publishBeta": "../../../tools/publish-frontend.sh experimentation",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn test --collect-coverage",
-    "test:watch": "yarn test --watch"  },
+    "test:watch": "yarn test --watch"
+  },
   "dependencies": {
     "@clutch-sh/api": "^0.0.0-beta",
     "@clutch-sh/core": "^0.0.0-beta",
     "@clutch-sh/data-layout": "^0.0.0-beta",
     "@material-ui/core": "^4.9.1",
+    "history": "^5.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-is": "^16.8.0",

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -22,6 +22,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@clutch-sh/api": "^0.0.0-beta",
     "@clutch-sh/core": "^0.0.0-beta",
     "@clutch-sh/data-layout": "^0.0.0-beta",
     "@clutch-sh/wizard": "^0.0.0-beta",

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -18,9 +18,10 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/wizard": "^0.0.0-beta",
+    "@clutch-sh/api": "^0.0.0-beta",
     "@clutch-sh/core": "^0.0.0-beta",
     "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/wizard": "^0.0.0-beta",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "yup": "^0.29.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3348,9 +3348,9 @@
   integrity sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==
 
 "@types/node@^13.7.0":
-  version "13.13.15"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.15.tgz#fe1cc3aa465a3ea6858b793fd380b66c39919766"
-  integrity sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==
+  version "13.13.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.20.tgz#8196a4db574220fc50e2e54f250ad51179bd0a03"
+  integrity sha512-1kx55tU3AvGX2Cjk2W4GMBxbgIz892V+X10S2gUreIAq8qCWgaQH+tZBOWc0bi2BKFhQt+CX0BTx28V9QPNa+A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
A few packages were missing dependencies:
- Moved protobufjs dependency from the root of the project to the API package
- Added history (needed as a peer dep to react-router-dom) to the experimentation package
- Added missing @clutch-sh/api package to k8s and server experimentation packages
