### PR TITLE
core: gateway initialize stats SubScope with component name

### DIFF
--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -97,7 +97,7 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 		}
 
 		logger.Info("registering service")
-		svc, err := factory(svcConfig.TypedConfig, logger, scope.SubScope("service"))
+		svc, err := factory(svcConfig.TypedConfig, logger, scope.SubScope(svcConfig.Name))
 		if err != nil {
 			logger.Fatal("service instantiation failed", zap.Error(err))
 		}
@@ -119,7 +119,7 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 		}
 
 		logger.Info("registering resolver")
-		res, err := factory(resolverCfg.TypedConfig, logger, scope.SubScope("resolver"))
+		res, err := factory(resolverCfg.TypedConfig, logger, scope.SubScope(resolverCfg.Name))
 		if err != nil {
 			logger.Fatal("resolver instantiation failed", zap.Error(err))
 		}
@@ -200,7 +200,7 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 		}
 
 		logger.Info("registering module")
-		mod, err := factory(modCfg.TypedConfig, logger, scope.SubScope("module"))
+		mod, err := factory(modCfg.TypedConfig, logger, scope.SubScope(modCfg.Name))
 		if err != nil {
 			logger.Fatal("module instantiation failed", zap.Error(err))
 		}

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -20,6 +21,11 @@ import (
 	"github.com/lyft/clutch/backend/resolver"
 	"github.com/lyft/clutch/backend/service"
 )
+
+// The purpose of this identifier is to trim the prefix off clutch component names,
+// such as services, modules and resolver.
+// This is used when constructing the stats namespace for a given component.
+const clutchComponentPrefix = "clutch."
 
 // All available components supply their factory here.
 // Whether or not they are used at runtime is dependent on the configuration passed to the Gateway.
@@ -97,7 +103,8 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 		}
 
 		logger.Info("registering service")
-		svc, err := factory(svcConfig.TypedConfig, logger, scope.SubScope(svcConfig.Name))
+		svc, err := factory(svcConfig.TypedConfig, logger, scope.SubScope(
+			strings.TrimPrefix(svcConfig.Name, clutchComponentPrefix)))
 		if err != nil {
 			logger.Fatal("service instantiation failed", zap.Error(err))
 		}
@@ -119,7 +126,8 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 		}
 
 		logger.Info("registering resolver")
-		res, err := factory(resolverCfg.TypedConfig, logger, scope.SubScope(resolverCfg.Name))
+		res, err := factory(resolverCfg.TypedConfig, logger, scope.SubScope(
+			strings.TrimPrefix(resolverCfg.Name, clutchComponentPrefix)))
 		if err != nil {
 			logger.Fatal("resolver instantiation failed", zap.Error(err))
 		}
@@ -200,7 +208,8 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 		}
 
 		logger.Info("registering module")
-		mod, err := factory(modCfg.TypedConfig, logger, scope.SubScope(modCfg.Name))
+		mod, err := factory(modCfg.TypedConfig, logger, scope.SubScope(
+			strings.TrimPrefix(modCfg.Name, clutchComponentPrefix)))
 		if err != nil {
 			logger.Fatal("module instantiation failed", zap.Error(err))
 		}

--- a/backend/module/chaos/experimentation/api/experimentation.go
+++ b/backend/module/chaos/experimentation/api/experimentation.go
@@ -45,14 +45,13 @@ func New(_ *any.Any, logger *zap.Logger, scope tally.Scope) (module.Module, erro
 		return nil, errors.New("service was not the correct type")
 	}
 
-	apiScope := scope.SubScope("experimentation")
 	return &Service{
 		experimentStore:             experimentStore,
 		logger:                      logger.Sugar(),
-		createExperimentStat:        apiScope.Counter("create_experiment"),
-		getExperimentsStat:          apiScope.Counter("get_experiments"),
-		getExperimentRunDetailsStat: apiScope.Counter("get_experiment_run_config_pair_details"),
-		cancelExperimentRunStat:     apiScope.Counter("cancel_experiment_run"),
+		createExperimentStat:        scope.Counter("create_experiment"),
+		getExperimentsStat:          scope.Counter("get_experiments"),
+		getExperimentRunDetailsStat: scope.Counter("get_experiment_run_config_pair_details"),
+		cancelExperimentRunStat:     scope.Counter("cancel_experiment_run"),
 	}, nil
 }
 

--- a/backend/module/chaos/serverexperimentation/rtds/rtds.go
+++ b/backend/module/chaos/serverexperimentation/rtds/rtds.go
@@ -107,7 +107,6 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (module.Module, er
 
 	gcpCacheV3 := gcpCacheV3.NewSnapshotCache(false, ClusterHashV3{}, logger.Sugar())
 	gcpCacheV2 := gcpCacheV2.NewSnapshotCache(false, ClusterHashV2{}, logger.Sugar())
-	rtdsScope := scope.SubScope("rtds")
 
 	return &Server{
 		ctx:                  context.Background(),
@@ -116,8 +115,8 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (module.Module, er
 		snapshotCacheV3:      gcpCacheV3,
 		cacheRefreshInterval: cacheRefreshInterval,
 		rtdsLayerName:        rtdsLayerName,
-		totalStreams:         rtdsScope.Gauge("totalStreams"),
-		totalResourcesServed: rtdsScope.Counter("totalResourcesServed"),
+		totalStreams:         scope.Gauge("totalStreams"),
+		totalResourcesServed: scope.Counter("totalResourcesServed"),
 		logger:               logger.Sugar(),
 	}, nil
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Include the name of the components thats being registered as the stats `SubScope`.

### Testing Performed
<!-- Describe how you tested this change below. -->
n/a
