### PR TITLE
ci: Add lyft/resilience to owners  of migrations directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-*                                                          @lyft/clutch-admin
-/api/chaos/                                                @lyft/resilience
-/backend/**/chaos/                                         @lyft/resilience
+*                                                    @lyft/clutch-admin
+/api/chaos/                                          @lyft/resilience
+/backend/**/chaos/                                   @lyft/resilience
 /backend/cmd/migrate/migrations/*_experimentation_*  @lyft/resilience
-/frontend/api/src/                                         @lyft/resilience
-/frontend/workflows/experimentation/                       @lyft/resilience
-/frontend/workflows/serverexperimentation/                 @lyft/resilience
+/frontend/api/src/                                   @lyft/resilience
+/frontend/workflows/experimentation/                 @lyft/resilience
+/frontend/workflows/serverexperimentation/           @lyft/resilience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-*                                            @lyft/clutch-admin
-/api/chaos/                                  @lyft/resilience
-/backend/**/chaos/                           @lyft/resilience
-/backend/cmd/migrate/migrations/             @lyft/resilience
-/frontend/api/src/                           @lyft/resilience
-/frontend/workflows/experimentation/         @lyft/resilience
-/frontend/workflows/serverexperimentation/   @lyft/resilience
+*                                                          @lyft/clutch-admin
+/api/chaos/                                                @lyft/resilience
+/backend/**/chaos/                                         @lyft/resilience
+/backend/cmd/migrate/migrations/*_chaos_experimentation_*  @lyft/resilience
+/frontend/api/src/                                         @lyft/resilience
+/frontend/workflows/experimentation/                       @lyft/resilience
+/frontend/workflows/serverexperimentation/                 @lyft/resilience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 *                                            @lyft/clutch-admin
 /api/chaos/                                  @lyft/resilience
 /backend/**/chaos/                           @lyft/resilience
+/backend/cmd/migrate/migrations/             @lyft/resilience
 /frontend/api/src/                           @lyft/resilience
 /frontend/workflows/experimentation/         @lyft/resilience
 /frontend/workflows/serverexperimentation/   @lyft/resilience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 *                                                          @lyft/clutch-admin
 /api/chaos/                                                @lyft/resilience
 /backend/**/chaos/                                         @lyft/resilience
-/backend/cmd/migrate/migrations/*_chaos_experimentation_*  @lyft/resilience
+/backend/cmd/migrate/migrations/*_experimentation_*  @lyft/resilience
 /frontend/api/src/                                         @lyft/resilience
 /frontend/workflows/experimentation/                       @lyft/resilience
 /frontend/workflows/serverexperimentation/                 @lyft/resilience


### PR DESCRIPTION
### Description
Add `lyft/resilience` to owners  of subset of files from migrations directory to make it possible for resilience team to develop `experimentation` package without approvals from core Clutch maintainers.

### Testing Performed
N/A