### PR TITLE
frontend: sanitize dictionaries in metadata table table cell

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -54,9 +54,14 @@ interface ViewOnlyRowProps {
 
 const ViewOnlyRow: React.FC<ViewOnlyRowProps> = ({ data, size }) => {
   let { value } = data;
+
   if (data.value instanceof Array && data.value.length > 1) {
     value = data.value.join(", ");
   }
+  if (!React.isValidElement(data.value)) {
+    value = JSON.stringify(data.value);
+  }
+
   return (
     <TableRow key={data.id}>
       <KeyCell data={data} size={size} />


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Sanitize Table Cell dictionaries before attempting to render their data by casting them to strings.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manually tested this correctly renders React elements and dictionaries in existing workflows
