### PR TITLE
frontend: apply global Typography and Link styles

### DIFF
--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -59,18 +59,18 @@ const getTheme = () => {
     overrides: {
       MuiTypography: {
         colorPrimary: {
-          color: NAVY
+          color: NAVY,
         },
         colorSecondary: {
-          color: GRAY
-        }
+          color: GRAY,
+        },
       },
       MuiLink: {
         root: {
-          color: TEAL
-        }
-      }
-    }
+          color: TEAL,
+        },
+      },
+    },
   });
 };
 

--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -56,6 +56,21 @@ const lightPalette = (): ClutchPalette => {
 const getTheme = () => {
   return createMuiTheme({
     palette: lightPalette(),
+    overrides: {
+      MuiTypography: {
+        colorPrimary: {
+          color: NAVY
+        },
+        colorSecondary: {
+          color: GRAY
+        }
+      },
+      MuiLink: {
+        root: {
+          color: TEAL
+        }
+      }
+    }
   });
 };
 

--- a/frontend/packages/core/src/landing.tsx
+++ b/frontend/packages/core/src/landing.tsx
@@ -21,6 +21,10 @@ const SizedCard = styled(CardContent)`
   `};
 `;
 
+const CardTitle = styled(Typography)`
+  color: #ffffff;
+`;
+
 interface MediaCardProps {
   title: string;
   description: string;
@@ -38,9 +42,9 @@ const MediaCard: React.FC<MediaCardProps> = ({ title, description, path }) => {
       <Card raised>
         <CardActionArea onClick={navigateTo}>
           <SizedCard>
-            <Typography gutterBottom variant="h6" color="primary">
+            <CardTitle gutterBottom variant="h6">
               {title}
-            </Typography>
+            </CardTitle>
             <Typography variant="body2" color="textSecondary">
               {description}
             </Typography>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Apply global styling to Typography and Links. The Typography font colors will now match the default text colors provided in the palette. This required a change to the landing cards as they relied on the Typography default primary color of white.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2020-09-22 at 1 58 13 PM](https://user-images.githubusercontent.com/1004789/93938451-1b595500-fcde-11ea-9db3-b22441853cf6.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual
