### PR TITLE
frontend: preserve terminal output when app starts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "lint:packages:fix": "sort-package-json package.json packages/**/package.json",
     "package": "func() { yarn workspace @clutch-sh/\"$@\"; }; func",
     "publishBeta": "lerna run compile && lerna run publishBeta --no-bail",
-    "start": "yarn compile:watch & yarn workspace @clutch-sh/app start",
+    "start": "yarn compile:watch & FORCE_COLOR=true yarn workspace @clutch-sh/app start | cat",
     "test": "lerna run test --stream --no-bail --",
     "test:coverage": "lerna run test:coverage --stream --no-bail --",
     "test:e2e": "lerna run test:e2e",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Currently react-scripts clears the contents of the terminal window when it builds and starts. This is particularly frustrating when the background process we spawn to run babel results in an error that gets thrown away. This change prevents react-scripts from clearing any information upon start.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual