### PR TITLE
core: nil checks for asset configuration

### DIFF
--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -70,15 +70,17 @@ func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Serve!
 	if f, err := a.fileSystem.Open(r.URL.Path); err != nil {
 		// If not a known static asset and an asset provider is configured, try streaming from the configured provider.
-		if a.assetCfg.Provider != nil && strings.HasPrefix(r.URL.Path, "/static") {
-			// We attatch this header simply for observibility purposes.
-			// Otherwise its difficult to know if the assets are being served from the configured provider.
-			w.Header().Set("x-clutch-asset-passthrough", "true")
+		if a.assetCfg != nil {
+			if a.assetCfg.Provider != nil && strings.HasPrefix(r.URL.Path, "/static") {
+				// We attatch this header simply for observibility purposes.
+				// Otherwise its difficult to know if the assets are being served from the configured provider.
+				w.Header().Set("x-clutch-asset-passthrough", "true")
 
-			// TODO: handle errors
-			asset, _ := a.assetProviderHandler(r.URL.Path)
-			_, _ = io.Copy(w, asset)
-			return
+				// TODO: handle errors
+				asset, _ := a.assetProviderHandler(r.URL.Path)
+				_, _ = io.Copy(w, asset)
+				return
+			}
 		}
 
 		// If not a known static asset serve the SPA.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Was not checking the existence of the `assetCfg` before attempting to look for a configured `Provider`

```
2020/09/28 11:37:57 http: panic serving 127.0.0.1:57789: runtime error: invalid memory address or nil pointer dereference
goroutine 13 [running]:
net/http.(*conn).serve.func1(0xc000a3de00)
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:1801 +0x147
panic(0x2f6c3c0, 0x4aeb620)
	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:975 +0x3e9
github.com/lyft/clutch/backend/gateway/mux.(*assetHandler).ServeHTTP(0xc000623e40, 0x379a3a0, 0xc000bf8460, 0xc000c6cd00)
	/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/gateway/mux/mux.go:73 +0x299
net/http.(*ServeMux).ServeHTTP(0xc000623e00, 0x379a3a0, 0xc000bf8460, 0xc000c6cd00)
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2417 +0x1ad
github.com/lyft/clutch/backend/gateway/mux.(*Mux).ServeHTTP(0xc0004f0a00, 0x379a3a0, 0xc000bf8460, 0xc000c6cd00)
	/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/gateway/mux/mux.go:214 +0x5d
golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP(0x3744640, 0xc0004f0a00, 0xc0005dd0c0, 0x379a3a0, 0xc000bf8460, 0xc000c6cd00)
	/Users/mcutalo/gocode/pkg/mod/golang.org/x/net@v0.0.0-20200927032502-5d4f70055728/http2/h2c/h2c.go:98 +0x30e
net/http.serverHandler.ServeHTTP(0xc000bf82a0, 0x379a3a0, 0xc000bf8460, 0xc000c6cd00)
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc000a3de00, 0x37a29a0, 0xc0005dd380)
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.15.2/libexec/src/net/http/server.go:2969 +0x36c
2020-09-28T11:37:58.183-0700	DEBUG	stats/debug_reporter.go:41	counter	{"name": "clutch.module.rpc_total", "value": 1, "tags": {"grpc_method":"Fetch","grpc_service":"clutch.assets.v1.AssetsAPI","grpc_status":"OK"}, "type": "counter"}
```

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
