### PR TITLE
housekeeping: fix react hook form peer dependency warning

### DIFF
--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@clutch-sh/api": "^0.0.0-beta",
     "@date-io/core": "^1.3.6",
-    "@hookform/devtools": "^2.0.4",
+    "@hookform/devtools": "^2.2.1",
     "@hookform/resolvers": "^1.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -41,7 +41,7 @@
     "material-table": "1.69.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-hook-form": "^6.3.0",
+    "react-hook-form": "^6.9.2",
     "react-is": "^16.8.0",
     "react-router": "^6.0.0-beta",
     "react-router-dom": "^6.0.0-beta",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2744,10 +2744,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@hookform/devtools@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@hookform/devtools/-/devtools-2.0.4.tgz#f4291d10af76fb6b3de6b2455a1a20764e1cfa57"
-  integrity sha512-+qP6U21Lxuuxc3BTqdB0XQlngckC2KAF5Eq82Ox0Fx/SWzCdYqpJ00siGZkdfZ0bIiUHeR7/gI8tS6rRTXHsfQ==
+"@hookform/devtools@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@hookform/devtools/-/devtools-2.2.1.tgz#2d88414d375199e193c2611b770b194b7752a623"
+  integrity sha512-VQh4kqwUOpz9LCDzIP0aJ4qnD/ob8Gp09L8gDy++9XtL66z6g8kbCynUvBrJm4qbCNdH0M7/Spm3AUjJqUuFlA==
   dependencies:
     "@emotion/core" "^10.0.28"
     "@emotion/styled" "^10.0.27"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16678,10 +16678,10 @@ react-hook-form@^6.0.8:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.0.8.tgz#29319df417c8ba68ee7ce497426c53a69df07aa5"
   integrity sha512-lf1TTuRuqHkYJqDtNIgDu9Rk7euKWkFaG2+XZ3FSkngiFWR72Lj96/FeSGF+ZMylCLdCFq2F059kzucVKWvDiQ==
 
-react-hook-form@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.3.0.tgz#5c1926d51d4532f44818ef73f96d1a8c11015a76"
-  integrity sha512-Xz7xxnILftxttc6H+miTSi2eYPehiW3XdsPaqY5dW8HcURFZPrnpxnmaRqz6JtZcbfRM8qjjppP/pOBaUzhn4w==
+react-hook-form@^6.9.2:
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.2.tgz#9512cd424e62235fda13c8fc1821f88c352e3d23"
+  integrity sha512-vCPEbHVCRvsoqrQARgQ7a3VrXzqbFOO53gHFRdQzLzHMT9kxum3wfcSi8A1b49KPRsomvsqexH4tBUJMneEu+Q==
 
 react-hook-thunk-reducer@^0.2.1:
   version "0.2.4"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixing react hook form peer dependency warning but including an additional update to hookform/devtools as it's required for the latest react-hook-form package.

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual
