### PR TITLE
storybook: add button story for default and destructive variant

### DIFF
--- a/frontend/packages/core/src/button.stories.tsx
+++ b/frontend/packages/core/src/button.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { Meta } from "@storybook/react";
+
+import type { ButtonProps } from './button'
+
+import { Button } from './button';
+
+export default {
+  title: 'Core/Button/Button',
+  component: Button,
+
+} as Meta;
+
+const Template = (props: ButtonProps) => <Button {...props} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  text: "click here",
+};
+
+export const Destructive  = Template.bind({});
+Destructive.args = {
+  ...Default.args,
+  text: "delete",
+  destructive: true,
+};

--- a/frontend/packages/core/src/button.stories.tsx
+++ b/frontend/packages/core/src/button.stories.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
+import React from "react";
 import type { Meta } from "@storybook/react";
 
-import type { ButtonProps } from './button'
-
-import { Button } from './button';
+import type { ButtonProps } from "./button";
+import { Button } from "./button";
 
 export default {
-  title: 'Core/Button/Button',
+  title: "Core/Button",
   component: Button,
-
+  argTypes: {
+    onClick: { action: "onClick event" },
+  },
 } as Meta;
 
 const Template = (props: ButtonProps) => <Button {...props} />;
@@ -18,9 +19,8 @@ Default.args = {
   text: "click here",
 };
 
-export const Destructive  = Template.bind({});
+export const Destructive = Template.bind({});
 Destructive.args = {
-  ...Default.args,
   text: "delete",
   destructive: true,
 };

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -20,7 +20,7 @@ const StyledButton = styled(MuiButton)`
 `;
 
 interface ButtonProps
-  extends Pick<MuiButtonProps, "endIcon" | "color" | "onClick" | "size" | "type" | "variant"> {
+  extends Pick<MuiButtonProps, "endIcon" | "onClick" | "size" | "type" | "variant"> {
   text: string;
   destructive?: boolean;
 }

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -19,7 +19,8 @@ const StyledButton = styled(MuiButton)`
   `}
 `;
 
-interface ButtonProps extends MuiButtonProps {
+interface ButtonProps
+  extends Pick<MuiButtonProps, "endIcon" | "color" | "onClick" | "size" | "type" | "variant"> {
   text: string;
   destructive?: boolean;
 }

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -20,7 +20,10 @@ const StyledButton = styled(MuiButton)`
 `;
 
 interface ButtonProps
-  extends Pick<MuiButtonProps, "disabled" | "endIcon" | "onClick" | "size" | "startIcon" | "type" | "variant"> {
+  extends Pick<
+    MuiButtonProps,
+    "disabled" | "endIcon" | "onClick" | "size" | "startIcon" | "type" | "variant"
+  > {
   text: string;
   destructive?: boolean;
 }

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -20,7 +20,7 @@ const StyledButton = styled(MuiButton)`
 `;
 
 interface ButtonProps
-  extends Pick<MuiButtonProps, "endIcon" | "onClick" | "size" | "type" | "variant"> {
+  extends Pick<MuiButtonProps, "disabled" | "endIcon" | "onClick" | "size" | "startIcon" | "type" | "variant"> {
   text: string;
   destructive?: boolean;
 }

--- a/frontend/packages/core/src/stories/button.stories.tsx
+++ b/frontend/packages/core/src/stories/button.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
 
-import type { ButtonProps } from "./button";
-import { Button } from "./button";
+import type { ButtonProps } from "../button";
+import { Button } from "../button";
 
 export default {
   title: "Core/Button",
@@ -16,7 +16,7 @@ const Template = (props: ButtonProps) => <Button {...props} />;
 
 export const Default = Template.bind({});
 Default.args = {
-  text: "click here",
+  text: "continue",
 };
 
 export const Destructive = Template.bind({});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,7 +20,8 @@
   },
   "exclude": [
     "node_modules",
-    "**/stories/*",
+    "**/*.stories.ts*",
+    "**/*.stories.js*",
     "**/*.test.js*",
     "**/*.test.ts*"
   ],


### PR DESCRIPTION
### Description
PR adds a story for a button, with two variant types: default and destructive


![button_story_3](https://user-images.githubusercontent.com/39421794/96467828-583f3b80-11f9-11eb-9baf-7fb66bdee884.gif)

(Update: removed `color` prop and added `disabled`, `startIcon` in recent commits)

![Screen Shot 2020-10-19 at 3 18 07 PM](https://user-images.githubusercontent.com/39421794/96501640-a155b680-121e-11eb-896f-23bddc5446cc.png)


### Testing Performed
Locally

And ran through one of the workflows with Button components
![resize_button_gif](https://user-images.githubusercontent.com/39421794/96467886-6e4cfc00-11f9-11eb-9e21-d4b0b277afa1.gif)