### PR TITLE
audit: localstorage simplification

### DIFF
--- a/backend/service/audit/storage/local/localstore.go
+++ b/backend/service/audit/storage/local/localstore.go
@@ -44,9 +44,7 @@ func (c *client) UnsentEvents(ctx context.Context) ([]*auditv1.Event, error) {
 	defer c.Unlock()
 
 	unsent := make([]*auditv1.Event, 0, len(c.events))
-	for _, v := range c.events {
-		unsent = append(unsent, v)
-	}
+	unsent = append(unsent, c.events...)
 	c.events = make([]*auditv1.Event, 0)
 
 	return unsent, nil


### PR DESCRIPTION
CI found the tests for this hanging before being killed. Isolated it to a
comparison for the `RequestEvent` returned after an update. The tests were
relying on `map` iteration order during `range` being the same as insertion
order. That's not the case!

This changes that by changing the underlying storage because a map indexed by an
integer has mostly the same interface as a slice. Verified locally with `go test
-count 1000000 ./service/audit/storage/local`.

Still unsure why the tests are hanging on an equality assertion, but that's an
upstream fix and making this green/reducing dev flake comes first.
