### PR TITLE
experimentation: improve the detection of cell selection

### DIFF
--- a/frontend/workflows/experimentation/src/list-view.tsx
+++ b/frontend/workflows/experimentation/src/list-view.tsx
@@ -158,7 +158,7 @@ const ListView: React.FC<ListViewProps> = ({ columns, items, onRowSelection }) =
                     return (
                       <TableRow
                         hover
-                        onClick={event => handleClick(event, item)}
+                        onSelect={event => handleClick(event, item)}
                         key={item.identifier.toString()}
                       >
                         {columns &&


### PR DESCRIPTION
### Description
Detect cell selection by using `onSelect` and not `onClick` so that a user can select a text in table row without triggering a navigation to experiment details view.


| Before | After |
| ----- | ------ |
|![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/4410346/96063160-30905200-0e4c-11eb-90d0-faf2aeaae243.gif)|![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/4410346/96063164-35550600-0e4c-11eb-8a14-0dceb7e2e96b.gif)|

### Testing Performed
See attached GIF

