### PR TITLE
Stack Trace Viewer: set font color to text primary

### DIFF
--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -138,7 +138,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
               </RightAlignedButton>
             </DialogTitle>
             <DialogContent dividers>
-              <DialogContentText tabIndex={-1} component="div">
+              <DialogContentText color="textPrimary" tabIndex={-1} component="div">
                 {errorInfo.componentStack.split("\n").map((i, key) => {
                   /* eslint-disable-next-line react/no-array-index-key */
                   return <div key={key}>{i}</div>;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->
Make the Stack Trace modal text easier to read.

<img width="639" alt="Screen Shot 2020-09-18 at 10 49 40 AM" src="https://user-images.githubusercontent.com/1004789/93631882-360b9100-f9a1-11ea-9493-bac14696bb8e.png">

