### PR TITLE
ui: fix checkbox panel

### DIFF
--- a/frontend/packages/core/src/Input/checkbox.tsx
+++ b/frontend/packages/core/src/Input/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = styled(MuiCheckbox)`
   `}
 `;
 
-interface CheckboxPanelProps {
+export interface CheckboxPanelProps {
   header?: string;
   options: {
     [option: string]: boolean;
@@ -53,41 +53,51 @@ const CheckboxPanel: React.FC<CheckboxPanelProps> = ({ header, options, onChange
   };
 
   const optionKeys = Object.keys(allOptions);
-  const column1Keys = [...optionKeys].splice(0, optionKeys.length / 2);
-  const column2Keys = [...optionKeys].splice(column1Keys.length + 1, optionKeys.length);
+  const column1Keys = [...optionKeys].splice(0, Math.ceil(optionKeys.length / 2));
+  const column2Keys = [...optionKeys].splice(column1Keys.length, optionKeys.length);
 
   return (
     <FormControl>
-      <Grid container direction="row" justify="center" alignItems="stretch">
-        <FormLabel color="secondary" component="legend">
+      <Grid container direction="column">
+        <FormLabel color="secondary" focused>
           {header}
         </FormLabel>
-        <FormGroup>
-          {column1Keys.map(option => (
-            <FormGroup row key={option}>
-              <FormControlLabel
-                key={option}
-                control={
-                  <Checkbox checked={selected[option].checked} onChange={onToggle} name={option} />
-                }
-                label={option}
-              />
-            </FormGroup>
-          ))}
-        </FormGroup>
-        <FormGroup>
-          {column2Keys.map(option => (
-            <FormGroup row key={option}>
-              <FormControlLabel
-                key={option}
-                control={
-                  <Checkbox checked={selected[option].checked} onChange={onToggle} name={option} />
-                }
-                label={option}
-              />
-            </FormGroup>
-          ))}
-        </FormGroup>
+        <Grid container direction="row">
+          <FormGroup>
+            {column1Keys.map(option => (
+              <FormGroup row key={option}>
+                <FormControlLabel
+                  key={option}
+                  control={
+                    <Checkbox
+                      checked={selected[option].checked}
+                      onChange={onToggle}
+                      name={option}
+                    />
+                  }
+                  label={option}
+                />
+              </FormGroup>
+            ))}
+          </FormGroup>
+          <FormGroup>
+            {column2Keys.map(option => (
+              <FormGroup row key={option}>
+                <FormControlLabel
+                  key={option}
+                  control={
+                    <Checkbox
+                      checked={selected[option].checked}
+                      onChange={onToggle}
+                      name={option}
+                    />
+                  }
+                  label={option}
+                />
+              </FormGroup>
+            ))}
+          </FormGroup>
+        </Grid>
       </Grid>
     </FormControl>
   );

--- a/frontend/packages/core/src/Input/stories/checkbox.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/checkbox.stories.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import type { Meta } from "@storybook/react";
+
+import type { CheckboxPanelProps } from "../checkbox";
+import CheckboxPanel from "../checkbox";
+
+export default {
+  title: "Core/Input/CheckboxPanel",
+  component: CheckboxPanel,
+  argTypes: {
+    onChange: { action: "onChange event" },
+  },
+} as Meta;
+
+const Template = (props: CheckboxPanelProps) => <CheckboxPanel {...props} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  header: "Select all that apply:",
+  options: {
+    "Option 1": false,
+    "Option 2": false,
+    "Option 3": false,
+  },
+};


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
The checkbox panel splits the options list into 2 in order to present the as siblings. If the list is an odd number the result of the first list ends up being a float which rounds to the nearest whole number and drops an option.

This PR also:
- fixes the checkbox panel heading alignment and color
- add a story for the Checkbox Panel

![Screen Shot 2020-10-02 at 2 00 30 PM](https://user-images.githubusercontent.com/1004789/94969542-caa0e380-04b7-11eb-8a4c-6bddd2f6b982.png)
