### PR TITLE
wizard: cleanup global warnings on exit

### DIFF
--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -90,17 +90,30 @@ const CompressedError = ({ title, message }) => {
   );
 };
 
-const Warning = ({ message }) => {
+interface WarningProps {
+  message: any;
+  onClose?: () => void;
+}
+
+const Warning: React.FC<WarningProps> = ({ message, onClose }) => {
   const [open, setOpen] = React.useState(true);
+
+  const onDismiss = () => {
+    if (onClose !== undefined) {
+      onClose();
+    }
+    setOpen(false);
+  }
 
   return (
     <Snackbar
       open={open}
       autoHideDuration={6000}
+      onExit={onDismiss}
       onClose={() => setOpen(false)}
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
     >
-      <Alert elevation={6} variant="filled" onClose={() => setOpen(false)} severity="warning">
+      <Alert elevation={6} variant="filled" onClose={onDismiss} severity="warning">
         {message}
       </Alert>
     </Snackbar>

--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -103,7 +103,7 @@ const Warning: React.FC<WarningProps> = ({ message, onClose }) => {
       onClose();
     }
     setOpen(false);
-  }
+  };
 
   return (
     <Snackbar

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -215,7 +215,7 @@ const Wizard: React.FC<WizardProps> = ({ heading, dataLayout, children, maxWidth
 
   const removeWarning = (warning: string) => {
     setGlobalWarnings(globalWarnings.filter(w => w !== warning));
-  }
+  };
 
   return (
     <Spacer margin="3">

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -213,6 +213,10 @@ const Wizard: React.FC<WizardProps> = ({ heading, dataLayout, children, maxWidth
     );
   });
 
+  const removeWarning = (warning: string) => {
+    setGlobalWarnings(globalWarnings.filter(w => w !== warning));
+  }
+
   return (
     <Spacer margin="3">
       <Container maxWidth={maxWidth}>
@@ -239,7 +243,7 @@ const Wizard: React.FC<WizardProps> = ({ heading, dataLayout, children, maxWidth
           </Grid>
         </SizedContainer>
         {globalWarnings.map(error => (
-          <Warning key={error} message={error} />
+          <Warning key={error} message={error} onClose={() => removeWarning(error)} />
         ))}
       </Container>
     </Spacer>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Cleanup global warnings when they are unmounted. This allows the warning to render multiple times from the same page. Prior behavior would only display the warning once until the wizard step was unmounted.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![warnings](https://user-images.githubusercontent.com/1004789/93944834-945ea980-fcea-11ea-825b-a140fdf3231d.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
