### PR TITLE
tools/scaffolding: Add Dockerfile Template for Custom Gateway

### DIFF
--- a/tools/scaffolding/templates/gateway/Dockerfile
+++ b/tools/scaffolding/templates/gateway/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:14-buster as nodebuild
+COPY ./frontend ./frontend
+COPY ./tools/install-yarn.sh ./tools/install-yarn.sh
+COPY Makefile .
+RUN tools/install-yarn.sh && yarn --cwd frontend install
+
+FROM golang:1.15-buster as gobuild
+WORKDIR /go/src/{{ .RepoProvider}}/{{ .RepoOwner }}/{{ .RepoName }}
+COPY ./backend ./backend
+COPY Makefile .
+COPY --from=nodebuild ./frontend/build ./frontend/build/
+RUN cd backend \
+    && go mod download \
+    && go run $(go list -f "{{ .Dir }}" -m "github.com/lyft/clutch/backend")/cmd/assets/generate.go ../frontend/build \
+    && go build -tags withAssets -o ../build/clutch -ldflags="-X main.version=${VERSION}"
+
+FROM gcr.io/distroless/base-debian10
+COPY --from=gobuild /go/src/{{ .RepoProvider}}/{{ .RepoOwner }}/{{ .RepoName }}/build/clutch /
+COPY backend/clutch-config.yaml /
+CMD ["/clutch"]

--- a/tools/scaffolding/templates/gateway/Dockerfile
+++ b/tools/scaffolding/templates/gateway/Dockerfile
@@ -11,7 +11,7 @@ COPY Makefile .
 COPY --from=nodebuild ./frontend/build ./frontend/build/
 RUN cd backend \
     && go mod download \
-    && go run $(go list -f "{{ .Dir }}" -m "github.com/lyft/clutch/backend")/cmd/assets/generate.go ../frontend/build \
+    && go run $(go list -f "{{ "{{" }} .Dir {{ "}}" }}" -m "github.com/lyft/clutch/backend")/cmd/assets/generate.go ../frontend/build \
     && go build -tags withAssets -o ../build/clutch -ldflags="-X main.version=${VERSION}"
 
 FROM gcr.io/distroless/base-debian10

--- a/tools/scaffolding/templates/gateway/Dockerfile
+++ b/tools/scaffolding/templates/gateway/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:14-buster as nodebuild
 COPY ./frontend ./frontend
-COPY ./tools/install-yarn.sh ./tools/install-yarn.sh
 COPY Makefile .
-RUN tools/install-yarn.sh && yarn --cwd frontend install
+RUN yarn --cwd frontend install
 
 FROM golang:1.15-buster as gobuild
 WORKDIR /go/src/{{ .RepoProvider}}/{{ .RepoOwner }}/{{ .RepoName }}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
This adds a `Dockerfile` to the templates used for `make scaffold-gateway` so that users can have a reference `Dockerfile` ready to go after scaffolding a custom gateway

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Local testing with:
* `make scaffold-gateway` 
* `docker build -t clutch-custom-gateway:latest .`

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->
N/A

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
N/A

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
