### PR TITLE
experimentation: rename ExperimentStore to Storer

### DIFF
--- a/backend/module/chaos/serverexperimentation/rtds/rtds.go
+++ b/backend/module/chaos/serverexperimentation/rtds/rtds.go
@@ -38,7 +38,7 @@ type Server struct {
 	ctx context.Context
 
 	// Experiment store
-	experimentStore experimentstore.ExperimentStore
+	storer experimentstore.Storer
 
 	// RTDS built-in cache for V2 xDS
 	snapshotCacheV2 gcpCacheV2.SnapshotCache
@@ -100,7 +100,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (module.Module, er
 		return nil, errors.New("could not find experiment store service")
 	}
 
-	experimentStore, ok := store.(experimentstore.ExperimentStore)
+	storer, ok := store.(experimentstore.Storer)
 	if !ok {
 		return nil, errors.New("service was not the correct type")
 	}
@@ -110,7 +110,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (module.Module, er
 
 	return &Server{
 		ctx:                  context.Background(),
-		experimentStore:      experimentStore,
+		storer:               storer,
 		snapshotCacheV2:      gcpCacheV2,
 		snapshotCacheV3:      gcpCacheV3,
 		cacheRefreshInterval: cacheRefreshInterval,

--- a/backend/module/chaos/serverexperimentation/rtds/rtds_cache.go
+++ b/backend/module/chaos/serverexperimentation/rtds/rtds_cache.go
@@ -104,15 +104,15 @@ func PeriodicallyRefreshCache(s *Server) {
 	go func() {
 		for range ticker.C {
 			s.logger.Info("Refreshing RTDS cache")
-			refreshCache(s.ctx, s.experimentStore, &cacheWrapperV2{s.snapshotCacheV2}, s.rtdsLayerName, s.logger)
-			refreshCache(s.ctx, s.experimentStore, &cacheWrapperV3{s.snapshotCacheV3}, s.rtdsLayerName, s.logger)
+			refreshCache(s.ctx, s.storer, &cacheWrapperV2{s.snapshotCacheV2}, s.rtdsLayerName, s.logger)
+			refreshCache(s.ctx, s.storer, &cacheWrapperV3{s.snapshotCacheV3}, s.rtdsLayerName, s.logger)
 		}
 	}()
 }
 
-func refreshCache(ctx context.Context, store experimentstore.ExperimentStore, snapshotCache cacheWrapper, rtdsLayerName string,
+func refreshCache(ctx context.Context, storer experimentstore.Storer, snapshotCache cacheWrapper, rtdsLayerName string,
 	logger *zap.SugaredLogger) {
-	allExperiments, err := store.GetExperiments(ctx, "type.googleapis.com/clutch.chaos.serverexperimentation.v1.TestConfig", experimentation.GetExperimentsRequest_RUNNING)
+	allExperiments, err := storer.GetExperiments(ctx, "type.googleapis.com/clutch.chaos.serverexperimentation.v1.TestConfig", experimentation.GetExperimentsRequest_RUNNING)
 	if err != nil {
 		logger.Errorw("Failed to get data from experiments store", "error", err)
 		return

--- a/backend/service/chaos/experimentation/experimentstore/storer.go
+++ b/backend/service/chaos/experimentation/experimentstore/storer.go
@@ -23,8 +23,8 @@ import (
 
 const Name = "clutch.service.chaos.experimentation.store"
 
-// ExperimentStore stores experiment data
-type ExperimentStore interface {
+// Storer stores experiment data
+type Storer interface {
 	CreateExperiment(context.Context, *any.Any, *time.Time, *time.Time) (*experimentation.Experiment, error)
 	CancelExperimentRun(context.Context, uint64) error
 	GetExperiments(ctx context.Context, configType string, status experimentation.GetExperimentsRequest_Status) ([]*experimentation.Experiment, error)
@@ -33,7 +33,7 @@ type ExperimentStore interface {
 	Close()
 }
 
-type experimentStore struct {
+type storer struct {
 	db *sql.DB
 }
 
@@ -49,18 +49,18 @@ func New(_ *any.Any, _ *zap.Logger, _ tally.Scope) (service.Service, error) {
 		return nil, errors.New("experiment store wrong type")
 	}
 
-	return &experimentStore{
+	return &storer{
 		client.DB(),
 	}, nil
 }
 
-func (fs *experimentStore) CreateExperiment(ctx context.Context, config *any.Any, startTime *time.Time, endTime *time.Time) (*experimentation.Experiment, error) {
+func (s *storer) CreateExperiment(ctx context.Context, config *any.Any, startTime *time.Time, endTime *time.Time) (*experimentation.Experiment, error) {
 	// This API call will eventually be broken into 2 separate calls:
 	// 1) creating the config
 	// 2) starting a new experiment with the config
 
 	// All experiments are created in a single transaction
-	tx, err := fs.db.Begin()
+	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (fs *experimentStore) CreateExperiment(ctx context.Context, config *any.Any
 	}
 
 	configSql := `INSERT INTO experiment_config (id, details) VALUES ($1, $2)`
-	_, err = fs.db.ExecContext(ctx, configSql, configID, configJson)
+	_, err = s.db.ExecContext(ctx, configSql, configID, configJson)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (fs *experimentStore) CreateExperiment(ctx context.Context, config *any.Any
 			VALUES ($1, $2, tstzrange($3, $4, '[]'), NOW())`
 
 	runId := id.NewID()
-	_, err = fs.db.ExecContext(ctx, runSql, runId, configID, startTime, endTime)
+	_, err = s.db.ExecContext(ctx, runSql, runId, configID, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}
@@ -137,19 +137,19 @@ func toProto(t *time.Time) (*timestamp.Timestamp, error) {
 	return timestampProto, nil
 }
 
-func (fs *experimentStore) CancelExperimentRun(ctx context.Context, id uint64) error {
+func (s *storer) CancelExperimentRun(ctx context.Context, id uint64) error {
 	sql :=
 		`UPDATE experiment_run 
          SET cancellation_time = NOW()
          WHERE id = $1 AND cancellation_time IS NULL AND (upper(execution_time) IS NULL OR NOW() < upper(execution_time))`
 
-	_, err := fs.db.ExecContext(ctx, sql, id)
+	_, err := s.db.ExecContext(ctx, sql, id)
 	return err
 }
 
 // GetExperiments experiments with a given type of the configuration. Returns all experiments if provided configuration type
 // parameter is an emtpy string.
-func (fs *experimentStore) GetExperiments(ctx context.Context, configType string, status experimentation.GetExperimentsRequest_Status) ([]*experimentation.Experiment, error) {
+func (s *storer) GetExperiments(ctx context.Context, configType string, status experimentation.GetExperimentsRequest_Status) ([]*experimentation.Experiment, error) {
 	query := `
 		SELECT 
 			experiment_run.id, 
@@ -162,7 +162,7 @@ func (fs *experimentStore) GetExperiments(ctx context.Context, configType string
 		// Return only running experiments if `status` is equal to `Running`, return all experiments otherwise.
 		` AND ($2 = 'UNSPECIFIED' OR (experiment_run.cancellation_time is NULL AND NOW() > lower(experiment_run.execution_time) AND (upper(experiment_run.execution_time) IS NULL OR NOW() < upper(experiment_run.execution_time))))`
 
-	rows, err := fs.db.QueryContext(ctx, query, configType, status.String())
+	rows, err := s.db.QueryContext(ctx, query, configType, status.String())
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (fs *experimentStore) GetExperiments(ctx context.Context, configType string
 	return experiments, nil
 }
 
-func (fs *experimentStore) GetListView(ctx context.Context) ([]*experimentation.ListViewItem, error) {
+func (s *storer) GetListView(ctx context.Context) ([]*experimentation.ListViewItem, error) {
 	query := `
 		SELECT 
 			experiment_run.id,
@@ -210,7 +210,7 @@ func (fs *experimentStore) GetListView(ctx context.Context) ([]*experimentation.
 		WHERE
 			experiment_config.id = experiment_run.experiment_config_id`
 
-	rows, err := fs.db.QueryContext(ctx, query)
+	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -258,12 +258,12 @@ func (fs *experimentStore) GetListView(ctx context.Context) ([]*experimentation.
 	return listViewItems, nil
 }
 
-func (fs *experimentStore) GetExperimentRunDetails(ctx context.Context, id uint64) (*experimentation.ExperimentRunDetails, error) {
+func (s *storer) GetExperimentRunDetails(ctx context.Context, id uint64) (*experimentation.ExperimentRunDetails, error) {
 	sqlQuery := `
         SELECT experiment_run.id, lower(execution_time), upper(execution_time), cancellation_time, creation_time, details FROM experiment_config, experiment_run
         WHERE experiment_run.id = $1 AND experiment_run.experiment_config_id = experiment_config.id`
 
-	row := fs.db.QueryRowContext(ctx, sqlQuery, id)
+	row := s.db.QueryRowContext(ctx, sqlQuery, id)
 
 	var fetchedID uint64
 	var startTime, endTime, cancellationTime sql.NullTime
@@ -279,8 +279,8 @@ func (fs *experimentStore) GetExperimentRunDetails(ctx context.Context, id uint6
 }
 
 // Close closes all resources held.
-func (fs *experimentStore) Close() {
-	fs.db.Close()
+func (s *storer) Close() {
+	s.db.Close()
 }
 
 func marshalConfig(config *any.Any) (string, error) {

--- a/backend/service/chaos/experimentation/experimentstore/storer_test.go
+++ b/backend/service/chaos/experimentation/experimentstore/storer_test.go
@@ -107,7 +107,7 @@ func TestCreateExperiments(t *testing.T) {
 			db, mock, err := sqlmock.New()
 			a.NoError(err)
 
-			es := &experimentStore{db: db}
+			es := &storer{db: db}
 			defer es.Close()
 			mock.ExpectBegin()
 			for _, query := range test.queries {
@@ -128,7 +128,7 @@ func TestCancelExperimentRun(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(err)
 
-	es := &experimentStore{db: db}
+	es := &storer{db: db}
 	defer es.Close()
 
 	expected := mock.ExpectExec(regexp.QuoteMeta(`UPDATE experiment_run SET cancellation_time = NOW() WHERE id = $1 AND cancellation_time IS NULL`))
@@ -146,7 +146,7 @@ func TestGetExperimentsUnmarshalsExperimentConfiguration(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(err)
 
-	es := &experimentStore{db: db}
+	es := &storer{db: db}
 	defer es.Close()
 
 	expected := mock.ExpectQuery(regexp.QuoteMeta(getExperimentsSQLQuery)).WithArgs("foo", "UNSPECIFIED")
@@ -180,7 +180,7 @@ func TestGetExperimentsFailsIfItReadsExperimentWithMalformedConfiguration(t *tes
 	db, mock, err := sqlmock.New()
 	assert.NoError(err)
 
-	es := &experimentStore{db: db}
+	es := &storer{db: db}
 	defer es.Close()
 
 	expected := mock.ExpectQuery(regexp.QuoteMeta(getExperimentsSQLQuery)).WithArgs("foo", "UNSPECIFIED")


### PR DESCRIPTION
I read a little bit about Go and apparently `-er` is the default choice when it comes to the names of interfaces in Go.

* https://stackoverflow.com/questions/38842457/interface-naming-convention-golang
* https://golang.org/doc/effective_go.html#interface-names