### PR TITLE
text field: fix date types with labels

### DIFF
--- a/frontend/packages/core/src/Input/stories/text-field.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/text-field.stories.tsx
@@ -26,3 +26,10 @@ WithLabel.args = {
   placeholder: "",
   label: "TextField",
 };
+
+export const WithType = Template.bind({});
+WithType.args = {
+  ...Primary.args,
+  label: "Date",
+  type: "datetime-local",
+};

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -29,6 +29,7 @@ const TextField: React.FC<TextFieldProps & MuiTextFieldProps> = ({
   onReturn,
   maxWidth,
   placeholder,
+  type,
   ...props
 }) => {
   const onKeyDown = (
@@ -46,7 +47,9 @@ const TextField: React.FC<TextFieldProps & MuiTextFieldProps> = ({
     color: "secondary",
   } as Partial<InputLabelProps>;
 
-  if (placeholder) {
+  const placeholderInputTypes = ["date", "datetime-local", "month", "time", "week"];
+  const hasInputPlaceholder = placeholderInputTypes.indexOf(type) !== -1;
+  if (placeholder || hasInputPlaceholder) {
     inputLabelProps.shrink = true;
   }
 
@@ -59,6 +62,7 @@ const TextField: React.FC<TextFieldProps & MuiTextFieldProps> = ({
       onFocus={onChange}
       onBlur={onChange}
       placeholder={placeholder}
+      type={type}
       {...props}
     />
   );


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Fix Text Field component to prevent any [input type that has a placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types) from being obscured by a label.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2020-10-07 at 7 26 53 PM](https://user-images.githubusercontent.com/1004789/95407948-4396a580-08d3-11eb-894b-a81c482e15f9.png)


### Testing Performed
<!-- Describe how you tested this change below. -->
manual & added story
