### PR TITLE
migrate: dont error if there are no changes to apply

### DIFF
--- a/backend/cmd/migrate/migrate.go
+++ b/backend/cmd/migrate/migrate.go
@@ -128,7 +128,7 @@ func Run() {
 	// Apply migrations!
 	logger.Info("applying migrations", zap.String("migrationDir", migrationDir))
 	err = m.Up()
-	if err != nil {
+	if err != nil && err != migrate.ErrNoChange {
 		logger.Fatal("failed running migrations", zap.Error(err))
 	}
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Currently, migrate script errors out if there are no changes

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Tested by manually running the migration script 

Output before change 
```
2020-10-07T22:46:41.090Z	INFO	migrate/migrate.go:85	using database	{"hostInfo": "clutch_admin@<db_url>:5432"}
2020-10-07T22:46:41.147Z	INFO	migrate/migrate.go:129	applying migrations	{"migrationDir": "<path_to_migration_files>"}
2020-10-07T22:46:41.151Z	FATAL	migrate/migrate.go:132	failed running migrations	{"error": "no change"}
exit status 1
```

Output after change 
```
2020-10-07T22:44:14.955Z	INFO	migrate/migrate.go:85	using database	{"hostInfo": "clutch_admin@<db_url>:5432"}
2020-10-07T22:44:14.997Z	INFO	migrate/migrate.go:129	applying migrations	{"migrationDir": "<path_to_migration_files>"}
```

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #[528](https://github.com/lyft/clutch/issues/528)

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
