### PR TITLE
core: log protos with custom field

### DIFF
--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -232,7 +232,7 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 	case *gatewayv1.Listener_Tcp:
 		// OK
 	default:
-		logger.Fatal("socket not supported", zap.Any("type", t))
+		logger.Fatal("socket not supported", zap.String("type", fmt.Sprintf("%T", t)))
 	}
 
 	if cfg.Gateway.Listener.GetTcp().Secure {

--- a/backend/gateway/log/log.go
+++ b/backend/gateway/log/log.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// ProtoField returns a zap field that logs as the embedded JSON representation of the Protobuf message.
 func ProtoField(key string, m proto.Message) zap.Field {
 	b, err := protojson.Marshal(m)
 	if err != nil {

--- a/backend/gateway/log/log.go
+++ b/backend/gateway/log/log.go
@@ -1,0 +1,17 @@
+package log
+
+import (
+	"encoding/json"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func ProtoField(key string, m proto.Message) zap.Field {
+	b, err := protojson.Marshal(m)
+	if err != nil {
+		return zap.Any(key, m)
+	}
+	return zap.Any(key, json.RawMessage(b))
+}

--- a/backend/gateway/log/log_test.go
+++ b/backend/gateway/log/log_test.go
@@ -1,0 +1,35 @@
+package log
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	healthcheckv1 "github.com/lyft/clutch/backend/api/healthcheck/v1"
+)
+
+func Test(t *testing.T) {
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+
+	logger := zap.New(
+		zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(w), zap.DebugLevel),
+	)
+
+	r := &healthcheckv1.HealthcheckRequest{}
+	a, _ := ptypes.MarshalAny(r)
+
+	logger.Info("test", ProtoField("key", a))
+	assert.NoError(t, logger.Sync())
+	assert.NoError(t, w.Flush())
+
+	o := make(map[string]interface{})
+	assert.NoError(t, json.Unmarshal(b.Bytes(), &o))
+	assert.Contains(t, b.String(), `{"@type":"type.googleapis.com/clutch.healthcheck.v1.HealthcheckRequest"}`)
+}

--- a/backend/gateway/log/log_test.go
+++ b/backend/gateway/log/log_test.go
@@ -14,7 +14,7 @@ import (
 	healthcheckv1 "github.com/lyft/clutch/backend/api/healthcheck/v1"
 )
 
-func Test(t *testing.T) {
+func TestProtoField(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -799,6 +799,7 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tj/assert v0.0.0-20171129193455-018094318fb0 h1:Rw8kxzWo1mr6FSaYXjQELRe88y2KdfynXdnK72rdjtA=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=

--- a/backend/middleware/audit/audit.go
+++ b/backend/middleware/audit/audit.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"
+	"github.com/lyft/clutch/backend/gateway/log"
 	"github.com/lyft/clutch/backend/gateway/meta"
 	"github.com/lyft/clutch/backend/middleware"
 	"github.com/lyft/clutch/backend/service"
@@ -72,8 +73,8 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 
 			if auditErr := m.audit.UpdateRequestEvent(ctx, id, update); auditErr != nil {
 				m.logger.Warn("error updating audit event",
-					zap.Int64("auditID", id),
-					zap.Any("update event", update),
+					zap.Int64("auditId", id),
+					log.ProtoField("updateEvent", update),
 				)
 			}
 		}

--- a/backend/middleware/audit/audit.go
+++ b/backend/middleware/audit/audit.go
@@ -73,7 +73,7 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 
 			if auditErr := m.audit.UpdateRequestEvent(ctx, id, update); auditErr != nil {
 				m.logger.Warn("error updating audit event",
-					zap.Int64("auditId", id),
+					zap.Int64("auditID", id),
 					log.ProtoField("updateEvent", update),
 				)
 			}

--- a/backend/service/audit/sql.go
+++ b/backend/service/audit/sql.go
@@ -14,6 +14,7 @@ import (
 
 	apiv1 "github.com/lyft/clutch/backend/api/api/v1"
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"
+	"github.com/lyft/clutch/backend/gateway/log"
 )
 
 func (c *client) WriteRequestEvent(ctx context.Context, event *auditv1.RequestEvent) (int64, error) {
@@ -81,7 +82,7 @@ func (c *client) UpdateRequestEvent(ctx context.Context, id int64, update *audit
 		c.logger.Warn(
 			"error updating audit row",
 			zap.Int64("row_id", id),
-			zap.Any("event", update),
+			log.ProtoField("event", update),
 			zap.Error(err),
 		)
 		return err

--- a/backend/service/auditsink/logger/logger.go
+++ b/backend/service/auditsink/logger/logger.go
@@ -12,6 +12,7 @@ import (
 
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"
 	configv1 "github.com/lyft/clutch/backend/api/config/service/audit/v1"
+	"github.com/lyft/clutch/backend/gateway/log"
 	"github.com/lyft/clutch/backend/service"
 	"github.com/lyft/clutch/backend/service/auditsink"
 )
@@ -37,7 +38,7 @@ type svc struct {
 
 func (s *svc) Write(event *auditv1.Event) error {
 	if auditsink.Filter(s.filter, event) {
-		s.logger.Info("new audit event", zap.Any("event", event))
+		s.logger.Info("new audit event", log.ProtoField("event", event))
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
Spent awhile trying to figure out how to add a hook in the logger to automatically intercept Any fields containing proto messages and fixing them automatically. I think it's possible but couldn't get it to work.

For now this PR introduces a custom field that logs correctly. I also went through and replaced any existing improper usages of zap.Any. Will have to rely on code review for now to ensure people use the correct field.

### Testing Performed
Unit