### PR TITLE
core / frontend: passthrough host support

### DIFF
--- a/api/config/gateway/v1/gateway.proto
+++ b/api/config/gateway/v1/gateway.proto
@@ -85,6 +85,23 @@ message GatewayOptions {
   Timeouts timeouts = 5;
 
   repeated Middleware middleware = 6;
+
+  Assets assets = 7;
+}
+
+// Assets configuration provide a passthrough host for frontend static assets.
+// This is useful if you dont have the ability to enable sticky sessions or a blue/green deploy system in place.
+message Assets {
+  // To use the S3Provider you must have the AWS service configured
+  message S3Provider {
+    string region = 1;
+    string bucket = 2;
+    string key = 3;
+  }
+
+  oneof provider {
+    S3Provider s3 = 1;
+  }
 }
 
 message Logger {

--- a/api/config/gateway/v1/gateway.proto
+++ b/api/config/gateway/v1/gateway.proto
@@ -96,6 +96,7 @@ message Assets {
   message S3Provider {
     string region = 1;
     string bucket = 2;
+    // key is the path to clutchs frontend static assets in the configured bucket
     string key = 3;
   }
 

--- a/backend/api/config/gateway/v1/gateway.pb.go
+++ b/backend/api/config/gateway/v1/gateway.pb.go
@@ -86,7 +86,7 @@ func (x Logger_Level) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Logger_Level.Descriptor instead.
 func (Logger_Level) EnumDescriptor() ([]byte, []int) {
-	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{6, 0}
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{7, 0}
 }
 
 type Config struct {
@@ -447,6 +447,7 @@ type GatewayOptions struct {
 	Stats                    *Stats        `protobuf:"bytes,4,opt,name=stats,proto3" json:"stats,omitempty"`
 	Timeouts                 *Timeouts     `protobuf:"bytes,5,opt,name=timeouts,proto3" json:"timeouts,omitempty"`
 	Middleware               []*Middleware `protobuf:"bytes,6,rep,name=middleware,proto3" json:"middleware,omitempty"`
+	Assets                   *Assets       `protobuf:"bytes,7,opt,name=assets,proto3" json:"assets,omitempty"`
 }
 
 func (x *GatewayOptions) Reset() {
@@ -523,6 +524,81 @@ func (x *GatewayOptions) GetMiddleware() []*Middleware {
 	return nil
 }
 
+func (x *GatewayOptions) GetAssets() *Assets {
+	if x != nil {
+		return x.Assets
+	}
+	return nil
+}
+
+// Assets configuration provide a passthrough host for frontend static assets.
+// This is useful if you dont have the ability to enable sticky sessions or a blue/green deploy system in place.
+type Assets struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Types that are assignable to Provider:
+	//	*Assets_S3
+	Provider isAssets_Provider `protobuf_oneof:"provider"`
+}
+
+func (x *Assets) Reset() {
+	*x = Assets{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Assets) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Assets) ProtoMessage() {}
+
+func (x *Assets) ProtoReflect() protoreflect.Message {
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Assets.ProtoReflect.Descriptor instead.
+func (*Assets) Descriptor() ([]byte, []int) {
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{6}
+}
+
+func (m *Assets) GetProvider() isAssets_Provider {
+	if m != nil {
+		return m.Provider
+	}
+	return nil
+}
+
+func (x *Assets) GetS3() *Assets_S3Provider {
+	if x, ok := x.GetProvider().(*Assets_S3); ok {
+		return x.S3
+	}
+	return nil
+}
+
+type isAssets_Provider interface {
+	isAssets_Provider()
+}
+
+type Assets_S3 struct {
+	S3 *Assets_S3Provider `protobuf:"bytes,1,opt,name=s3,proto3,oneof"`
+}
+
+func (*Assets_S3) isAssets_Provider() {}
+
 type Logger struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -537,7 +613,7 @@ type Logger struct {
 func (x *Logger) Reset() {
 	*x = Logger{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[6]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -550,7 +626,7 @@ func (x *Logger) String() string {
 func (*Logger) ProtoMessage() {}
 
 func (x *Logger) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[6]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -563,7 +639,7 @@ func (x *Logger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Logger.ProtoReflect.Descriptor instead.
 func (*Logger) Descriptor() ([]byte, []int) {
-	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{6}
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Logger) GetLevel() Logger_Level {
@@ -609,7 +685,7 @@ type Middleware struct {
 func (x *Middleware) Reset() {
 	*x = Middleware{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[7]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -622,7 +698,7 @@ func (x *Middleware) String() string {
 func (*Middleware) ProtoMessage() {}
 
 func (x *Middleware) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[7]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -635,7 +711,7 @@ func (x *Middleware) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Middleware.ProtoReflect.Descriptor instead.
 func (*Middleware) Descriptor() ([]byte, []int) {
-	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{7}
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Middleware) GetName() string {
@@ -664,7 +740,7 @@ type Service struct {
 func (x *Service) Reset() {
 	*x = Service{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[8]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -677,7 +753,7 @@ func (x *Service) String() string {
 func (*Service) ProtoMessage() {}
 
 func (x *Service) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[8]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -690,7 +766,7 @@ func (x *Service) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Service.ProtoReflect.Descriptor instead.
 func (*Service) Descriptor() ([]byte, []int) {
-	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{8}
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Service) GetName() string {
@@ -719,7 +795,7 @@ type Resolver struct {
 func (x *Resolver) Reset() {
 	*x = Resolver{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[9]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -732,7 +808,7 @@ func (x *Resolver) String() string {
 func (*Resolver) ProtoMessage() {}
 
 func (x *Resolver) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[9]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -745,7 +821,7 @@ func (x *Resolver) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Resolver.ProtoReflect.Descriptor instead.
 func (*Resolver) Descriptor() ([]byte, []int) {
-	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{9}
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Resolver) GetName() string {
@@ -774,7 +850,7 @@ type Module struct {
 func (x *Module) Reset() {
 	*x = Module{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[10]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -787,7 +863,7 @@ func (x *Module) String() string {
 func (*Module) ProtoMessage() {}
 
 func (x *Module) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[10]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -800,7 +876,7 @@ func (x *Module) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Module.ProtoReflect.Descriptor instead.
 func (*Module) Descriptor() ([]byte, []int) {
-	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{10}
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Module) GetName() string {
@@ -826,7 +902,7 @@ type Stats_LogReporter struct {
 func (x *Stats_LogReporter) Reset() {
 	*x = Stats_LogReporter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[11]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -839,7 +915,7 @@ func (x *Stats_LogReporter) String() string {
 func (*Stats_LogReporter) ProtoMessage() {}
 
 func (x *Stats_LogReporter) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[11]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -869,7 +945,7 @@ type Stats_StatsdReporter struct {
 func (x *Stats_StatsdReporter) Reset() {
 	*x = Stats_StatsdReporter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[12]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -882,7 +958,7 @@ func (x *Stats_StatsdReporter) String() string {
 func (*Stats_StatsdReporter) ProtoMessage() {}
 
 func (x *Stats_StatsdReporter) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[12]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -940,7 +1016,7 @@ type Stats_StatsdReporter_PointTags struct {
 func (x *Stats_StatsdReporter_PointTags) Reset() {
 	*x = Stats_StatsdReporter_PointTags{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[13]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -953,7 +1029,7 @@ func (x *Stats_StatsdReporter_PointTags) String() string {
 func (*Stats_StatsdReporter_PointTags) ProtoMessage() {}
 
 func (x *Stats_StatsdReporter_PointTags) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[13]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -989,7 +1065,7 @@ type Timeouts_Entry struct {
 func (x *Timeouts_Entry) Reset() {
 	*x = Timeouts_Entry{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_config_gateway_v1_gateway_proto_msgTypes[14]
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1002,7 +1078,7 @@ func (x *Timeouts_Entry) String() string {
 func (*Timeouts_Entry) ProtoMessage() {}
 
 func (x *Timeouts_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_config_gateway_v1_gateway_proto_msgTypes[14]
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1037,6 +1113,70 @@ func (x *Timeouts_Entry) GetTimeout() *duration.Duration {
 		return x.Timeout
 	}
 	return nil
+}
+
+// To use the S3Provider you must have the AWS service configured
+type Assets_S3Provider struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Region string `protobuf:"bytes,1,opt,name=region,proto3" json:"region,omitempty"`
+	Bucket string `protobuf:"bytes,2,opt,name=bucket,proto3" json:"bucket,omitempty"`
+	Key    string `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
+}
+
+func (x *Assets_S3Provider) Reset() {
+	*x = Assets_S3Provider{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_config_gateway_v1_gateway_proto_msgTypes[16]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Assets_S3Provider) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Assets_S3Provider) ProtoMessage() {}
+
+func (x *Assets_S3Provider) ProtoReflect() protoreflect.Message {
+	mi := &file_config_gateway_v1_gateway_proto_msgTypes[16]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Assets_S3Provider.ProtoReflect.Descriptor instead.
+func (*Assets_S3Provider) Descriptor() ([]byte, []int) {
+	return file_config_gateway_v1_gateway_proto_rawDescGZIP(), []int{6, 0}
+}
+
+func (x *Assets_S3Provider) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+func (x *Assets_S3Provider) GetBucket() string {
+	if x != nil {
+		return x.Bucket
+	}
+	return ""
+}
+
+func (x *Assets_S3Provider) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
 }
 
 var File_config_gateway_v1_gateway_proto protoreflect.FileDescriptor
@@ -1128,7 +1268,7 @@ var file_config_gateway_v1_gateway_proto_rawDesc = []byte{
 	0x19, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
 	0x66, 0x2e, 0x44, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x0c, 0xfa, 0x42, 0x09, 0xaa,
 	0x01, 0x06, 0x08, 0x01, 0x32, 0x02, 0x08, 0x01, 0x52, 0x07, 0x74, 0x69, 0x6d, 0x65, 0x6f, 0x75,
-	0x74, 0x22, 0xc8, 0x03, 0x0a, 0x0e, 0x47, 0x61, 0x74, 0x65, 0x77, 0x61, 0x79, 0x4f, 0x70, 0x74,
+	0x74, 0x22, 0x82, 0x04, 0x0a, 0x0e, 0x47, 0x61, 0x74, 0x65, 0x77, 0x61, 0x79, 0x4f, 0x70, 0x74,
 	0x69, 0x6f, 0x6e, 0x73, 0x12, 0x48, 0x0a, 0x08, 0x6c, 0x69, 0x73, 0x74, 0x65, 0x6e, 0x65, 0x72,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x63, 0x6c, 0x75, 0x74, 0x63, 0x68, 0x2e,
 	0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e, 0x67, 0x61, 0x74, 0x65, 0x77, 0x61, 0x79, 0x2e, 0x76,
@@ -1156,7 +1296,21 @@ var file_config_gateway_v1_gateway_proto_rawDesc = []byte{
 	0x77, 0x61, 0x72, 0x65, 0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x24, 0x2e, 0x63, 0x6c, 0x75,
 	0x74, 0x63, 0x68, 0x2e, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e, 0x67, 0x61, 0x74, 0x65, 0x77,
 	0x61, 0x79, 0x2e, 0x76, 0x31, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65,
-	0x52, 0x0a, 0x6d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x22, 0xc4, 0x01, 0x0a,
+	0x52, 0x0a, 0x6d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x12, 0x38, 0x0a, 0x06,
+	0x61, 0x73, 0x73, 0x65, 0x74, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x20, 0x2e, 0x63,
+	0x6c, 0x75, 0x74, 0x63, 0x68, 0x2e, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e, 0x67, 0x61, 0x74,
+	0x65, 0x77, 0x61, 0x79, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x73, 0x73, 0x65, 0x74, 0x73, 0x52, 0x06,
+	0x61, 0x73, 0x73, 0x65, 0x74, 0x73, 0x22, 0xa3, 0x01, 0x0a, 0x06, 0x41, 0x73, 0x73, 0x65, 0x74,
+	0x73, 0x12, 0x3d, 0x0a, 0x02, 0x73, 0x33, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2b, 0x2e,
+	0x63, 0x6c, 0x75, 0x74, 0x63, 0x68, 0x2e, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e, 0x67, 0x61,
+	0x74, 0x65, 0x77, 0x61, 0x79, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x73, 0x73, 0x65, 0x74, 0x73, 0x2e,
+	0x53, 0x33, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x48, 0x00, 0x52, 0x02, 0x73, 0x33,
+	0x1a, 0x4e, 0x0a, 0x0a, 0x53, 0x33, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x12, 0x16,
+	0x0a, 0x06, 0x72, 0x65, 0x67, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06,
+	0x72, 0x65, 0x67, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x62, 0x75, 0x63, 0x6b, 0x65, 0x74,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x62, 0x75, 0x63, 0x6b, 0x65, 0x74, 0x12, 0x10,
+	0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79,
+	0x42, 0x0a, 0x0a, 0x08, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x22, 0xc4, 0x01, 0x0a,
 	0x06, 0x4c, 0x6f, 0x67, 0x67, 0x65, 0x72, 0x12, 0x3c, 0x0a, 0x05, 0x6c, 0x65, 0x76, 0x65, 0x6c,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x26, 0x2e, 0x63, 0x6c, 0x75, 0x74, 0x63, 0x68, 0x2e,
 	0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e, 0x67, 0x61, 0x74, 0x65, 0x77, 0x61, 0x79, 0x2e, 0x76,
@@ -1210,7 +1364,7 @@ func file_config_gateway_v1_gateway_proto_rawDescGZIP() []byte {
 }
 
 var file_config_gateway_v1_gateway_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_config_gateway_v1_gateway_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_config_gateway_v1_gateway_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_config_gateway_v1_gateway_proto_goTypes = []interface{}{
 	(Logger_Level)(0),                      // 0: clutch.config.gateway.v1.Logger.Level
 	(*Config)(nil),                         // 1: clutch.config.gateway.v1.Config
@@ -1219,47 +1373,51 @@ var file_config_gateway_v1_gateway_proto_goTypes = []interface{}{
 	(*Stats)(nil),                          // 4: clutch.config.gateway.v1.Stats
 	(*Timeouts)(nil),                       // 5: clutch.config.gateway.v1.Timeouts
 	(*GatewayOptions)(nil),                 // 6: clutch.config.gateway.v1.GatewayOptions
-	(*Logger)(nil),                         // 7: clutch.config.gateway.v1.Logger
-	(*Middleware)(nil),                     // 8: clutch.config.gateway.v1.Middleware
-	(*Service)(nil),                        // 9: clutch.config.gateway.v1.Service
-	(*Resolver)(nil),                       // 10: clutch.config.gateway.v1.Resolver
-	(*Module)(nil),                         // 11: clutch.config.gateway.v1.Module
-	(*Stats_LogReporter)(nil),              // 12: clutch.config.gateway.v1.Stats.LogReporter
-	(*Stats_StatsdReporter)(nil),           // 13: clutch.config.gateway.v1.Stats.StatsdReporter
-	(*Stats_StatsdReporter_PointTags)(nil), // 14: clutch.config.gateway.v1.Stats.StatsdReporter.PointTags
-	(*Timeouts_Entry)(nil),                 // 15: clutch.config.gateway.v1.Timeouts.Entry
-	(*duration.Duration)(nil),              // 16: google.protobuf.Duration
-	(*any.Any)(nil),                        // 17: google.protobuf.Any
+	(*Assets)(nil),                         // 7: clutch.config.gateway.v1.Assets
+	(*Logger)(nil),                         // 8: clutch.config.gateway.v1.Logger
+	(*Middleware)(nil),                     // 9: clutch.config.gateway.v1.Middleware
+	(*Service)(nil),                        // 10: clutch.config.gateway.v1.Service
+	(*Resolver)(nil),                       // 11: clutch.config.gateway.v1.Resolver
+	(*Module)(nil),                         // 12: clutch.config.gateway.v1.Module
+	(*Stats_LogReporter)(nil),              // 13: clutch.config.gateway.v1.Stats.LogReporter
+	(*Stats_StatsdReporter)(nil),           // 14: clutch.config.gateway.v1.Stats.StatsdReporter
+	(*Stats_StatsdReporter_PointTags)(nil), // 15: clutch.config.gateway.v1.Stats.StatsdReporter.PointTags
+	(*Timeouts_Entry)(nil),                 // 16: clutch.config.gateway.v1.Timeouts.Entry
+	(*Assets_S3Provider)(nil),              // 17: clutch.config.gateway.v1.Assets.S3Provider
+	(*duration.Duration)(nil),              // 18: google.protobuf.Duration
+	(*any.Any)(nil),                        // 19: google.protobuf.Any
 }
 var file_config_gateway_v1_gateway_proto_depIdxs = []int32{
 	6,  // 0: clutch.config.gateway.v1.Config.gateway:type_name -> clutch.config.gateway.v1.GatewayOptions
-	9,  // 1: clutch.config.gateway.v1.Config.services:type_name -> clutch.config.gateway.v1.Service
-	10, // 2: clutch.config.gateway.v1.Config.resolvers:type_name -> clutch.config.gateway.v1.Resolver
-	11, // 3: clutch.config.gateway.v1.Config.modules:type_name -> clutch.config.gateway.v1.Module
+	10, // 1: clutch.config.gateway.v1.Config.services:type_name -> clutch.config.gateway.v1.Service
+	11, // 2: clutch.config.gateway.v1.Config.resolvers:type_name -> clutch.config.gateway.v1.Resolver
+	12, // 3: clutch.config.gateway.v1.Config.modules:type_name -> clutch.config.gateway.v1.Module
 	2,  // 4: clutch.config.gateway.v1.Listener.tcp:type_name -> clutch.config.gateway.v1.TCPSocket
-	16, // 5: clutch.config.gateway.v1.Stats.flush_interval:type_name -> google.protobuf.Duration
-	12, // 6: clutch.config.gateway.v1.Stats.log_reporter:type_name -> clutch.config.gateway.v1.Stats.LogReporter
-	13, // 7: clutch.config.gateway.v1.Stats.statsd_reporter:type_name -> clutch.config.gateway.v1.Stats.StatsdReporter
-	16, // 8: clutch.config.gateway.v1.Timeouts.default:type_name -> google.protobuf.Duration
-	15, // 9: clutch.config.gateway.v1.Timeouts.overrides:type_name -> clutch.config.gateway.v1.Timeouts.Entry
+	18, // 5: clutch.config.gateway.v1.Stats.flush_interval:type_name -> google.protobuf.Duration
+	13, // 6: clutch.config.gateway.v1.Stats.log_reporter:type_name -> clutch.config.gateway.v1.Stats.LogReporter
+	14, // 7: clutch.config.gateway.v1.Stats.statsd_reporter:type_name -> clutch.config.gateway.v1.Stats.StatsdReporter
+	18, // 8: clutch.config.gateway.v1.Timeouts.default:type_name -> google.protobuf.Duration
+	16, // 9: clutch.config.gateway.v1.Timeouts.overrides:type_name -> clutch.config.gateway.v1.Timeouts.Entry
 	3,  // 10: clutch.config.gateway.v1.GatewayOptions.listener:type_name -> clutch.config.gateway.v1.Listener
 	3,  // 11: clutch.config.gateway.v1.GatewayOptions.json_grpc_loopback_listener:type_name -> clutch.config.gateway.v1.Listener
-	7,  // 12: clutch.config.gateway.v1.GatewayOptions.logger:type_name -> clutch.config.gateway.v1.Logger
+	8,  // 12: clutch.config.gateway.v1.GatewayOptions.logger:type_name -> clutch.config.gateway.v1.Logger
 	4,  // 13: clutch.config.gateway.v1.GatewayOptions.stats:type_name -> clutch.config.gateway.v1.Stats
 	5,  // 14: clutch.config.gateway.v1.GatewayOptions.timeouts:type_name -> clutch.config.gateway.v1.Timeouts
-	8,  // 15: clutch.config.gateway.v1.GatewayOptions.middleware:type_name -> clutch.config.gateway.v1.Middleware
-	0,  // 16: clutch.config.gateway.v1.Logger.level:type_name -> clutch.config.gateway.v1.Logger.Level
-	17, // 17: clutch.config.gateway.v1.Middleware.typed_config:type_name -> google.protobuf.Any
-	17, // 18: clutch.config.gateway.v1.Service.typed_config:type_name -> google.protobuf.Any
-	17, // 19: clutch.config.gateway.v1.Resolver.typed_config:type_name -> google.protobuf.Any
-	17, // 20: clutch.config.gateway.v1.Module.typed_config:type_name -> google.protobuf.Any
-	14, // 21: clutch.config.gateway.v1.Stats.StatsdReporter.point_tags:type_name -> clutch.config.gateway.v1.Stats.StatsdReporter.PointTags
-	16, // 22: clutch.config.gateway.v1.Timeouts.Entry.timeout:type_name -> google.protobuf.Duration
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	9,  // 15: clutch.config.gateway.v1.GatewayOptions.middleware:type_name -> clutch.config.gateway.v1.Middleware
+	7,  // 16: clutch.config.gateway.v1.GatewayOptions.assets:type_name -> clutch.config.gateway.v1.Assets
+	17, // 17: clutch.config.gateway.v1.Assets.s3:type_name -> clutch.config.gateway.v1.Assets.S3Provider
+	0,  // 18: clutch.config.gateway.v1.Logger.level:type_name -> clutch.config.gateway.v1.Logger.Level
+	19, // 19: clutch.config.gateway.v1.Middleware.typed_config:type_name -> google.protobuf.Any
+	19, // 20: clutch.config.gateway.v1.Service.typed_config:type_name -> google.protobuf.Any
+	19, // 21: clutch.config.gateway.v1.Resolver.typed_config:type_name -> google.protobuf.Any
+	19, // 22: clutch.config.gateway.v1.Module.typed_config:type_name -> google.protobuf.Any
+	15, // 23: clutch.config.gateway.v1.Stats.StatsdReporter.point_tags:type_name -> clutch.config.gateway.v1.Stats.StatsdReporter.PointTags
+	18, // 24: clutch.config.gateway.v1.Timeouts.Entry.timeout:type_name -> google.protobuf.Duration
+	25, // [25:25] is the sub-list for method output_type
+	25, // [25:25] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_config_gateway_v1_gateway_proto_init() }
@@ -1341,7 +1499,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Logger); i {
+			switch v := v.(*Assets); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1353,7 +1511,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Middleware); i {
+			switch v := v.(*Logger); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1365,7 +1523,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Service); i {
+			switch v := v.(*Middleware); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1377,7 +1535,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Resolver); i {
+			switch v := v.(*Service); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1389,7 +1547,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Module); i {
+			switch v := v.(*Resolver); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1401,7 +1559,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Stats_LogReporter); i {
+			switch v := v.(*Module); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1413,7 +1571,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Stats_StatsdReporter); i {
+			switch v := v.(*Stats_LogReporter); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1425,7 +1583,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Stats_StatsdReporter_PointTags); i {
+			switch v := v.(*Stats_StatsdReporter); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1437,7 +1595,31 @@ func file_config_gateway_v1_gateway_proto_init() {
 			}
 		}
 		file_config_gateway_v1_gateway_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*Stats_StatsdReporter_PointTags); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_config_gateway_v1_gateway_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Timeouts_Entry); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_config_gateway_v1_gateway_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*Assets_S3Provider); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1457,9 +1639,12 @@ func file_config_gateway_v1_gateway_proto_init() {
 		(*Stats_StatsdReporter_)(nil),
 	}
 	file_config_gateway_v1_gateway_proto_msgTypes[6].OneofWrappers = []interface{}{
+		(*Assets_S3)(nil),
+	}
+	file_config_gateway_v1_gateway_proto_msgTypes[7].OneofWrappers = []interface{}{
 		(*Logger_Pretty)(nil),
 	}
-	file_config_gateway_v1_gateway_proto_msgTypes[12].OneofWrappers = []interface{}{
+	file_config_gateway_v1_gateway_proto_msgTypes[13].OneofWrappers = []interface{}{
 		(*Stats_StatsdReporter_PointTags_)(nil),
 	}
 	type x struct{}
@@ -1468,7 +1653,7 @@ func file_config_gateway_v1_gateway_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_config_gateway_v1_gateway_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/backend/api/config/gateway/v1/gateway.pb.go
+++ b/backend/api/config/gateway/v1/gateway.pb.go
@@ -1123,7 +1123,8 @@ type Assets_S3Provider struct {
 
 	Region string `protobuf:"bytes,1,opt,name=region,proto3" json:"region,omitempty"`
 	Bucket string `protobuf:"bytes,2,opt,name=bucket,proto3" json:"bucket,omitempty"`
-	Key    string `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
+	// key is the path to clutchs frontend static assets in the configured bucket
+	Key string `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
 }
 
 func (x *Assets_S3Provider) Reset() {

--- a/backend/api/config/gateway/v1/gateway.pb.validate.go
+++ b/backend/api/config/gateway/v1/gateway.pb.validate.go
@@ -642,6 +642,16 @@ func (m *GatewayOptions) Validate() error {
 
 	}
 
+	if v, ok := interface{}(m.GetAssets()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return GatewayOptionsValidationError{
+				field:  "Assets",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -698,6 +708,86 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = GatewayOptionsValidationError{}
+
+// Validate checks the field values on Assets with the rules defined in the
+// proto definition for this message. If any rules are violated, an error is returned.
+func (m *Assets) Validate() error {
+	if m == nil {
+		return nil
+	}
+
+	switch m.Provider.(type) {
+
+	case *Assets_S3:
+
+		if v, ok := interface{}(m.GetS3()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return AssetsValidationError{
+					field:  "S3",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// AssetsValidationError is the validation error returned by Assets.Validate if
+// the designated constraints aren't met.
+type AssetsValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e AssetsValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e AssetsValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e AssetsValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e AssetsValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e AssetsValidationError) ErrorName() string { return "AssetsValidationError" }
+
+// Error satisfies the builtin error interface
+func (e AssetsValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sAssets.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = AssetsValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = AssetsValidationError{}
 
 // Validate checks the field values on Logger with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
@@ -1419,3 +1509,76 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = Timeouts_EntryValidationError{}
+
+// Validate checks the field values on Assets_S3Provider with the rules defined
+// in the proto definition for this message. If any rules are violated, an
+// error is returned.
+func (m *Assets_S3Provider) Validate() error {
+	if m == nil {
+		return nil
+	}
+
+	// no validation rules for Region
+
+	// no validation rules for Bucket
+
+	// no validation rules for Key
+
+	return nil
+}
+
+// Assets_S3ProviderValidationError is the validation error returned by
+// Assets_S3Provider.Validate if the designated constraints aren't met.
+type Assets_S3ProviderValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e Assets_S3ProviderValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e Assets_S3ProviderValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e Assets_S3ProviderValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e Assets_S3ProviderValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e Assets_S3ProviderValidationError) ErrorName() string {
+	return "Assets_S3ProviderValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e Assets_S3ProviderValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sAssets_S3Provider.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = Assets_S3ProviderValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = Assets_S3ProviderValidationError{}

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -156,7 +156,7 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 	}
 
 	// Instantiate and register modules listed in the configuration.
-	rpcMux := mux.New(interceptors, assets)
+	rpcMux := mux.New(interceptors, assets, cfg.Gateway.Assets)
 	ctx := context.TODO()
 
 	// Create a client connection for the registrar to make grpc-gateway's handlers available.

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -156,7 +156,10 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 	}
 
 	// Instantiate and register modules listed in the configuration.
-	rpcMux := mux.New(interceptors, assets, cfg.Gateway.Assets)
+	rpcMux, err := mux.New(interceptors, assets, cfg.Gateway.Assets)
+	if err != nil {
+		panic(err)
+	}
 	ctx := context.TODO()
 
 	// Create a client connection for the registrar to make grpc-gateway's handlers available.

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -70,15 +70,17 @@ func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Serve!
 	if f, err := a.fileSystem.Open(r.URL.Path); err != nil {
 		// If not a known static asset and an asset provider is configured, try streaming from the configured provider.
-		if a.assetCfg.Provider != nil && strings.HasPrefix(r.URL.Path, "/static") {
-			// We attatch this header simply for observibility purposes.
-			// Otherwise its difficult to know if the assets are being served from the configured provider.
-			w.Header().Set("x-clutch-asset-passthrough", "true")
+		if a.assetCfg != nil {
+			if a.assetCfg.Provider != nil && strings.HasPrefix(r.URL.Path, "/static") {
+				// We attatch this header simply for observibility purposes.
+				// Otherwise its difficult to know if the assets are being served from the configured provider.
+				w.Header().Set("x-clutch-asset-passthrough", "true")
 
-			// TODO: handle errors
-			asset, _ := a.assetProviderHandler(r.URL.Path)
-			_, _ = io.Copy(w, asset)
-			return
+				// TODO: handle errors
+				asset, _ := a.assetProviderHandler(r.URL.Path)
+				_, _ = io.Copy(w, asset)
+				return
+			}
 		}
 
 		// If not a known static asset serve the SPA.

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -71,14 +71,14 @@ func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if f, err := a.fileSystem.Open(r.URL.Path); err != nil {
 		// If not a known static asset and an asset provider is configured, try streaming from the configured provider.
 		if a.assetCfg != nil && a.assetCfg.Provider != nil && strings.HasPrefix(r.URL.Path, "/static/") {
-			// We attatch this header simply for observibility purposes.
+			// We attach this header simply for observability purposes.
 			// Otherwise its difficult to know if the assets are being served from the configured provider.
 			w.Header().Set("x-clutch-asset-passthrough", "true")
 
 			asset, err := a.assetProviderHandler(r.Context(), r.URL.Path)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte("Error getting assets from the configured asset provider"))
+				_, _ = w.Write([]byte(fmt.Sprintf("Error getting assets from the configured asset provider: %v", err)))
 				return
 			}
 			defer asset.Close()
@@ -86,7 +86,7 @@ func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			_, err = io.Copy(w, asset)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte("Error getting assets from the configured asset provider"))
+				_, _ = w.Write([]byte(fmt.Sprintf("Error getting assets from the configured asset provider: %v", err)))
 				return
 			}
 			return
@@ -198,7 +198,7 @@ func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, m runtime.Ma
 	runtime.DefaultHTTPProtoErrorHandler(ctx, mux, m, w, req, err)
 }
 
-func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem, assetCfg *gatewayv1.Assets) *Mux {
+func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem, assetCfg *gatewayv1.Assets) (*Mux, error) {
 	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(unaryInterceptors...))
 	jsonGateway := runtime.NewServeMux(
 		runtime.WithForwardResponseOption(customResponseForwarder),
@@ -219,7 +219,7 @@ func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem
 	if assetCfg != nil && assetCfg.Provider != nil {
 		_, err := getAssetProviderService(assetCfg)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
 
@@ -236,7 +236,7 @@ func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem
 		JSONGateway: jsonGateway,
 		HTTPMux:     httpMux,
 	}
-	return mux
+	return mux, nil
 }
 
 // Mux allows sharing one port between gRPC and the corresponding JSON gateway via header-based multiplexing.

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -19,11 +20,17 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
+
+	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
+	"github.com/lyft/clutch/backend/service"
+	awsservice "github.com/lyft/clutch/backend/service/aws"
 )
 
 var apiPattern = regexp.MustCompile(`^/v\d+/`)
 
 type assetHandler struct {
+	assetCfg *gatewayv1.Assets
+
 	next       http.Handler
 	fileSystem http.FileSystem
 	fileServer http.Handler
@@ -62,12 +69,49 @@ func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Serve!
 	if f, err := a.fileSystem.Open(r.URL.Path); err != nil {
+		// If not a known static asset and an asset provider is configured, try streaming from the configured provider.
+		if a.assetCfg.Provider != nil && strings.HasPrefix(r.URL.Path, "/static") {
+			// We attatch this header simply for observibility purposes.
+			// Otherwise its difficult to know if the assets are being served from the configured provider.
+			w.Header().Set("x-clutch-asset-passthrough", "true")
+
+			// TODO: handle errors
+			asset, _ := a.assetProviderHandler(r.URL.Path)
+			_, _ = io.Copy(w, asset)
+			return
+		}
+
 		// If not a known static asset serve the SPA.
 		r.URL.Path = "/"
 	} else {
 		_ = f.Close()
 	}
+
 	a.fileServer.ServeHTTP(w, r)
+}
+
+func (a *assetHandler) assetProviderHandler(urlPath string) (io.Reader, error) {
+	switch a.assetCfg.Provider.(type) {
+	case *gatewayv1.Assets_S3:
+		aws, ok := service.Registry[awsservice.Name]
+		if !ok {
+			return nil, fmt.Errorf("The AWS service must be configured to use the asset s3 provider.")
+		}
+
+		awsClient, ok := aws.(awsservice.Client)
+		if !ok {
+			return nil, fmt.Errorf("Unable to aquire the aws client")
+		}
+
+		return awsClient.S3StreamingGet(
+			context.Background(),
+			a.assetCfg.GetS3().Region,
+			a.assetCfg.GetS3().Bucket,
+			path.Join(a.assetCfg.GetS3().Key, strings.TrimPrefix(urlPath, "/static")),
+		)
+	default:
+		return nil, fmt.Errorf("No asset provider is configured")
+	}
 }
 
 func customResponseForwarder(ctx context.Context, w http.ResponseWriter, resp proto.Message) error {
@@ -122,7 +166,7 @@ func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, m runtime.Ma
 	runtime.DefaultHTTPProtoErrorHandler(ctx, mux, m, w, req, err)
 }
 
-func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem) *Mux {
+func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem, assetCfg *gatewayv1.Assets) *Mux {
 	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(unaryInterceptors...))
 	jsonGateway := runtime.NewServeMux(
 		runtime.WithForwardResponseOption(customResponseForwarder),
@@ -140,6 +184,7 @@ func New(unaryInterceptors []grpc.UnaryServerInterceptor, assets http.FileSystem
 
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/", &assetHandler{
+		assetCfg:   assetCfg,
 		next:       jsonGateway,
 		fileSystem: assets,
 		fileServer: http.FileServer(assets),

--- a/backend/gateway/mux/mux_test.go
+++ b/backend/gateway/mux/mux_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
 )
 
 func TestCopyHTTPResponse(t *testing.T) {
@@ -28,4 +30,22 @@ func TestCopyHTTPResponse(t *testing.T) {
 	assert.Equal(t, status, result.StatusCode)
 	assert.Equal(t, headers, rec.Header())
 	assert.Equal(t, body, rec.Body.String())
+}
+
+func TestAssetProviderS3Handler(t *testing.T) {
+	handler := &assetHandler{
+		assetCfg: &gatewayv1.Assets{
+			Provider: &gatewayv1.Assets_S3{
+				S3: &gatewayv1.Assets_S3Provider{
+					Region: "us-east-1",
+					Bucket: "clutch",
+					Key:    "static",
+				},
+			},
+		},
+	}
+
+	// Test that the aws service must be configured to use the S3 handler
+	_, err := handler.assetProviderHandler("clutch.sh/static/main.js")
+	assert.Error(t, err)
 }

--- a/backend/gateway/mux/mux_test.go
+++ b/backend/gateway/mux/mux_test.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -46,6 +47,6 @@ func TestAssetProviderS3Handler(t *testing.T) {
 	}
 
 	// Test that the aws service must be configured to use the S3 handler
-	_, err := handler.assetProviderHandler("clutch.sh/static/main.js")
+	_, err := handler.assetProviderHandler(context.TODO(), "clutch.sh/static/main.js")
 	assert.Error(t, err)
 }

--- a/backend/gateway/mux/mux_test.go
+++ b/backend/gateway/mux/mux_test.go
@@ -50,3 +50,19 @@ func TestAssetProviderS3Handler(t *testing.T) {
 	_, err := handler.assetProviderHandler(context.TODO(), "clutch.sh/static/main.js")
 	assert.Error(t, err)
 }
+
+func TestGetAssetProivderService(t *testing.T) {
+	assetCfg := &gatewayv1.Assets{
+		Provider: &gatewayv1.Assets_S3{
+			S3: &gatewayv1.Assets_S3Provider{
+				Region: "us-east-1",
+				Bucket: "clutch",
+				Key:    "static",
+			},
+		},
+	}
+
+	// Test that the aws service must be configured to use the S3 handler
+	_, err := getAssetProviderService(assetCfg)
+	assert.Error(t, err)
+}

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -159,6 +159,7 @@ github.com/containerd/containerd v1.3.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMX
 github.com/corbym/gocrest v1.0.3/go.mod h1:maVFL5lbdS2PgfOQgGRWDYTeunSWQeiEgoNdTABShCs=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
 github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
@@ -629,6 +630,7 @@ github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -708,6 +710,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=

--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -3,6 +3,7 @@ package awsmock
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 
 	"github.com/golang/protobuf/ptypes/any"
@@ -90,6 +91,10 @@ func (s *svc) DescribeInstances(ctx context.Context, region string, ids []string
 
 func (s *svc) TerminateInstances(ctx context.Context, region string, ids []string) error {
 	return nil
+}
+
+func (s *svc) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
+	return nil, nil
 }
 
 func (s *svc) Regions() []string {

--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -94,7 +94,7 @@ func (s *svc) TerminateInstances(ctx context.Context, region string, ids []strin
 }
 
 func (s *svc) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
-	return nil, nil
+	panic("implement me")
 }
 
 func (s *svc) Regions() []string {

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -7,6 +7,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -17,6 +18,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/iancoleman/strcase"
@@ -55,6 +58,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 
 		c.clients[region] = &regionalClient{
 			region:      region,
+			s3:          s3.New(awsSession),
 			kinesis:     kinesis.New(awsSession),
 			ec2:         ec2.New(awsSession),
 			autoscaling: autoscaling.New(awsSession),
@@ -73,6 +77,8 @@ type Client interface {
 
 	DescribeKinesisStream(ctx context.Context, region string, streamName string) (*kinesisv1.Stream, error)
 	UpdateKinesisShardCount(ctx context.Context, region string, streamName string, targetShardCount uint32) error
+
+	S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error)
 
 	Regions() []string
 }
@@ -197,6 +203,7 @@ func (c *client) Regions() []string {
 type regionalClient struct {
 	region string
 
+	s3          s3iface.S3API
 	kinesis     kinesisiface.KinesisAPI
 	ec2         ec2iface.EC2API
 	autoscaling autoscalingiface.AutoScalingAPI

--- a/backend/service/aws/s3.go
+++ b/backend/service/aws/s3.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func (c *client) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
+	rc, ok := c.clients[region]
+	if !ok {
+		return nil, fmt.Errorf("no client found for region '%s'", region)
+	}
+
+	in := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	out, err := rc.s3.GetObjectWithContext(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Body, nil
+}

--- a/frontend/api/src/index.d.ts
+++ b/frontend/api/src/index.d.ts
@@ -3843,6 +3843,9 @@ export namespace clutch {
 
                     /** GatewayOptions middleware */
                     middleware?: (clutch.config.gateway.v1.IMiddleware[]|null);
+
+                    /** GatewayOptions assets */
+                    assets?: (clutch.config.gateway.v1.IAssets|null);
                 }
 
                 /** Represents a GatewayOptions. */
@@ -3872,6 +3875,9 @@ export namespace clutch {
                     /** GatewayOptions middleware. */
                     public middleware: clutch.config.gateway.v1.IMiddleware[];
 
+                    /** GatewayOptions assets. */
+                    public assets?: (clutch.config.gateway.v1.IAssets|null);
+
                     /**
                      * Verifies a GatewayOptions message.
                      * @param message Plain object to verify
@@ -3899,6 +3905,120 @@ export namespace clutch {
                      * @returns JSON object
                      */
                     public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of an Assets. */
+                interface IAssets {
+
+                    /** Assets s3 */
+                    s3?: (clutch.config.gateway.v1.Assets.IS3Provider|null);
+                }
+
+                /** Represents an Assets. */
+                class Assets implements IAssets {
+
+                    /**
+                     * Constructs a new Assets.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: clutch.config.gateway.v1.IAssets);
+
+                    /** Assets s3. */
+                    public s3?: (clutch.config.gateway.v1.Assets.IS3Provider|null);
+
+                    /** Assets provider. */
+                    public provider?: "s3";
+
+                    /**
+                     * Verifies an Assets message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates an Assets message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns Assets
+                     */
+                    public static fromObject(object: { [k: string]: any }): clutch.config.gateway.v1.Assets;
+
+                    /**
+                     * Creates a plain object from an Assets message. Also converts values to other types if specified.
+                     * @param message Assets
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: clutch.config.gateway.v1.Assets, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this Assets to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                namespace Assets {
+
+                    /** Properties of a S3Provider. */
+                    interface IS3Provider {
+
+                        /** S3Provider region */
+                        region?: (string|null);
+
+                        /** S3Provider bucket */
+                        bucket?: (string|null);
+
+                        /** S3Provider key */
+                        key?: (string|null);
+                    }
+
+                    /** Represents a S3Provider. */
+                    class S3Provider implements IS3Provider {
+
+                        /**
+                         * Constructs a new S3Provider.
+                         * @param [properties] Properties to set
+                         */
+                        constructor(properties?: clutch.config.gateway.v1.Assets.IS3Provider);
+
+                        /** S3Provider region. */
+                        public region: string;
+
+                        /** S3Provider bucket. */
+                        public bucket: string;
+
+                        /** S3Provider key. */
+                        public key: string;
+
+                        /**
+                         * Verifies a S3Provider message.
+                         * @param message Plain object to verify
+                         * @returns `null` if valid, otherwise the reason why it is not
+                         */
+                        public static verify(message: { [k: string]: any }): (string|null);
+
+                        /**
+                         * Creates a S3Provider message from a plain object. Also converts values to their respective internal types.
+                         * @param object Plain object
+                         * @returns S3Provider
+                         */
+                        public static fromObject(object: { [k: string]: any }): clutch.config.gateway.v1.Assets.S3Provider;
+
+                        /**
+                         * Creates a plain object from a S3Provider message. Also converts values to other types if specified.
+                         * @param message S3Provider
+                         * @param [options] Conversion options
+                         * @returns Plain object
+                         */
+                        public static toObject(message: clutch.config.gateway.v1.Assets.S3Provider, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                        /**
+                         * Converts this S3Provider to JSON.
+                         * @returns JSON object
+                         */
+                        public toJSON(): { [k: string]: any };
+                    }
                 }
 
                 /** Properties of a Logger. */

--- a/frontend/api/src/index.js
+++ b/frontend/api/src/index.js
@@ -8983,6 +8983,7 @@ export const clutch = $root.clutch = (() => {
                      * @property {clutch.config.gateway.v1.IStats|null} [stats] GatewayOptions stats
                      * @property {clutch.config.gateway.v1.ITimeouts|null} [timeouts] GatewayOptions timeouts
                      * @property {Array.<clutch.config.gateway.v1.IMiddleware>|null} [middleware] GatewayOptions middleware
+                     * @property {clutch.config.gateway.v1.IAssets|null} [assets] GatewayOptions assets
                      */
 
                     /**
@@ -9050,6 +9051,14 @@ export const clutch = $root.clutch = (() => {
                     GatewayOptions.prototype.middleware = $util.emptyArray;
 
                     /**
+                     * GatewayOptions assets.
+                     * @member {clutch.config.gateway.v1.IAssets|null|undefined} assets
+                     * @memberof clutch.config.gateway.v1.GatewayOptions
+                     * @instance
+                     */
+                    GatewayOptions.prototype.assets = null;
+
+                    /**
                      * Verifies a GatewayOptions message.
                      * @function verify
                      * @memberof clutch.config.gateway.v1.GatewayOptions
@@ -9093,6 +9102,11 @@ export const clutch = $root.clutch = (() => {
                                 if (error)
                                     return "middleware." + error;
                             }
+                        }
+                        if (message.assets != null && message.hasOwnProperty("assets")) {
+                            let error = $root.clutch.config.gateway.v1.Assets.verify(message.assets);
+                            if (error)
+                                return "assets." + error;
                         }
                         return null;
                     };
@@ -9144,6 +9158,11 @@ export const clutch = $root.clutch = (() => {
                                 message.middleware[i] = $root.clutch.config.gateway.v1.Middleware.fromObject(object.middleware[i]);
                             }
                         }
+                        if (object.assets != null) {
+                            if (typeof object.assets !== "object")
+                                throw TypeError(".clutch.config.gateway.v1.GatewayOptions.assets: object expected");
+                            message.assets = $root.clutch.config.gateway.v1.Assets.fromObject(object.assets);
+                        }
                         return message;
                     };
 
@@ -9168,6 +9187,7 @@ export const clutch = $root.clutch = (() => {
                             object.logger = null;
                             object.stats = null;
                             object.timeouts = null;
+                            object.assets = null;
                         }
                         if (message.listener != null && message.hasOwnProperty("listener"))
                             object.listener = $root.clutch.config.gateway.v1.Listener.toObject(message.listener, options);
@@ -9184,6 +9204,8 @@ export const clutch = $root.clutch = (() => {
                             for (let j = 0; j < message.middleware.length; ++j)
                                 object.middleware[j] = $root.clutch.config.gateway.v1.Middleware.toObject(message.middleware[j], options);
                         }
+                        if (message.assets != null && message.hasOwnProperty("assets"))
+                            object.assets = $root.clutch.config.gateway.v1.Assets.toObject(message.assets, options);
                         return object;
                     };
 
@@ -9199,6 +9221,265 @@ export const clutch = $root.clutch = (() => {
                     };
 
                     return GatewayOptions;
+                })();
+
+                v1.Assets = (function() {
+
+                    /**
+                     * Properties of an Assets.
+                     * @memberof clutch.config.gateway.v1
+                     * @interface IAssets
+                     * @property {clutch.config.gateway.v1.Assets.IS3Provider|null} [s3] Assets s3
+                     */
+
+                    /**
+                     * Constructs a new Assets.
+                     * @memberof clutch.config.gateway.v1
+                     * @classdesc Represents an Assets.
+                     * @implements IAssets
+                     * @constructor
+                     * @param {clutch.config.gateway.v1.IAssets=} [properties] Properties to set
+                     */
+                    function Assets(properties) {
+                        if (properties)
+                            for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * Assets s3.
+                     * @member {clutch.config.gateway.v1.Assets.IS3Provider|null|undefined} s3
+                     * @memberof clutch.config.gateway.v1.Assets
+                     * @instance
+                     */
+                    Assets.prototype.s3 = null;
+
+                    // OneOf field names bound to virtual getters and setters
+                    let $oneOfFields;
+
+                    /**
+                     * Assets provider.
+                     * @member {"s3"|undefined} provider
+                     * @memberof clutch.config.gateway.v1.Assets
+                     * @instance
+                     */
+                    Object.defineProperty(Assets.prototype, "provider", {
+                        get: $util.oneOfGetter($oneOfFields = ["s3"]),
+                        set: $util.oneOfSetter($oneOfFields)
+                    });
+
+                    /**
+                     * Verifies an Assets message.
+                     * @function verify
+                     * @memberof clutch.config.gateway.v1.Assets
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    Assets.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        let properties = {};
+                        if (message.s3 != null && message.hasOwnProperty("s3")) {
+                            properties.provider = 1;
+                            {
+                                let error = $root.clutch.config.gateway.v1.Assets.S3Provider.verify(message.s3);
+                                if (error)
+                                    return "s3." + error;
+                            }
+                        }
+                        return null;
+                    };
+
+                    /**
+                     * Creates an Assets message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof clutch.config.gateway.v1.Assets
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {clutch.config.gateway.v1.Assets} Assets
+                     */
+                    Assets.fromObject = function fromObject(object) {
+                        if (object instanceof $root.clutch.config.gateway.v1.Assets)
+                            return object;
+                        let message = new $root.clutch.config.gateway.v1.Assets();
+                        if (object.s3 != null) {
+                            if (typeof object.s3 !== "object")
+                                throw TypeError(".clutch.config.gateway.v1.Assets.s3: object expected");
+                            message.s3 = $root.clutch.config.gateway.v1.Assets.S3Provider.fromObject(object.s3);
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from an Assets message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof clutch.config.gateway.v1.Assets
+                     * @static
+                     * @param {clutch.config.gateway.v1.Assets} message Assets
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    Assets.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        let object = {};
+                        if (message.s3 != null && message.hasOwnProperty("s3")) {
+                            object.s3 = $root.clutch.config.gateway.v1.Assets.S3Provider.toObject(message.s3, options);
+                            if (options.oneofs)
+                                object.provider = "s3";
+                        }
+                        return object;
+                    };
+
+                    /**
+                     * Converts this Assets to JSON.
+                     * @function toJSON
+                     * @memberof clutch.config.gateway.v1.Assets
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    Assets.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    Assets.S3Provider = (function() {
+
+                        /**
+                         * Properties of a S3Provider.
+                         * @memberof clutch.config.gateway.v1.Assets
+                         * @interface IS3Provider
+                         * @property {string|null} [region] S3Provider region
+                         * @property {string|null} [bucket] S3Provider bucket
+                         * @property {string|null} [key] S3Provider key
+                         */
+
+                        /**
+                         * Constructs a new S3Provider.
+                         * @memberof clutch.config.gateway.v1.Assets
+                         * @classdesc Represents a S3Provider.
+                         * @implements IS3Provider
+                         * @constructor
+                         * @param {clutch.config.gateway.v1.Assets.IS3Provider=} [properties] Properties to set
+                         */
+                        function S3Provider(properties) {
+                            if (properties)
+                                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+
+                        /**
+                         * S3Provider region.
+                         * @member {string} region
+                         * @memberof clutch.config.gateway.v1.Assets.S3Provider
+                         * @instance
+                         */
+                        S3Provider.prototype.region = "";
+
+                        /**
+                         * S3Provider bucket.
+                         * @member {string} bucket
+                         * @memberof clutch.config.gateway.v1.Assets.S3Provider
+                         * @instance
+                         */
+                        S3Provider.prototype.bucket = "";
+
+                        /**
+                         * S3Provider key.
+                         * @member {string} key
+                         * @memberof clutch.config.gateway.v1.Assets.S3Provider
+                         * @instance
+                         */
+                        S3Provider.prototype.key = "";
+
+                        /**
+                         * Verifies a S3Provider message.
+                         * @function verify
+                         * @memberof clutch.config.gateway.v1.Assets.S3Provider
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        S3Provider.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.region != null && message.hasOwnProperty("region"))
+                                if (!$util.isString(message.region))
+                                    return "region: string expected";
+                            if (message.bucket != null && message.hasOwnProperty("bucket"))
+                                if (!$util.isString(message.bucket))
+                                    return "bucket: string expected";
+                            if (message.key != null && message.hasOwnProperty("key"))
+                                if (!$util.isString(message.key))
+                                    return "key: string expected";
+                            return null;
+                        };
+
+                        /**
+                         * Creates a S3Provider message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof clutch.config.gateway.v1.Assets.S3Provider
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {clutch.config.gateway.v1.Assets.S3Provider} S3Provider
+                         */
+                        S3Provider.fromObject = function fromObject(object) {
+                            if (object instanceof $root.clutch.config.gateway.v1.Assets.S3Provider)
+                                return object;
+                            let message = new $root.clutch.config.gateway.v1.Assets.S3Provider();
+                            if (object.region != null)
+                                message.region = String(object.region);
+                            if (object.bucket != null)
+                                message.bucket = String(object.bucket);
+                            if (object.key != null)
+                                message.key = String(object.key);
+                            return message;
+                        };
+
+                        /**
+                         * Creates a plain object from a S3Provider message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof clutch.config.gateway.v1.Assets.S3Provider
+                         * @static
+                         * @param {clutch.config.gateway.v1.Assets.S3Provider} message S3Provider
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        S3Provider.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            let object = {};
+                            if (options.defaults) {
+                                object.region = "";
+                                object.bucket = "";
+                                object.key = "";
+                            }
+                            if (message.region != null && message.hasOwnProperty("region"))
+                                object.region = message.region;
+                            if (message.bucket != null && message.hasOwnProperty("bucket"))
+                                object.bucket = message.bucket;
+                            if (message.key != null && message.hasOwnProperty("key"))
+                                object.key = message.key;
+                            return object;
+                        };
+
+                        /**
+                         * Converts this S3Provider to JSON.
+                         * @function toJSON
+                         * @memberof clutch.config.gateway.v1.Assets.S3Provider
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        S3Provider.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+
+                        return S3Provider;
+                    })();
+
+                    return Assets;
                 })();
 
                 v1.Logger = (function() {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Add passthrough host support for frontend static assets. If the deployed version of clutch does not have the requested frontend assets on disk the passthrough host will be used to fetch the correct assets assuming they exist for the configured provider.

In a different PR we would have a more pretty failure mode, currently you simply get a white page.

### Testing Performed
<!-- Describe how you tested this change below. -->
Testing was performed internally at Lyft, forcing all static asset traffic to go through the passthrough host.
```
gateway:
  assets:
    s3:
      region: us-east-1
      bucket: clutch
      key: static
```
### GitHub Issue 
Passthrough host support #471 
