### PR TITLE
resolver: automatically trim whitespace from strings

### DIFF
--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -69,13 +69,16 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
   React.useEffect(() => loadSchemas(type, dispatch), []);
 
   const submitHandler = () => {
+    // Move to loading state.
     dispatch({ type: ResolverAction.RESOLVING });
 
-    const trimmedData = _.mapValues(state.queryData, v => (_.isString(v) && _.trim(v)) || v);
-    const data = {
-      ...trimmedData,
-      "@type": state.allSchemas[state.selectedSchema]?.typeUrl,
-    };
+    // Copy incoming data, trimming whitespace from any string values (usually artifact of cut and paste into tool).
+    const data = _.mapValues(state.queryData, v => (_.isString(v) && _.trim(v)) || v);
+
+    // Set desired type.
+    data["@type"] = state.allSchemas[state.selectedSchema]?.typeUrl;
+
+    // Resolve!
     resolveResource(
       type,
       searchLimit,

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -70,8 +70,10 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
 
   const submitHandler = () => {
     dispatch({ type: ResolverAction.RESOLVING });
+
+    const trimmedData = _.mapValues(state.queryData, v => (_.isString(v) && _.trim(v)) || v);
     const data = {
-      ...state.queryData,
+      ...trimmedData,
       "@type": state.allSchemas[state.selectedSchema]?.typeUrl,
     };
     resolveResource(


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Automatically trim whitespace from any string values for resolver input.

From internal chat:

>UX suggestion - at least for the resize ASG workflow, any leading/trailing whitespace in the “search by name” form input leads to a “not found” error, which is something one can run into when copy/pasting ASG names around and fat-fingering selection. What about sanitizing the input somehow by trimming leading/trailing whitespace?

### Testing Performed
Manual
