### PR TITLE
topology: cache Set/Delete operations

### DIFF
--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -70,7 +70,7 @@ func convertLockIdToAdvisoryLockId(lockID string) uint32 {
 	return binary.BigEndian.Uint32(x)
 }
 
-func (c *client) SetCache(obj *topologyv1.Resource) error {
+func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
 	const upsertQuery = `
 		INSERT INTO topology_cache (id, resolver_type_url, data, metadata)
 		VALUES ($1, $2, $3, $4)
@@ -95,7 +95,7 @@ func (c *client) SetCache(obj *topologyv1.Resource) error {
 	}
 
 	_, err = c.db.ExecContext(
-		context.Background(),
+		ctx,
 		upsertQuery,
 		obj.Id,
 		obj.Pb.GetTypeUrl(),
@@ -111,12 +111,12 @@ func (c *client) SetCache(obj *topologyv1.Resource) error {
 	return nil
 }
 
-func (c *client) DeleteCache(obj *topologyv1.Resource) error {
+func (c *client) DeleteCache(ctx context.Context, obj *topologyv1.Resource) error {
 	const deleteQuery = `
 		DELETE FROM topology_cache WHERE id = $1
 	`
 
-	_, err := c.db.ExecContext(context.Background(), deleteQuery, obj.Id)
+	_, err := c.db.ExecContext(ctx, deleteQuery, obj.Id)
 	if err != nil {
 		c.scope.SubScope("topology.cache").Counter("cache.delete.failure").Inc(1)
 		return err

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 )
@@ -70,13 +71,13 @@ func convertLockIdToAdvisoryLockId(lockID string) uint32 {
 	return binary.BigEndian.Uint32(x)
 }
 
-// TODO (mcutalo): make this private once its in use
-func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
+// nolint:unused
+// TODO (mcutalo): remove lint directive once in use
+func (c *client) setCache(ctx context.Context, obj *topologyv1.Resource) error {
 	const upsertQuery = `
 		INSERT INTO topology_cache (id, resolver_type_url, data, metadata)
 		VALUES ($1, $2, $3, $4)
 		ON CONFLICT (id) DO UPDATE SET
-			id = EXCLUDED.id,
 			resolver_type_url = EXCLUDED.resolver_type_url,
 			data = EXCLUDED.data,
 			metadata = EXCLUDED.metadata,
@@ -89,7 +90,7 @@ func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
 		return err
 	}
 
-	dataJson, err := json.Marshal(obj.Pb.Value)
+	dataJson, err := protojson.Marshal(obj.Pb)
 	if err != nil {
 		c.scope.SubScope("cache").Counter("set.failure").Inc(1)
 		return err
@@ -112,8 +113,9 @@ func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
 	return nil
 }
 
-// TODO (mcutalo): make this private once its in use
-func (c *client) DeleteCache(ctx context.Context, id string) error {
+// nolint:unused
+// TODO (mcutalo): remove lint directive once in use
+func (c *client) deleteCache(ctx context.Context, id string) error {
 	const deleteQuery = `
 		DELETE FROM topology_cache WHERE id = $1
 	`

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -70,7 +70,7 @@ func convertLockIdToAdvisoryLockId(lockID string) uint32 {
 	return binary.BigEndian.Uint32(x)
 }
 
-func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
+func (c *client) setCache(ctx context.Context, obj *topologyv1.Resource) error {
 	const upsertQuery = `
 		INSERT INTO topology_cache (id, resolver_type_url, data, metadata)
 		VALUES ($1, $2, $3, $4)
@@ -111,7 +111,7 @@ func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
 	return nil
 }
 
-func (c *client) DeleteCache(ctx context.Context, id string) error {
+func (c *client) deleteCache(ctx context.Context, id string) error {
 	const deleteQuery = `
 		DELETE FROM topology_cache WHERE id = $1
 	`

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -70,7 +70,8 @@ func convertLockIdToAdvisoryLockId(lockID string) uint32 {
 	return binary.BigEndian.Uint32(x)
 }
 
-func (c *client) setCache(ctx context.Context, obj *topologyv1.Resource) error {
+// TODO (mcutalo): make this private once its in use
+func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
 	const upsertQuery = `
 		INSERT INTO topology_cache (id, resolver_type_url, data, metadata)
 		VALUES ($1, $2, $3, $4)
@@ -111,7 +112,8 @@ func (c *client) setCache(ctx context.Context, obj *topologyv1.Resource) error {
 	return nil
 }
 
-func (c *client) deleteCache(ctx context.Context, id string) error {
+// TODO (mcutalo): make this private once its in use
+func (c *client) DeleteCache(ctx context.Context, id string) error {
 	const deleteQuery = `
 		DELETE FROM topology_cache WHERE id = $1
 	`

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -84,13 +84,13 @@ func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
 
 	metadataJson, err := json.Marshal(obj.Metadata)
 	if err != nil {
-		c.scope.SubScope("topology.cache").Counter("cache.set.failure").Inc(1)
+		c.scope.SubScope("cache").Counter("set.failure").Inc(1)
 		return err
 	}
 
 	dataJson, err := json.Marshal(obj.Pb.Value)
 	if err != nil {
-		c.scope.SubScope("topology.cache").Counter("cache.set.failure").Inc(1)
+		c.scope.SubScope("cache").Counter("set.failure").Inc(1)
 		return err
 	}
 
@@ -103,25 +103,25 @@ func (c *client) SetCache(ctx context.Context, obj *topologyv1.Resource) error {
 		metadataJson,
 	)
 	if err != nil {
-		c.scope.SubScope("topology.cache").Counter("cache.set.failure").Inc(1)
+		c.scope.SubScope("cache").Counter("set.failure").Inc(1)
 		return err
 	}
 
-	c.scope.SubScope("topology.cache").Counter("cache.set.success").Inc(1)
+	c.scope.SubScope("cache").Counter("set.success").Inc(1)
 	return nil
 }
 
-func (c *client) DeleteCache(ctx context.Context, obj *topologyv1.Resource) error {
+func (c *client) DeleteCache(ctx context.Context, id string) error {
 	const deleteQuery = `
 		DELETE FROM topology_cache WHERE id = $1
 	`
 
-	_, err := c.db.ExecContext(ctx, deleteQuery, obj.Id)
+	_, err := c.db.ExecContext(ctx, deleteQuery, id)
 	if err != nil {
-		c.scope.SubScope("topology.cache").Counter("cache.delete.failure").Inc(1)
+		c.scope.SubScope("cache").Counter("delete.failure").Inc(1)
 		return err
 	}
 
-	c.scope.SubScope("topology.cache").Counter("cache.delete.success").Inc(1)
+	c.scope.SubScope("cache").Counter("delete.success").Inc(1)
 	return nil
 }

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -70,7 +70,7 @@ func convertLockIdToAdvisoryLockId(lockID string) uint32 {
 	return binary.BigEndian.Uint32(x)
 }
 
-func (c *client) SetCache(obj *topologyv1.Resource) {
+func (c *client) SetCache(obj *topologyv1.Resource) error {
 	const upsertQuery = `
 		INSERT INTO topology_cache (id, resolver_type_url, data, metadata)
 		VALUES ($1, $2, $3, $4)
@@ -85,13 +85,13 @@ func (c *client) SetCache(obj *topologyv1.Resource) {
 	metadataJson, err := json.Marshal(obj.Metadata)
 	if err != nil {
 		c.log.With(zap.Error(err)).Error("unable to marshal metadata")
-		return
+		return err
 	}
 
 	dataJson, err := json.Marshal(obj.Pb.Value)
 	if err != nil {
 		c.log.With(zap.Error(err)).Error("unable to marshal pb data")
-		return
+		return err
 	}
 
 	_, err = c.db.ExecContext(
@@ -105,6 +105,8 @@ func (c *client) SetCache(obj *topologyv1.Resource) {
 	if err != nil {
 		c.log.With(zap.Error(err)).Error("unable to upsert cache item")
 	}
+
+	return nil
 }
 
 func (c *client) DeleteCache(obj *topologyv1.Resource) {

--- a/backend/service/topology/cache_test.go
+++ b/backend/service/topology/cache_test.go
@@ -4,7 +4,14 @@ import (
 	"log"
 	"testing"
 
+	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
+
+	"database/sql/driver"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestConvertLockIdToAdvisoryLockId(t *testing.T) {
@@ -35,5 +42,46 @@ func TestConvertLockIdToAdvisoryLockId(t *testing.T) {
 			log.Printf("%v", id)
 			assert.Equal(t, tt.expect, id)
 		})
+	}
+}
+
+var topologyCacheColumns = []string{
+	"id",
+	"data",
+	"resolver_type_url",
+	"metadata",
+	"updated_at",
+}
+
+func TestSetCache(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+
+	topologyClient := &client{
+		log: log,
+		db:  db,
+	}
+
+	pb, err := ptypes.MarshalAny(&topologyv1.Resource{})
+	assert.NoError(t, err)
+
+	cacheItem := &topologyv1.Resource{
+		Id: "pod-name",
+		Pb: pb,
+		Metadata: map[string]string{
+			"key": "value",
+		},
+	}
+
+	mock.ExpectExec("INSERT INTO topology_cache (id, resolver_type_url, data, metadata) VALUES ($1, $2, $3, $4)").WithArgs([]driver.Value{
+		sqlmock.AnyArg(),
+	})
+
+	topologyClient.SetCache(cacheItem)
+
+	// we make sure that all expectations were met
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 }

--- a/backend/service/topology/cache_test.go
+++ b/backend/service/topology/cache_test.go
@@ -6,8 +6,6 @@ import (
 
 	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 
-	"database/sql/driver"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
@@ -54,8 +52,10 @@ var topologyCacheColumns = []string{
 }
 
 func TestSetCache(t *testing.T) {
+	t.Parallel()
+
 	log := zaptest.NewLogger(t)
-	db, mock, err := sqlmock.New()
+	db, _, err := sqlmock.New()
 	assert.NoError(t, err)
 
 	topologyClient := &client{
@@ -66,22 +66,68 @@ func TestSetCache(t *testing.T) {
 	pb, err := ptypes.MarshalAny(&topologyv1.Resource{})
 	assert.NoError(t, err)
 
-	cacheItem := &topologyv1.Resource{
-		Id: "pod-name",
-		Pb: pb,
-		Metadata: map[string]string{
-			"key": "value",
+	invalidInputTestCases := []struct {
+		id       string
+		cacheObj *topologyv1.Resource
+	}{
+		{
+			id: "no metadata",
+			cacheObj: &topologyv1.Resource{
+				Id: "pod-name",
+				Pb: pb,
+			},
+		},
+		{
+			id: "no protobuff",
+			cacheObj: &topologyv1.Resource{
+				Id: "pod-name",
+				Metadata: map[string]string{
+					"key": "value",
+				},
+			},
 		},
 	}
 
-	mock.ExpectExec("INSERT INTO topology_cache (id, resolver_type_url, data, metadata) VALUES ($1, $2, $3, $4)").WithArgs([]driver.Value{
-		sqlmock.AnyArg(),
-	})
+	for _, tt := range invalidInputTestCases {
+		tt := tt
+		t.Run(tt.id, func(t *testing.T) {
+			t.Parallel()
 
-	topologyClient.SetCache(cacheItem)
-
-	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expectations: %s", err)
+			err = topologyClient.SetCache(tt.cacheObj)
+			assert.NoError(t, err)
+		})
 	}
 }
+
+// func TestSetCache(t *testing.T) {
+// 	log := zaptest.NewLogger(t)
+// 	db, mock, err := sqlmock.New()
+// 	assert.NoError(t, err)
+
+// 	topologyClient := &client{
+// 		log: log,
+// 		db:  db,
+// 	}
+
+// 	pb, err := ptypes.MarshalAny(&topologyv1.Resource{})
+// 	assert.NoError(t, err)
+
+// 	cacheItem := &topologyv1.Resource{
+// 		Id: "pod-name",
+// 		Pb: pb,
+// 		Metadata: map[string]string{
+// 			"key": "value",
+// 		},
+// 	}
+
+// 	mock.ExpectExec("INSERT INTO topology_cache (id, resolver_type_url, data, metadata) VALUES ($1, $2, $3, $4)").WithArgs([]driver.Value{
+// 		sqlmock.AnyArg(),
+// 	})
+
+// 	topologyClient.SetCache(cacheItem)
+
+// 	// we make sure that all expectations were met
+// 	if err := mock.ExpectationsWereMet(); err != nil {
+// 		t.Errorf("there were unfulfilled expectations: %s", err)
+// 	}
+// }

--- a/backend/service/topology/cache_test.go
+++ b/backend/service/topology/cache_test.go
@@ -4,12 +4,7 @@ import (
 	"log"
 	"testing"
 
-	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
-
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestConvertLockIdToAdvisoryLockId(t *testing.T) {
@@ -42,92 +37,3 @@ func TestConvertLockIdToAdvisoryLockId(t *testing.T) {
 		})
 	}
 }
-
-var topologyCacheColumns = []string{
-	"id",
-	"data",
-	"resolver_type_url",
-	"metadata",
-	"updated_at",
-}
-
-func TestSetCache(t *testing.T) {
-	t.Parallel()
-
-	log := zaptest.NewLogger(t)
-	db, _, err := sqlmock.New()
-	assert.NoError(t, err)
-
-	topologyClient := &client{
-		log: log,
-		db:  db,
-	}
-
-	pb, err := ptypes.MarshalAny(&topologyv1.Resource{})
-	assert.NoError(t, err)
-
-	invalidInputTestCases := []struct {
-		id       string
-		cacheObj *topologyv1.Resource
-	}{
-		{
-			id: "no metadata",
-			cacheObj: &topologyv1.Resource{
-				Id: "pod-name",
-				Pb: pb,
-			},
-		},
-		{
-			id: "no protobuff",
-			cacheObj: &topologyv1.Resource{
-				Id: "pod-name",
-				Metadata: map[string]string{
-					"key": "value",
-				},
-			},
-		},
-	}
-
-	for _, tt := range invalidInputTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-
-			err = topologyClient.SetCache(tt.cacheObj)
-			assert.NoError(t, err)
-		})
-	}
-}
-
-// func TestSetCache(t *testing.T) {
-// 	log := zaptest.NewLogger(t)
-// 	db, mock, err := sqlmock.New()
-// 	assert.NoError(t, err)
-
-// 	topologyClient := &client{
-// 		log: log,
-// 		db:  db,
-// 	}
-
-// 	pb, err := ptypes.MarshalAny(&topologyv1.Resource{})
-// 	assert.NoError(t, err)
-
-// 	cacheItem := &topologyv1.Resource{
-// 		Id: "pod-name",
-// 		Pb: pb,
-// 		Metadata: map[string]string{
-// 			"key": "value",
-// 		},
-// 	}
-
-// 	mock.ExpectExec("INSERT INTO topology_cache (id, resolver_type_url, data, metadata) VALUES ($1, $2, $3, $4)").WithArgs([]driver.Value{
-// 		sqlmock.AnyArg(),
-// 	})
-
-// 	topologyClient.SetCache(cacheItem)
-
-// 	// we make sure that all expectations were met
-// 	if err := mock.ExpectationsWereMet(); err != nil {
-// 		t.Errorf("there were unfulfilled expectations: %s", err)
-// 	}
-// }

--- a/backend/service/topology/topology.go
+++ b/backend/service/topology/topology.go
@@ -11,17 +11,13 @@ import (
 	"golang.org/x/net/context"
 
 	topologyv1cfg "github.com/lyft/clutch/backend/api/config/service/topology/v1"
-	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 	"github.com/lyft/clutch/backend/service"
 	pgservice "github.com/lyft/clutch/backend/service/db/postgres"
 )
 
 const Name = "clutch.service.topology"
 
-type Service interface {
-	SetCache(obj *topologyv1.Resource) error
-	DeleteCache(obj *topologyv1.Resource) error
-}
+type Service interface{}
 
 type client struct {
 	config *topologyv1cfg.Config

--- a/backend/service/topology/topology.go
+++ b/backend/service/topology/topology.go
@@ -10,17 +10,21 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 
-	topologyv1 "github.com/lyft/clutch/backend/api/config/service/topology/v1"
+	topologyv1cfg "github.com/lyft/clutch/backend/api/config/service/topology/v1"
+	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 	"github.com/lyft/clutch/backend/service"
 	pgservice "github.com/lyft/clutch/backend/service/db/postgres"
 )
 
 const Name = "clutch.service.topology"
 
-type Service interface{}
+type Service interface {
+	SetCache(obj *topologyv1.Resource) error
+	DeleteCache(obj *topologyv1.Resource) error
+}
 
 type client struct {
-	config *topologyv1.Config
+	config *topologyv1cfg.Config
 
 	db    *sql.DB
 	log   *zap.Logger
@@ -28,7 +32,7 @@ type client struct {
 }
 
 func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, error) {
-	topologyConfig := &topologyv1.Config{}
+	topologyConfig := &topologyv1cfg.Config{}
 	err := ptypes.UnmarshalAny(cfg, topologyConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Implements some of the basic caching functionality needed to make progress on the Topology API #30. 

I did think about making this functionality public, however for consistency across services they should implement the standardized interface to populate cache by implementing the [CacheableTopology](https://github.com/lyft/clutch/pull/362/files#diff-a352069dcb53d7f4a25245319d355ea8R39-R48) interface.

### Testing Performed
Manual with https://github.com/lyft/clutch/pull/362 test implementation. 

### GitHub Issue
This PR makes progress on the Topology API story #30
