### PR TITLE
experimentation: refresh view when experiment is stopped

### DIFF
--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -52,7 +52,7 @@ const ViewExperimentRun: React.FC = () => {
         client
           .post("/v1/chaos/experimentation/cancelExperimentRun", { id: runID })
           .then(() => {
-            goBack();
+            setExperiment(undefined);
           })
           .catch(err => {
             setError(err.response.statusText);


### PR DESCRIPTION
### Description
Do not go back to experiments list view after a user stops/cancels an experiment

| Before | After |
| ----- | ------ |
|![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/4410346/94325909-b019b800-ff55-11ea-996f-629ff107aa29.gif)|![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/4410346/94325912-b60f9900-ff55-11ea-83b9-60b9cd62926a.gif)|

### Testing Performed
See attached GIFs.
