### PR TITLE
storybook: add select story & add CSS fixes

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -7,18 +7,10 @@ import {
 } from "@material-ui/core";
 import styled from "styled-components";
 
-const InputLabel = styled(MuiInputLabel)`
-  ${({ theme }) => `
-  && {
-    color: ${theme.palette.text.primary};
-  }
-  `}
-`;
-
 const FormControl = styled(MuiFormControl)`
   ${({ theme, ...props }) => `
   display: flex;
-  width: 100%;
+  min-width: fit-content;
   max-width: ${props["data-max-width"] || "500px"};
   .MuiInput-underline:after {
     border-bottom: 2px solid ${theme.palette.accent.main};
@@ -26,13 +18,19 @@ const FormControl = styled(MuiFormControl)`
   `}
 `;
 
-const StyledSelect = styled(MuiSelect)`
-  ${({ ...props }) => `
-  display: flex;
-  margin: 16px 0;
-  width: 100%;
-  max-width: ${props["data-max-width"] || "500px"};
+const InputLabel = styled(MuiInputLabel)`
+  ${({ theme }) => `
+  && {
+    color: ${theme.palette.text.primary};
+  }
+  position: relative;
   `}
+`;
+
+const StyledSelect = styled(MuiSelect)`
+  && {
+    margin-top: 0px;
+  }
 `;
 
 interface SelectOption {
@@ -40,9 +38,9 @@ interface SelectOption {
   value?: string;
 }
 
-interface SelectProps {
+export interface SelectProps {
   defaultOption?: number;
-  label: string;
+  label?: string;
   maxWidth?: string;
   name: string;
   options: SelectOption[];
@@ -72,18 +70,21 @@ const Select: React.FC<SelectProps> = ({
   };
 
   React.useEffect(() => {
-    onChange(options[selectedIdx].value || options[selectedIdx].label);
+    onChange(options[selectedIdx]?.value || options[selectedIdx].label);
   }, []);
 
   return (
     <FormControl key={name} data-max-width={maxWidth}>
-      <InputLabel color="secondary">{label}</InputLabel>
+      <InputLabel shrink color="secondary">
+        {label}
+      </InputLabel>
       <StyledSelect
-        value={options[selectedIdx].value || options[selectedIdx].label}
+        value={options[selectedIdx]?.value || options[selectedIdx].label}
         onChange={updateSelectedOption}
+        fullWidth
       >
         {options.map(option => (
-          <MenuItem key={option.label} value={option.value || option.label}>
+          <MenuItem key={option.label} value={option?.value || option?.label}>
             {option.label}
           </MenuItem>
         ))}

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -84,7 +84,7 @@ const Select: React.FC<SelectProps> = ({
         fullWidth
       >
         {options.map(option => (
-          <MenuItem key={option.label} value={option?.value || option?.label}>
+          <MenuItem key={option.label} value={option?.value || option.label}>
             {option.label}
           </MenuItem>
         ))}

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -64,7 +64,7 @@ const Select: React.FC<SelectProps> = ({
 
   const updateSelectedOption = (event: React.ChangeEvent<{ name?: string; value: string }>) => {
     const { value } = event.target;
-    const optionValues = options.map(o => o.value || o.label);
+    const optionValues = options.map(o => o?.value || o.label);
     setSelectedIdx(optionValues.indexOf(value));
     onChange(value);
   };

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -11,7 +11,7 @@ const FormControl = styled(MuiFormControl)`
   ${({ theme, ...props }) => `
   display: flex;
   min-width: fit-content;
-  max-width: ${props["data-max-width"] || "500px"};
+  width: ${props["data-max-width"] || "500px"};
   .MuiInput-underline:after {
     border-bottom: 2px solid ${theme.palette.accent.main};
   }

--- a/frontend/packages/core/src/Input/stories/select.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/select.stories.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import type { Meta } from "@storybook/react";
+
+import type { SelectProps } from "../select";
+import Select from "../select";
+
+export default {
+  title: "Core/Input/Select",
+  component: Select,
+  argTypes: {
+    onChange: { action: "onChange event" },
+    options: { control: { type: "object" } },
+  },
+} as Meta;
+
+const Template = (props: SelectProps) => <Select name="demo" {...props} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  options: [
+    {
+      label: "option 1",
+    },
+    {
+      label: "option 2",
+    },
+  ],
+};
+
+export const CustomValues = Template.bind({});
+CustomValues.args = {
+  options: [
+    {
+      label: "option 1",
+      value: "value 1",
+    },
+    {
+      label: "option 2",
+      value: "value 2",
+    },
+  ],
+};
+
+export const WithLabel = Template.bind({});
+WithLabel.argTypes = {
+  defaultOption: {
+    control: {
+      type: "select",
+      options: Primary.args.options.map((_: any, i: number) => i),
+    },
+  },
+};
+WithLabel.args = {
+  ...Primary.args,
+  defaultOption: 0,
+  label: "Please select one",
+  maxWidth: "100px",
+};


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add new story for the Select component. This also includes various style fixes and cleanup to Select in order to prevent the label from overlaying on top of the select window when the specified width < label text length.

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![select](https://user-images.githubusercontent.com/1004789/96300823-13be6080-0fab-11eb-97d1-7343d28fcda8.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual