### PR TITLE
ci: use docusaurus monorepo group in renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
     ":separateMultipleMajorReleases",
     ":unpublishSafe",
     "group:definitelyTyped",
+    "group:docusaurusMonorepo",
     "group:materialMonorepo",
     "group:reactMonorepo",
     "group:reactrouterMonorepo"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Update renovatebot config to group docusaurus dependency updates.
