### PR TITLE
Workflow Config: allow any route component type

### DIFF
--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -41,7 +41,7 @@ export interface WorkflowConfiguration extends BaseWorkflowConfiguration {
 }
 
 interface Route {
-  component: React.FC;
+  component: React.FC<any>;
   description: string;
   displayName?: string;
   path: string;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
Allow a functional component with any props to be passed as a routes component. This is necessary for strict type checking.

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
