### PR TITLE
chaos: fix missing store error message

### DIFF
--- a/backend/module/chaos/experimentation/api/experimentation.go
+++ b/backend/module/chaos/experimentation/api/experimentation.go
@@ -43,7 +43,7 @@ func New(_ *any.Any, logger *zap.Logger, scope tally.Scope) (module.Module, erro
 
 	experimentStore, ok := store.(experimentstore.Storer)
 	if !ok {
-		return nil, errors.New("service was not the correct type")
+		return nil, errors.New("could not find valid experiment store")
 	}
 
 	return &Service{


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

The existing error message implies there is a misconfiguration of the service when in reality the store being misconfigured or missing entirely is the real issue.

### Testing Performed
<!-- Describe how you tested this change below. -->

Manual
