### PR TITLE
experimentation: RTDS to disable fault if GetExperiments call to DB fails

### DIFF
--- a/backend/module/chaos/serverexperimentation/rtds/rtds_cache.go
+++ b/backend/module/chaos/serverexperimentation/rtds/rtds_cache.go
@@ -115,7 +115,9 @@ func refreshCache(ctx context.Context, storer experimentstore.Storer, snapshotCa
 	allExperiments, err := storer.GetExperiments(ctx, "type.googleapis.com/clutch.chaos.serverexperimentation.v1.TestConfig", experimentation.GetExperimentsRequest_RUNNING)
 	if err != nil {
 		logger.Errorw("Failed to get data from experiments store", "error", err)
-		return
+
+		// If failed to get data from DB, stop all ongoing faults.
+		allExperiments = []*experimentation.Experiment{}
 	}
 
 	// Group faults by upstream cluster


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
While performing a periodic RTDS cache refresh, [GetExperiments call](https://github.com/lyft/clutch/blob/7974eeb457c478eb431b76f557843c27becdf917/backend/module/chaos/serverexperimentation/rtds/rtds_cache.go#L115) gets all the server experiments from DB. Currently, if this call fails, we do nothing. 

Going forward, we will disable all the active server experiments if DB call fails as a safety mechanism
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
