### PR TITLE
experimentation: small naming tweaks in configuration file

### DIFF
--- a/frontend/workflows/experimentation/src/index.tsx
+++ b/frontend/workflows/experimentation/src/index.tsx
@@ -10,8 +10,8 @@ const register = (): WorkflowConfiguration => {
       contactUrl: "mailto:hello@clutch.sh",
     },
     path: "experimentation",
-    group: "Experimentation",
-    displayName: "Experimentation",
+    group: "Chaos Experimentation",
+    displayName: "Chaos Experimentation",
     routes: {
       listExperiments: {
         path: "list",
@@ -22,7 +22,7 @@ const register = (): WorkflowConfiguration => {
       viewExperimentRun: {
         path: "run/:runID",
         displayName: "View Experiment Run",
-        description: "View Experiment Run",
+        description: "View Experiment Run.",
         hideNav: true,
         component: ViewExperimentRun,
       },

--- a/frontend/workflows/experimentation/src/index.tsx
+++ b/frontend/workflows/experimentation/src/index.tsx
@@ -15,7 +15,7 @@ const register = (): WorkflowConfiguration => {
     routes: {
       listExperiments: {
         path: "list",
-        displayName: "Experiments",
+        displayName: "Manage experiments",
         description: "Manage experiments.",
         component: ListExperiments,
       },

--- a/frontend/workflows/experimentation/src/index.tsx
+++ b/frontend/workflows/experimentation/src/index.tsx
@@ -11,12 +11,12 @@ const register = (): WorkflowConfiguration => {
     },
     path: "experimentation",
     group: "Experimentation",
-    displayName: "Fault Injection",
+    displayName: "Experimentation",
     routes: {
       listExperiments: {
         path: "list",
         displayName: "Experiments",
-        description: "Manage fault injection experiments.",
+        description: "Manage experiments.",
         component: ListExperiments,
       },
       viewExperimentRun: {

--- a/frontend/workflows/experimentation/src/index.tsx
+++ b/frontend/workflows/experimentation/src/index.tsx
@@ -10,13 +10,13 @@ const register = (): WorkflowConfiguration => {
       contactUrl: "mailto:hello@clutch.sh",
     },
     path: "experimentation",
-    group: "Chaos Experimentation",
-    displayName: "Chaos Experimentation",
+    group: "Experimentation",
+    displayName: "Fault Injection",
     routes: {
       listExperiments: {
         path: "list",
-        displayName: "List Experiments",
-        description: "List Experiments.",
+        displayName: "Experiments",
+        description: "Manage fault injection experiments.",
         component: ListExperiments,
       },
       viewExperimentRun: {

--- a/frontend/workflows/serverexperimentation/src/index.tsx
+++ b/frontend/workflows/serverexperimentation/src/index.tsx
@@ -10,7 +10,7 @@ const register = (): WorkflowConfiguration => {
     },
     path: "server-experimentation",
     group: "Experimentation",
-    displayName: "Server Fault Injection",
+    displayName: "Server Experimentation",
     routes: {
       startAbortExperiment: {
         path: "startabort",

--- a/frontend/workflows/serverexperimentation/src/index.tsx
+++ b/frontend/workflows/serverexperimentation/src/index.tsx
@@ -9,8 +9,8 @@ const register = (): WorkflowConfiguration => {
       contactUrl: "mailto:hello@clutch.sh",
     },
     path: "server-experimentation",
-    group: "Chaos Experimentation",
-    displayName: "Server Experimentation",
+    group: "Experimentation",
+    displayName: "Server Fault Injection",
     routes: {
       startAbortExperiment: {
         path: "startabort",

--- a/frontend/workflows/serverexperimentation/src/index.tsx
+++ b/frontend/workflows/serverexperimentation/src/index.tsx
@@ -9,7 +9,7 @@ const register = (): WorkflowConfiguration => {
       contactUrl: "mailto:hello@clutch.sh",
     },
     path: "server-experimentation",
-    group: "Experimentation",
+    group: "Chaos Experimentation",
     displayName: "Server Experimentation",
     routes: {
       startAbortExperiment: {

--- a/frontend/workflows/serverexperimentation/src/index.tsx
+++ b/frontend/workflows/serverexperimentation/src/index.tsx
@@ -10,7 +10,7 @@ const register = (): WorkflowConfiguration => {
     },
     path: "server-experimentation",
     group: "Experimentation",
-    displayName: "Server Experimentation",
+    displayName: "Server Fault Injection",
     routes: {
       startAbortExperiment: {
         path: "startabort",


### PR DESCRIPTION
### Description
Use `chaos experimentation` name when displaying routes in the UI.

### Testing Performed
N/A
