### PR TITLE
experimentation: set scheduled_end_time of created experiments

### DIFF
--- a/backend/service/chaos/experimentation/experimentstore/experiment_store.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_store.go
@@ -85,7 +85,7 @@ func (fs *experimentStore) CreateExperiment(ctx context.Context, config *any.Any
 	// Step 2) start a new experiment with the config
 	runSql := `
 			INSERT INTO experiment_run (
-                id, 
+            id,
 		        experiment_config_id,
 						execution_time,
 						scheduled_end_time,

--- a/backend/service/chaos/experimentation/experimentstore/experiment_store.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_store.go
@@ -90,7 +90,7 @@ func (fs *experimentStore) CreateExperiment(ctx context.Context, config *any.Any
 				execution_time,
 				scheduled_end_time,
 				creation_time)
-            VALUES ($1, $2, tstzrange($3, $4, '[]'), $4, NOW())`
+			VALUES ($1, $2, tstzrange($3, $4, '[]'), $4, NOW())`
 
 	runId := id.NewID()
 	_, err = fs.db.ExecContext(ctx, runSql, runId, configID, startTime, endTime)

--- a/backend/service/chaos/experimentation/experimentstore/experiment_store.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_store.go
@@ -87,9 +87,10 @@ func (fs *experimentStore) CreateExperiment(ctx context.Context, config *any.Any
 			INSERT INTO experiment_run (
                 id, 
 		        experiment_config_id,
-		        execution_time,
+						execution_time,
+						scheduled_end_time,
 		        creation_time)
-            VALUES ($1, $2, tstzrange($3, $4, '[]'), NOW())`
+            VALUES ($1, $2, tstzrange($3, $4, '[]'), $4, NOW())`
 
 	runId := id.NewID()
 	_, err = fs.db.ExecContext(ctx, runSql, runId, configID, startTime, endTime)

--- a/backend/service/chaos/experimentation/experimentstore/experiment_store.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_store.go
@@ -85,11 +85,11 @@ func (fs *experimentStore) CreateExperiment(ctx context.Context, config *any.Any
 	// Step 2) start a new experiment with the config
 	runSql := `
 			INSERT INTO experiment_run (
-            id,
-		        experiment_config_id,
-						execution_time,
-						scheduled_end_time,
-		        creation_time)
+				id,
+				experiment_config_id,
+				execution_time,
+				scheduled_end_time,
+				creation_time)
             VALUES ($1, $2, tstzrange($3, $4, '[]'), $4, NOW())`
 
 	runId := id.NewID()

--- a/backend/service/chaos/experimentation/experimentstore/experiment_store_test.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_store_test.go
@@ -69,7 +69,7 @@ func createExperimentsTests() ([]experimentTest, error) {
 					},
 				},
 				{
-					sql: `INSERT INTO experiment_run ( id, experiment_config_id, execution_time, creation_time) VALUES ($1, $2, tstzrange($3, $4, '[]'), NOW())`,
+					sql: `INSERT INTO experiment_run ( id, experiment_config_id, execution_time, scheduled_end_time, creation_time) VALUES ($1, $2, tstzrange($3, $4, '[]'), $4, NOW())`,
 					args: []driver.Value{
 						sqlmock.AnyArg(),
 						sqlmock.AnyArg(),


### PR DESCRIPTION
### Description
What `scheduled_end_time` is supposed to be used for if we have start_time and end_time fields?

When a new experiment is created its `end_time` and `scheduled_end_time` fields are set to exactly the same value. If an experiment is manually stopped by a user - with the use of a stop button in the experiment details view - we stop the experiment by setting its `end_time` to the current time. For these cases, we can use scheduled_end_time field to see whether there is a difference between originally `scheduled_end_time` and the actually `end_time` to find experiments that were stopped manually.

### Testing Performed
Unit Tests