### PR TITLE
checkbox panel: align options side by side

### DIFF
--- a/frontend/packages/core/src/Input/checkbox.tsx
+++ b/frontend/packages/core/src/Input/checkbox.tsx
@@ -52,14 +52,31 @@ const CheckboxPanel: React.FC<CheckboxPanelProps> = ({ header, options, onChange
     onChange(callbackOptions);
   };
 
+  const optionKeys = Object.keys(allOptions);
+  const column1Keys = optionKeys.splice(0, optionKeys.length/2);
+  const column2Keys = optionKeys.splice(column1Keys.length+1, optionKeys.length);
+
   return (
     <FormControl>
-      <Grid container direction="column">
+      <Grid container direction="row" justify="center" alignItems="stretch">
         <FormLabel color="secondary" component="legend">
           {header}
         </FormLabel>
-        <FormGroup row>
-          {Object.keys(allOptions).map(option => (
+        <FormGroup>
+          {column1Keys.map(option => (
+            <FormGroup row key={option}>
+              <FormControlLabel
+                key={option}
+                control={
+                  <Checkbox checked={selected[option].checked} onChange={onToggle} name={option} />
+                }
+                label={option}
+              />
+            </FormGroup>
+          ))}
+        </FormGroup>
+        <FormGroup>
+        {column2Keys.map(option => (
             <FormGroup row key={option}>
               <FormControlLabel
                 key={option}

--- a/frontend/packages/core/src/Input/checkbox.tsx
+++ b/frontend/packages/core/src/Input/checkbox.tsx
@@ -53,8 +53,8 @@ const CheckboxPanel: React.FC<CheckboxPanelProps> = ({ header, options, onChange
   };
 
   const optionKeys = Object.keys(allOptions);
-  const column1Keys = [...optionKeys].splice(0, optionKeys.length/2);
-  const column2Keys = [...optionKeys].splice(column1Keys.length+1, optionKeys.length);
+  const column1Keys = [...optionKeys].splice(0, optionKeys.length / 2);
+  const column2Keys = [...optionKeys].splice(column1Keys.length + 1, optionKeys.length);
 
   return (
     <FormControl>
@@ -76,7 +76,7 @@ const CheckboxPanel: React.FC<CheckboxPanelProps> = ({ header, options, onChange
           ))}
         </FormGroup>
         <FormGroup>
-        {column2Keys.map(option => (
+          {column2Keys.map(option => (
             <FormGroup row key={option}>
               <FormControlLabel
                 key={option}

--- a/frontend/packages/core/src/Input/checkbox.tsx
+++ b/frontend/packages/core/src/Input/checkbox.tsx
@@ -53,8 +53,8 @@ const CheckboxPanel: React.FC<CheckboxPanelProps> = ({ header, options, onChange
   };
 
   const optionKeys = Object.keys(allOptions);
-  const column1Keys = optionKeys.splice(0, optionKeys.length/2);
-  const column2Keys = optionKeys.splice(column1Keys.length+1, optionKeys.length);
+  const column1Keys = [...optionKeys].splice(0, optionKeys.length/2);
+  const column2Keys = [...optionKeys].splice(column1Keys.length+1, optionKeys.length);
 
   return (
     <FormControl>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Properly align checkbox panel children side by side.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2020-09-24 at 12 03 38 PM](https://user-images.githubusercontent.com/1004789/94188783-b842fc00-fe5e-11ea-9f86-917f3a02de66.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
