### PR TITLE
MetadataTable: stringify objects for TableCell data

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -52,6 +52,9 @@ const ViewOnlyRow: React.FC<ViewOnlyRowProps> = ({ data, size }) => {
   if (data.value instanceof Array && data.value.length > 1) {
     value = data.value.join(", ");
   }
+  if (data.value instanceof Object) {
+    value = JSON.stringify(data.value);
+  }
   return (
     <TableRow key={data.id}>
       <KeyCell data={data} size={size} />


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

material-table cannot render an object as a cell child. This should prevent users from accidentally passing in an object and having an error thrown.

https://github.com/mbrn/material-table/issues/1074
