### PR TITLE
core: add a Theme component

### DIFF
--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -32,6 +32,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.43",
+    "@material-ui/styles": "^4.10.0",
     "axios": "^0.20.0",
     "history": "^5.0.0",
     "js-cookie": "^2.2.1",

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { BrowserRouter as Router, Outlet, Route, Routes } from "react-router-dom";
-import { CssBaseline, MuiThemeProvider } from "@material-ui/core";
 import _ from "lodash";
-import { ThemeProvider as StyledThemeProvider } from "styled-components";
 
 import AppLayout from "../AppLayout";
 import { ApplicationContext } from "../Contexts/app-context";
@@ -10,7 +8,7 @@ import Landing from "../landing";
 import NotFound from "../not-found";
 
 import registeredWorkflows from "./registrar";
-import { getTheme } from "./themes";
+import { Theme } from "./themes";
 import type { ConfiguredRoute, Workflow, WorkflowConfiguration } from "./workflow";
 import ErrorBoundary from "./workflow";
 
@@ -47,43 +45,40 @@ const ClutchApp: React.FC<ClutchAppProps> = ({ availableWorkflows, configuration
 
   return (
     <Router>
-      <MuiThemeProvider theme={getTheme()}>
-        <StyledThemeProvider theme={getTheme()}>
-          <CssBaseline />
-          <div id="App">
-            <ApplicationContext.Provider value={{ workflows: publicWorkflows }}>
-              <Routes>
-                <Route path="/*" element={<AppLayout />}>
-                  <Route key="landing" path="/" element={<Landing />} />
-                  {workflows.map((workflow: Workflow) => (
-                    <ErrorBoundary workflow={workflow} key={workflow.path.split("/")[0]}>
-                      <Route path={`${workflow.path}/*`} element={<Outlet />}>
-                        {workflow.routes.map(route => {
-                          const heading = route.displayName
-                            ? `${workflow.displayName}: ${route.displayName}`
-                            : workflow.displayName;
-                          return (
-                            <Route
-                              key={workflow.path}
-                              path={`${route.path}`}
-                              element={React.cloneElement(<route.component />, {
-                                ...route.componentProps,
-                                heading,
-                              })}
-                            />
-                          );
-                        })}
-                        <Route key={`${workflow.path}/notFound`} path="*" element={<NotFound />} />
-                      </Route>
-                    </ErrorBoundary>
-                  ))}
-                  <Route key="notFound" path="*" element={<NotFound />} />
-                </Route>
-              </Routes>
-            </ApplicationContext.Provider>
-          </div>
-        </StyledThemeProvider>
-      </MuiThemeProvider>
+      <Theme variant="light">
+        <div id="App">
+          <ApplicationContext.Provider value={{ workflows: publicWorkflows }}>
+            <Routes>
+              <Route path="/*" element={<AppLayout />}>
+                <Route key="landing" path="/" element={<Landing />} />
+                {workflows.map((workflow: Workflow) => (
+                  <ErrorBoundary workflow={workflow} key={workflow.path.split("/")[0]}>
+                    <Route path={`${workflow.path}/*`} element={<Outlet />}>
+                      {workflow.routes.map(route => {
+                        const heading = route.displayName
+                          ? `${workflow.displayName}: ${route.displayName}`
+                          : workflow.displayName;
+                        return (
+                          <Route
+                            key={workflow.path}
+                            path={`${route.path}`}
+                            element={React.cloneElement(<route.component />, {
+                              ...route.componentProps,
+                              heading,
+                            })}
+                          />
+                        );
+                      })}
+                      <Route key={`${workflow.path}/notFound`} path="*" element={<NotFound />} />
+                    </Route>
+                  </ErrorBoundary>
+                ))}
+                <Route key="notFound" path="*" element={<NotFound />} />
+              </Route>
+            </Routes>
+          </ApplicationContext.Provider>
+        </div>
+      </Theme>
     </Router>
   );
 };

--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -1,7 +1,9 @@
-import { createMuiTheme, ThemeOptions } from "@material-ui/core";
+import React from "react";
+import { createMuiTheme, CssBaseline, MuiThemeProvider, ThemeOptions } from "@material-ui/core";
 import { useTheme as useMuiTheme } from "@material-ui/core/styles";
 import type { PaletteOptions } from "@material-ui/core/styles/createPalette";
-import {} from "styled-components";
+import { StylesProvider } from "@material-ui/styles";
+import { ThemeProvider as StyledThemeProvider } from "styled-components";
 
 interface ClutchPalette extends PaletteOptions {
   accent: {
@@ -53,7 +55,7 @@ const lightPalette = (): ClutchPalette => {
   };
 };
 
-const getTheme = () => {
+const lightTheme = () => {
   return createMuiTheme({
     palette: lightPalette(),
     overrides: {
@@ -78,4 +80,20 @@ const useTheme = () => {
   return useMuiTheme() as ClutchTheme;
 };
 
-export { getTheme, useTheme };
+interface ThemeProps {
+  variant?: "light";
+}
+
+const Theme: React.FC<ThemeProps> = ({ children }) => {
+  const theme = lightTheme;
+  return (
+    <MuiThemeProvider theme={theme()}>
+      <StyledThemeProvider theme={theme()}>
+        <CssBaseline />
+        <StylesProvider injectFirst>{children}</StylesProvider>
+      </StyledThemeProvider>
+    </MuiThemeProvider>
+  );
+};
+
+export { Theme, useTheme };

--- a/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
@@ -1,64 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Not Found component renders correctly 1`] = `
-"<ThemeProvider theme={{...}}>
-  <NotFound>
-    <WithStyles(ForwardRef(Grid)) container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\">
-      <ForwardRef(Grid) classes={{...}} container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\">
-        <div className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center MuiGrid-justify-xs-center\\">
-          <Styled(WithStyles(ForwardRef(Grid))) item={true}>
-            <WithStyles(ForwardRef(Grid)) item={true} className=\\"sc-AxjAm fOtbrD\\">
-              <ForwardRef(Grid) classes={{...}} item={true} className=\\"sc-AxjAm fOtbrD\\">
-                <div className=\\"MuiGrid-root sc-AxjAm fOtbrD MuiGrid-item\\">
-                  <ForwardRef fontSize=\\"inherit\\">
-                    <WithStyles(ForwardRef(SvgIcon)) fontSize=\\"inherit\\">
-                      <ForwardRef(SvgIcon) classes={{...}} fontSize=\\"inherit\\">
-                        <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" color={[undefined]} aria-hidden={true} role={[undefined]}>
-                          <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
-                        </svg>
-                      </ForwardRef(SvgIcon)>
-                    </WithStyles(ForwardRef(SvgIcon))>
-                  </ForwardRef>
-                </div>
-              </ForwardRef(Grid)>
-            </WithStyles(ForwardRef(Grid))>
-          </Styled(WithStyles(ForwardRef(Grid)))>
-          <WithStyles(ForwardRef(Grid)) item={true}>
-            <ForwardRef(Grid) classes={{...}} item={true}>
-              <div className=\\"MuiGrid-root MuiGrid-item\\">
-                <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
-                  <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
-                    <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
-                      <WithStyles(ForwardRef(Grid)) item={true}>
-                        <ForwardRef(Grid) classes={{...}} item={true}>
-                          <div className=\\"MuiGrid-root MuiGrid-item\\">
-                            Whoops...
-                          </div>
-                        </ForwardRef(Grid)>
-                      </WithStyles(ForwardRef(Grid))>
-                      <WithStyles(ForwardRef(Grid)) item={true}>
-                        <ForwardRef(Grid) classes={{...}} item={true}>
-                          <div className=\\"MuiGrid-root MuiGrid-item\\">
-                            Looks like you took a wrong turn
-                          </div>
-                        </ForwardRef(Grid)>
-                      </WithStyles(ForwardRef(Grid))>
-                    </h3>
-                  </ForwardRef(Typography)>
-                </WithStyles(ForwardRef(Typography))>
-                <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
-                  <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
-                    <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
-                      &lt; 404 Not Found &gt;
-                    </h6>
-                  </ForwardRef(Typography)>
-                </WithStyles(ForwardRef(Typography))>
+"<Theme>
+  <ThemeProvider theme={{...}}>
+    <ThemeProvider theme={{...}}>
+      <WithStyles(CssBaseline)>
+        <CssBaseline classes={{...}} />
+      </WithStyles(CssBaseline)>
+      <StylesProvider injectFirst={true}>
+        <NotFound>
+          <WithStyles(ForwardRef(Grid)) container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\">
+            <ForwardRef(Grid) classes={{...}} container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\">
+              <div className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center MuiGrid-justify-xs-center\\">
+                <Styled(WithStyles(ForwardRef(Grid))) item={true}>
+                  <WithStyles(ForwardRef(Grid)) item={true} className=\\"sc-AxjAm fOtbrD\\">
+                    <ForwardRef(Grid) classes={{...}} item={true} className=\\"sc-AxjAm fOtbrD\\">
+                      <div className=\\"MuiGrid-root sc-AxjAm fOtbrD MuiGrid-item\\">
+                        <ForwardRef fontSize=\\"inherit\\">
+                          <WithStyles(ForwardRef(SvgIcon)) fontSize=\\"inherit\\">
+                            <ForwardRef(SvgIcon) classes={{...}} fontSize=\\"inherit\\">
+                              <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" color={[undefined]} aria-hidden={true} role={[undefined]}>
+                                <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
+                              </svg>
+                            </ForwardRef(SvgIcon)>
+                          </WithStyles(ForwardRef(SvgIcon))>
+                        </ForwardRef>
+                      </div>
+                    </ForwardRef(Grid)>
+                  </WithStyles(ForwardRef(Grid))>
+                </Styled(WithStyles(ForwardRef(Grid)))>
+                <WithStyles(ForwardRef(Grid)) item={true}>
+                  <ForwardRef(Grid) classes={{...}} item={true}>
+                    <div className=\\"MuiGrid-root MuiGrid-item\\">
+                      <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
+                        <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
+                          <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
+                            <WithStyles(ForwardRef(Grid)) item={true}>
+                              <ForwardRef(Grid) classes={{...}} item={true}>
+                                <div className=\\"MuiGrid-root MuiGrid-item\\">
+                                  Whoops...
+                                </div>
+                              </ForwardRef(Grid)>
+                            </WithStyles(ForwardRef(Grid))>
+                            <WithStyles(ForwardRef(Grid)) item={true}>
+                              <ForwardRef(Grid) classes={{...}} item={true}>
+                                <div className=\\"MuiGrid-root MuiGrid-item\\">
+                                  Looks like you took a wrong turn
+                                </div>
+                              </ForwardRef(Grid)>
+                            </WithStyles(ForwardRef(Grid))>
+                          </h3>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                      <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
+                        <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
+                          <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
+                            &lt; 404 Not Found &gt;
+                          </h6>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                    </div>
+                  </ForwardRef(Grid)>
+                </WithStyles(ForwardRef(Grid))>
               </div>
             </ForwardRef(Grid)>
           </WithStyles(ForwardRef(Grid))>
-        </div>
-      </ForwardRef(Grid)>
-    </WithStyles(ForwardRef(Grid))>
-  </NotFound>
-</ThemeProvider>"
+        </NotFound>
+      </StylesProvider>
+    </ThemeProvider>
+  </ThemeProvider>
+</Theme>"
 `;

--- a/frontend/packages/core/src/tests/not-found.test.tsx
+++ b/frontend/packages/core/src/tests/not-found.test.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
-import { ThemeProvider as StyledThemeProvider } from "styled-components";
 
-import { getTheme } from "../AppProvider/themes";
+import { Theme } from "../AppProvider/themes";
 import NotFound from "../not-found";
 
 describe("Not Found component", () => {
@@ -10,9 +9,9 @@ describe("Not Found component", () => {
 
   beforeAll(() => {
     component = mount(
-      <StyledThemeProvider theme={getTheme()}>
+      <Theme>
         <NotFound />
-      </StyledThemeProvider>
+      </Theme>
     );
   });
 

--- a/frontend/packages/tools/package.json
+++ b/frontend/packages/tools/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.6.0",
     "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
-    "@babel/plugin-proposal-optional-chaining": "^7.7.5",
+    "@babel/plugin-proposal-optional-chaining": "^7.11.0",
     "@babel/plugin-transform-runtime": "^7.9.6",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-react": "^7.7.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -495,6 +495,13 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-skip-transparent-expression-wrappers@^7.11.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz#eec162f112c2f58d3af0af125e3bb57665146729"
+  integrity sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==
+  dependencies:
+    "@babel/types" "^7.11.0"
+
 "@babel/helper-split-export-declaration@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz#c6f4be1cbc15e3a868e4c64a17d5d31d754da35f"
@@ -710,7 +717,16 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.7.5", "@babel/plugin-proposal-optional-chaining@^7.8.3":
+"@babel/plugin-proposal-optional-chaining@^7.11.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz#de5866d0646f6afdaab8a566382fe3a221755076"
+  integrity sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz#ae10b3214cb25f7adb1f3bc87ba42ca10b7e2543"
   integrity sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
By centralizing the theme providers we use it'll allow us to more easily swap them out. This also allows us to inject all theme providers in a single place (useful for storybook).

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
