### PR TITLE
docs: add registration function step to Amiibo tutorial

### DIFF
--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -549,7 +549,39 @@ Here we define the data layout structure and pass it to the wizard along with th
 
 ##### Configuration
 
-The final step is registering this new Amiibo workflow with the Clutch app. Open your `clutch.config.js` file and add the following:
+The final step is registering this new Amiibo workflow with the Clutch app. First update the component name by replacing the scaffolded default in our workflow's registration function.
+
+```tsx title="frontend/workflows/amiibo/src/index.tsx"
+import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
+// highlight-next-line
+import Amiibo from "./hello-world";
+
+export interface WorkflowProps extends BaseWorkflowProps {}
+
+const register = (): WorkflowConfiguration => {
+  return {
+    developer: {
+      name: "Name McName",
+      contactUrl: "mailto:foo@foo-email.com>",
+    },
+    path: "amiibo",
+    group: "Amiibo",
+    displayName: "Amiibo",
+    routes: {
+      landing: {
+        path: "/",
+        description: "Lookup all Amiibo by name.",
+	// highlight-next-line
+        component: Amiibo,
+      },
+    },
+  };
+};
+
+export default register;
+```
+
+Next, open your `clutch.config.js` file and add the following:
 
 ```js title="clutch.config.js"
 module.exports = {

--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -549,7 +549,7 @@ Here we define the data layout structure and pass it to the wizard along with th
 
 ##### Configuration
 
-The final step is registering this new Amiibo workflow with the Clutch app. First update the component name by replacing the scaffolded default in our workflow's registration function.
+The final step is registering this new Amiibo workflow with the Clutch app. First update the component name by replacing the scaffolded default (`HelloWorld`) in our workflow's registration function.
 
 ```tsx title="frontend/workflows/amiibo/src/index.tsx"
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";

--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -562,7 +562,7 @@ const register = (): WorkflowConfiguration => {
   return {
     developer: {
       name: "Name McName",
-      contactUrl: "mailto:foo@foo-email.com>",
+      contactUrl: "mailto:foo@foo-email.com",
     },
     path: "amiibo",
     group: "Amiibo",


### PR DESCRIPTION
### Description
This PR adds an additional step to the Amiibo tutorial's documentation. It guides the user in updating the scaffolded index.tsx file by providing a sample file and highlighting the changed lines.  

### Motivation
To successfully register the Amiibo workflow, we also need to update the registration function to reflect the component name changed in previous tutorial steps.

### Testing Performed
Manually followed tutorial steps and confirmed that the workflow does not get registered until the registration function is also updated.


