### PR TITLE
aws: topology caching for aws resources

### DIFF
--- a/backend/clutch-config.yaml
+++ b/backend/clutch-config.yaml
@@ -24,16 +24,6 @@ modules:
   - name: clutch.module.k8s
   - name: clutch.module.kinesis
 services:
-  - name: clutch.service.db.postgres
-    typed_config:
-      "@type": types.google.com/clutch.config.service.db.postgres.v1.Config
-      connection:
-        host: 0.0.0.0
-        port: 5432
-        user: clutch
-        ssl_mode: DISABLE
-        dbname: clutch
-        password: clutch
   - name: clutch.service.aws
     typed_config:
       "@type": types.google.com/clutch.config.service.aws.v1.Config
@@ -48,9 +38,6 @@ services:
   - name: clutch.service.k8s
     typed_config:
       "@type": types.google.com/clutch.config.service.k8s.v1.Config
-  - name: clutch.service.topology
-    typed_config:
-      "@type": types.google.com/clutch.config.service.topology.v1.Config
 resolvers:
   - name: clutch.resolver.aws
   - name: clutch.resolver.k8s

--- a/backend/clutch-config.yaml
+++ b/backend/clutch-config.yaml
@@ -24,6 +24,16 @@ modules:
   - name: clutch.module.k8s
   - name: clutch.module.kinesis
 services:
+  - name: clutch.service.db.postgres
+    typed_config:
+      "@type": types.google.com/clutch.config.service.db.postgres.v1.Config
+      connection:
+        host: 0.0.0.0
+        port: 5432
+        user: clutch
+        ssl_mode: DISABLE
+        dbname: clutch
+        password: clutch
   - name: clutch.service.aws
     typed_config:
       "@type": types.google.com/clutch.config.service.aws.v1.Config
@@ -38,6 +48,9 @@ services:
   - name: clutch.service.k8s
     typed_config:
       "@type": types.google.com/clutch.config.service.k8s.v1.Config
+  - name: clutch.service.topology
+    typed_config:
+      "@type": types.google.com/clutch.config.service.topology.v1.Config
 resolvers:
   - name: clutch.resolver.aws
   - name: clutch.resolver.k8s

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -46,7 +46,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 
 	c := &client{
 		clients:            make(map[string]*regionalClient, len(ac.Regions)),
-		topologyObjectChan: make(chan *topologyv1.UpdateCacheRequest, 5000),
+		topologyObjectChan: make(chan *topologyv1.UpdateCacheRequest, topologyObjectChanBufferSize),
 		log:                logger,
 		scope:              scope,
 	}

