### PR TITLE
tools: link types for gateways

### DIFF
--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -2,7 +2,24 @@
 set -euo pipefail
 
 REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
-LINKED_PACKAGES=("react" "react-dom" "react-router" "react-router-dom" "styled-components" "@material-ui/styles" "@material-ui/core")
+LINKED_PACKAGES=(
+  "react"
+  "react-dom"
+  "react-router"
+  "react-router-dom"
+  "styled-components"
+  "@material-ui/styles"
+  "@material-ui/core"
+  "@types/enzyme"
+  "@types/jest"
+  "@types/mocha"
+  "@types/node"
+  "@types/react"
+  "@types/react-dom"
+  "@types/styled-components"
+  "@types/yup"
+  "typescript"
+)
 
 EXTERNAL_ROOT="${1}"
 YARN="${EXTERNAL_ROOT}/build/bin/yarn.sh"

--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
+# Packages should be added to this list if there can only be one of them present when using Clutch as a submodule.
 LINKED_PACKAGES=(
   "react"
   "react-dom"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
This will allow us to use a unified type system when consuming Clutch as a submodule.

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual
