### PR TITLE
topology: cache expiry

### DIFF
--- a/backend/clutch-config.yaml
+++ b/backend/clutch-config.yaml
@@ -24,16 +24,6 @@ modules:
   - name: clutch.module.k8s
   - name: clutch.module.kinesis
 services:
-  - name: clutch.service.db.postgres
-    typed_config:
-      "@type": types.google.com/clutch.config.service.db.postgres.v1.Config
-      connection:
-        host: 0.0.0.0
-        port: 5432
-        user: clutch
-        ssl_mode: DISABLE
-        dbname: clutch
-        password: clutch
   - name: clutch.service.aws
     typed_config:
       "@type": types.google.com/clutch.config.service.aws.v1.Config
@@ -48,9 +38,6 @@ services:
   - name: clutch.service.k8s
     typed_config:
       "@type": types.google.com/clutch.config.service.k8s.v1.Config
-  - name: clutch.service.topology
-    typed_config:
-      "@type": types.google.com/clutch.config.service.topology.v1.Config
 resolvers:
   - name: clutch.resolver.aws
   - name: clutch.resolver.k8s

--- a/backend/clutch-config.yaml
+++ b/backend/clutch-config.yaml
@@ -24,6 +24,16 @@ modules:
   - name: clutch.module.k8s
   - name: clutch.module.kinesis
 services:
+  - name: clutch.service.db.postgres
+    typed_config:
+      "@type": types.google.com/clutch.config.service.db.postgres.v1.Config
+      connection:
+        host: 0.0.0.0
+        port: 5432
+        user: clutch
+        ssl_mode: DISABLE
+        dbname: clutch
+        password: clutch
   - name: clutch.service.aws
     typed_config:
       "@type": types.google.com/clutch.config.service.aws.v1.Config
@@ -38,6 +48,9 @@ services:
   - name: clutch.service.k8s
     typed_config:
       "@type": types.google.com/clutch.config.service.k8s.v1.Config
+  - name: clutch.service.topology
+    typed_config:
+      "@type": types.google.com/clutch.config.service.topology.v1.Config
 resolvers:
   - name: clutch.resolver.aws
   - name: clutch.resolver.k8s

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -184,14 +184,17 @@ func (c *client) expireCache(ctx context.Context) {
 	for {
 		result, err := c.db.ExecContext(ctx, expireQuery)
 		if err != nil {
+			c.scope.SubScope("cache").Counter("expire.failure").Inc(1)
 			c.log.Error("unable to expire cache", zap.Error(err))
 			continue
 		}
 
 		numOfItemsRemoved, err := result.RowsAffected()
 		if err != nil {
+			c.scope.SubScope("cache").Counter("expire.failure").Inc(1)
 			c.log.Error("unable to get rows removed from cache expiry query", zap.Error(err))
 		} else {
+			c.scope.SubScope("cache").Counter("expire.success").Inc(1)
 			c.log.Info("successfully removed expired cache", zap.Int64("count", numOfItemsRemoved))
 		}
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Expire topology cache that is older than 2 hours.

### Testing Performed
Tested locally by reducing the expiry time to 60 seconds.

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->
This PR makes progress on the Topology API #30 issue.
