### PR TITLE
migrate: export Run method

### DIFF
--- a/backend/cmd/migrate/migrate.go
+++ b/backend/cmd/migrate/migrate.go
@@ -45,7 +45,7 @@ func (m *migrateLogger) Verbose() bool {
 	return true
 }
 
-func main() {
+func Run() {
 	// Read flags and config.
 	f := &MigrateFlags{}
 	f.Link()
@@ -131,4 +131,8 @@ func main() {
 	if err != nil {
 		logger.Fatal("failed running migrations", zap.Error(err))
 	}
+}
+
+func main() {
+	Run()
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Export a run method so we can import everything in a custom gateway to avoid unknown Any types.