--- a/backend/service/aws/cache.go
+++ b/backend/service/aws/cache.go
@@ -51,14 +51,16 @@ func (c *client) processRegionTopologyObjects(ctx context.Context) {
 
 func (c *client) startTickerForCacheResource(ctx context.Context, duration time.Duration, client *regionalClient, resourceFunc func(context.Context, *regionalClient)) {
 	ticker := time.NewTicker(duration)
-
-	go func() {
-		<-ctx.Done()
-		ticker.Stop()
-	}()
-
-	for ; true; <-ticker.C {
+	for {
 		resourceFunc(ctx, client)
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		}
 	}
 }
 

--- a/backend/service/aws/cache.go
+++ b/backend/service/aws/cache.go
@@ -7,34 +7,36 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/golang/protobuf/ptypes"
 	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
 
+const topologyObjectChanBufferSize = 5000
+
 func (c *client) CacheEnabled() bool {
 	return true
 }
 
 func (c *client) StartTopologyCaching(ctx context.Context) <-chan *topologyv1.UpdateCacheRequest {
-	for name, client := range c.clients {
-		c.log.Info("starting topology caching for region", zap.String("region", name))
-		go c.processRegionTopologyObjects(ctx, client)
-	}
-
+	go c.processRegionTopologyObjects(ctx)
 	return c.topologyObjectChan
 }
 
-func (c *client) processRegionTopologyObjects(ctx context.Context, client *regionalClient) {
+func (c *client) processRegionTopologyObjects(ctx context.Context) {
 	ticker := time.NewTicker(time.Minute * 30)
 
 	for ; true; <-ticker.C {
-		eg, _ := errgroup.WithContext(context.Background())
+		eg, _ := errgroup.WithContext(ctx)
 
-		eg.Go(func() error { return c.processAllEC2Instances(ctx, client) })
-		eg.Go(func() error { return c.processAllAutoScalingGroups(ctx, client) })
-		// eg.Go(func() error { return c.getAllKinesisStreams(ctx, client) })
+		for name, client := range c.clients {
+			c.log.Info("processing topology objects for region", zap.String("region", name))
+			eg.Go(func() error { return c.processAllEC2Instances(ctx, client) })
+			eg.Go(func() error { return c.processAllAutoScalingGroups(ctx, client) })
+			eg.Go(func() error { return c.processAllKinesisStreams(ctx, client) })
+		}
 
 		if err := eg.Wait(); err != nil {
 			c.log.Error("errors", zap.Error(err))
@@ -90,9 +92,26 @@ func (c *client) processAllEC2Instances(ctx context.Context, client *regionalCli
 		})
 }
 
-// func (c *client) processAllKinesisStreams(ctx context.Context, client *regionalClient) error {
-// 	input := kinesis.DescribeStreamInput{
-// 		Max
-// 	}
-// 	return nil
-// }
+func (c *client) processAllKinesisStreams(ctx context.Context, client *regionalClient) error {
+	input := kinesis.ListStreamsInput{
+		Limit: aws.Int64(100),
+	}
+
+	return client.kinesis.ListStreamsPagesWithContext(ctx, &input,
+		func(page *kinesis.ListStreamsOutput, lastPage bool) bool {
+
+			for _, stream := range page.StreamNames {
+				v1Stream, _ := c.DescribeKinesisStream(ctx, client.region, *stream)
+				protoStream, _ := ptypes.MarshalAny(v1Stream)
+				c.topologyObjectChan <- &topologyv1.UpdateCacheRequest{
+					Resource: &topologyv1.Resource{
+						Id: v1Stream.StreamName,
+						Pb: protoStream,
+					},
+					Action: topologyv1.UpdateCacheRequest_CREATE_OR_UPDATE,
+				}
+			}
+
+			return !lastPage
+		})
+}

--- a/backend/service/aws/cache.go
+++ b/backend/service/aws/cache.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/protobuf/ptypes"
+	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+func (c *client) CacheEnabled() bool {
+	return true
+}
+
+func (c *client) StartTopologyCaching(ctx context.Context) <-chan *topologyv1.UpdateCacheRequest {
+	for name, client := range c.clients {
+		c.log.Info("starting topology caching for region", zap.String("region", name))
+		go c.processRegionTopologyObjects(ctx, client)
+	}
+
+	return c.topologyObjectChan
+}
+
+func (c *client) processRegionTopologyObjects(ctx context.Context, client *regionalClient) {
+	ticker := time.NewTicker(time.Minute * 30)
+
+	for ; true; <-ticker.C {
+		eg, _ := errgroup.WithContext(context.Background())
+
+		eg.Go(func() error { return c.processAllEC2Instances(ctx, client) })
+		eg.Go(func() error { return c.processAllAutoScalingGroups(ctx, client) })
+		// eg.Go(func() error { return c.getAllKinesisStreams(ctx, client) })
+
+		if err := eg.Wait(); err != nil {
+			c.log.Error("errors", zap.Error(err))
+		}
+	}
+}
+
+func (c *client) processAllAutoScalingGroups(ctx context.Context, client *regionalClient) error {
+	input := autoscaling.DescribeAutoScalingGroupsInput{
+		MaxRecords: aws.Int64(100),
+	}
+
+	return client.autoscaling.DescribeAutoScalingGroupsPagesWithContext(ctx, &input,
+		func(page *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
+
+			for _, asg := range page.AutoScalingGroups {
+				protoAsg, _ := ptypes.MarshalAny(newProtoForAutoscalingGroup(asg))
+				c.topologyObjectChan <- &topologyv1.UpdateCacheRequest{
+					Resource: &topologyv1.Resource{
+						Id: *asg.AutoScalingGroupName,
+						Pb: protoAsg,
+					},
+					Action: topologyv1.UpdateCacheRequest_CREATE_OR_UPDATE,
+				}
+			}
+
+			return !lastPage
+		})
+}
+
+func (c *client) processAllEC2Instances(ctx context.Context, client *regionalClient) error {
+	input := ec2.DescribeInstancesInput{
+		MaxResults: aws.Int64(1000),
+	}
+
+	return client.ec2.DescribeInstancesPagesWithContext(ctx, &input,
+		func(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
+
+			for _, reservation := range page.Reservations {
+				for _, instance := range reservation.Instances {
+					protoInstance, _ := ptypes.MarshalAny(newProtoForInstance(instance))
+					c.topologyObjectChan <- &topologyv1.UpdateCacheRequest{
+						Resource: &topologyv1.Resource{
+							Id: *instance.InstanceId,
+							Pb: protoInstance,
+						},
+						Action: topologyv1.UpdateCacheRequest_CREATE_OR_UPDATE,
+					}
+				}
+			}
+
+			return !lastPage
+		})
+}
+
+// func (c *client) processAllKinesisStreams(ctx context.Context, client *regionalClient) error {
+// 	input := kinesis.DescribeStreamInput{
+// 		Max
+// 	}
+// 	return nil
+// }

--- a/backend/service/aws/cache_test.go
+++ b/backend/service/aws/cache_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"testing"
 
-	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/semaphore"
+
+	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 )
 
 func TestStartTopologyCache(t *testing.T) {
+	log := zaptest.NewLogger(t)
 	c := client{
 		topologyObjectChan: make(chan *topologyv1.UpdateCacheRequest, topologyObjectChanBufferSize),
 		topologyLock:       semaphore.NewWeighted(1),
+		log:                log,
 	}
 
 	buff, err := c.StartTopologyCaching(context.Background())

--- a/backend/service/aws/cache_test.go
+++ b/backend/service/aws/cache_test.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestStartTopologyCache(t *testing.T) {
+	c := client{
+		topologyObjectChan: make(chan *topologyv1.UpdateCacheRequest, topologyObjectChanBufferSize),
+		topologyLock:       semaphore.NewWeighted(1),
+	}
+
+	buff, err := c.StartTopologyCaching(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, buff)
+
+	// Asserts that the topologyLock has already been aquired
+	_, err = c.StartTopologyCaching(context.Background())
+	assert.Error(t, err)
+}

--- a/backend/service/aws/cache_test.go
+++ b/backend/service/aws/cache_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
@@ -26,4 +27,27 @@ func TestStartTopologyCache(t *testing.T) {
 	// Asserts that the topologyLock has already been aquired
 	_, err = c.StartTopologyCaching(context.Background())
 	assert.Error(t, err)
+}
+
+func TestStartTickerForCacheResource(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := client{}
+
+	// This lets us track the number of invocations to processFakeResource()
+	numProcessFakeResourceCalls := 0
+
+	processFakeResource := func(ctx context.Context, client *regionalClient) {
+		numProcessFakeResourceCalls++
+	}
+
+	go func() {
+		// Give the ticker time to tick at least once
+		time.Sleep(time.Second)
+		cancel()
+	}()
+
+	c.startTickerForCacheResource(ctx, time.Millisecond, &regionalClient{}, processFakeResource)
+
+	// This asserts that we setup a ticker, it was invoked at least once, and the cancel context was successful.
+	assert.Greater(t, numProcessFakeResourceCalls, 0)
 }

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -39,7 +39,7 @@ func (s *svc) StartTopologyCaching(ctx context.Context) (<-chan *topologyv1.Upda
 	// There should only ever be one instances of all the informers for topology caching
 	// We lock here until the context is closed
 	if !s.topologyInformerLock.TryAcquire(topologyInformerLockId) {
-		return nil, errors.New("TopologyCahing is already in progress")
+		return nil, errors.New("TopologyCaching is already in progress")
 	}
 
 	for name, cs := range s.manager.Clientsets() {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Topology caching for AWS. Currently we will cache all AWS objects that clutch can operate on, this includes ASG's, EC2 Instances and Kinesis Streams.

Also cleaned up a few spelling mistakes in this pr.

### Testing Performed
Unit \ Locally.

### GitHub Issue
This PR makes progress on the Topology API #30 issue.