### PR TITLE
core: start moving to v2 golang protobuf apis

### DIFF
--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -10,14 +10,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"text/template"
-	"time"
 
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
-	durpb "github.com/golang/protobuf/ptypes/duration"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/yaml.v3"
 
 	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
@@ -126,22 +123,12 @@ func parseYAML(contents []byte, pb proto.Message) error {
 	}
 
 	// Unmarshal JSON to proto object.
-	if err := jsonpb.Unmarshal(jsonBuffer, pb); err != nil {
+	if err := protojson.Unmarshal(jsonBuffer.Bytes(), pb); err != nil {
 		return err
 	}
 
 	// All good!
 	return nil
-}
-
-// Helper "must" function to convert proto durations to Go durations. This should only be called during bootstrap where
-// a panic is not a problem. Config validation should also prevent the panic from ever occurring.
-func duration(p *durpb.Duration) time.Duration {
-	d, err := ptypes.Duration(p)
-	if err != nil {
-		panic(err)
-	}
-	return d
 }
 
 func newLogger(msg *gatewayv1.Logger) (*zap.Logger, error) {
@@ -183,15 +170,17 @@ type validator interface {
 	Validate() error
 }
 
-func validateAny(a *any.Any) error {
+func validateAny(a *anypb.Any) error {
 	if a == nil {
 		return nil
 	}
-	var pb ptypes.DynamicAny
-	if err := ptypes.UnmarshalAny(a, &pb); err != nil {
+
+	m, err := a.UnmarshalNew()
+	if err != nil {
 		return err
 	}
-	if v, ok := pb.Message.(validator); ok {
+
+	if v, ok := m.(validator); ok {
 		return v.Validate()
 	}
 	return nil

--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -117,13 +117,13 @@ func parseYAML(contents []byte, pb proto.Message) error {
 	}
 
 	// Encode YAML to JSON.
-	jsonBuffer := new(bytes.Buffer)
-	if err := json.NewEncoder(jsonBuffer).Encode(rawConfig); err != nil {
+	rawJSON, err := json.Marshal(rawConfig)
+	if err != nil {
 		return err
 	}
 
 	// Unmarshal JSON to proto object.
-	if err := protojson.Unmarshal(jsonBuffer.Bytes(), pb); err != nil {
+	if err := protojson.Unmarshal(rawJSON, pb); err != nil {
 		return err
 	}
 

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -76,7 +76,7 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 			Reporter: reporter,
 			Prefix:   "clutch",
 		},
-		duration(cfg.Gateway.Stats.FlushInterval),
+		cfg.Gateway.Stats.FlushInterval.AsDuration(),
 	)
 	defer func() {
 		if err := scopeCloser.Close(); err != nil {

--- a/backend/gateway/meta/meta.go
+++ b/backend/gateway/meta/meta.go
@@ -2,16 +2,14 @@ package meta
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 
-	"github.com/golang/protobuf/descriptor"
-	"github.com/golang/protobuf/proto"
-	"github.com/iancoleman/strcase"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	apiv1 "github.com/lyft/clutch/backend/api/api/v1"
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"
@@ -22,6 +20,10 @@ var (
 	methodDescriptors map[string]*desc.MethodDescriptor
 
 	fieldNameRegexp = regexp.MustCompile(`{(\w+)}`)
+
+	actionTypeDescriptor     = apiv1.E_Action.TypeDescriptor()
+	identifierTypeDescriptor = apiv1.E_Id.TypeDescriptor()
+	referenceTypeDescriptor  = apiv1.E_Reference.TypeDescriptor()
 )
 
 func GenerateGRPCMetadata(server *grpc.Server) error {
@@ -47,49 +49,37 @@ func GetAction(method string) apiv1.ActionType {
 	if !ok {
 		return apiv1.ActionType_UNSPECIFIED
 	}
-
 	opts := md.GetMethodOptions()
-	ext, err := proto.GetExtension(opts, apiv1.E_Action)
-	if err != nil {
-		return apiv1.ActionType_UNSPECIFIED
-	}
 
-	action := ext.(*apiv1.Action)
-	return action.Type
+	v := opts.ProtoReflect().Get(actionTypeDescriptor)
+	return v.Message().Interface().(*apiv1.Action).Type
 }
 
-func ResourceNames(message descriptor.Message) []*auditv1.Resource {
-	_, descriptorMeta := descriptor.ForMessage(message)
-	if proto.HasExtension(descriptorMeta.Options, apiv1.E_Id) {
-		idExt, err := proto.GetExtension(descriptorMeta.Options, apiv1.E_Id)
-		if err != nil {
-			return nil
-		}
+func ResourceNames(pb proto.Message) []*auditv1.Resource {
+	m := pb.ProtoReflect()
+	opts := m.Descriptor().Options().ProtoReflect()
 
-		id := idExt.(*apiv1.Identifier)
+	if opts.Has(identifierTypeDescriptor) {
+		v := opts.Get(identifierTypeDescriptor)
+		id := v.Message().Interface().(*apiv1.Identifier)
 
 		names := make([]*auditv1.Resource, 0, len(id.Patterns))
 		for _, pattern := range id.Patterns {
-			if newName := resolvePattern(message, pattern); newName != nil {
-				names = append(names, resolvePattern(message, pattern))
+			if newName := resolvePattern(pb, pattern); newName != nil {
+				names = append(names, newName)
 			}
 		}
-
 		return names
 	}
 
-	if proto.HasExtension(descriptorMeta.Options, apiv1.E_Reference) {
-		refExt, err := proto.GetExtension(descriptorMeta.Options, apiv1.E_Reference)
-		if err != nil {
-			return nil
-		}
-
-		ref := refExt.(*apiv1.Reference)
+	if opts.Has(referenceTypeDescriptor) {
+		v := opts.Get(referenceTypeDescriptor)
+		ref := v.Message().Interface().(*apiv1.Reference)
 
 		// Best effort to avoid reallocations.
 		names := make([]*auditv1.Resource, 0, len(ref.Fields))
 		for _, field := range ref.Fields {
-			for _, resolved := range resolveField(message, field) {
+			for _, resolved := range resolveField(pb, field) {
 				if resolved == nil {
 					continue
 				}
@@ -103,71 +93,44 @@ func ResourceNames(message descriptor.Message) []*auditv1.Resource {
 	return nil
 }
 
-func resolveField(message descriptor.Message, field string) []*auditv1.Resource {
-	// Loop through fields by name looking for field
-	rvalue := reflect.ValueOf(message)
-	if rvalue.Kind() == reflect.Ptr {
-		rvalue = rvalue.Elem()
+func resolveField(pb proto.Message, name string) []*auditv1.Resource {
+	m := pb.ProtoReflect()
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+
+	v := m.Get(fd)
+
+	if fd.IsList() {
+		return resolveSlice(v.List())
 	}
 
-	// Somehow we haven't ended up with a proto message, kick out.
-	if rvalue.Kind() != reflect.Struct {
-		return nil
-	}
-
-	title := strcase.ToCamel(field)
-	value := rvalue.FieldByName(title)
-
-	// If we're looking at a slice (i.e. a repeated field), then resolve the name for each element.
-	if value.Kind() == reflect.Slice {
-		return resolveSlice(value)
-	}
-
-	// Otherwise, resolve for the plain type field here.
-	message, ok := value.Interface().(descriptor.Message)
-	if !ok {
-		return nil
-	}
-	return ResourceNames(message)
+	return ResourceNames(v.Message().Interface())
 }
 
-func resolveSlice(value reflect.Value) []*auditv1.Resource {
+func resolveSlice(list protoreflect.List) []*auditv1.Resource {
 	var resources []*auditv1.Resource
-	for i := 0; i < value.Len(); i++ {
-		item := value.Index(i)
-		message, ok := item.Interface().(descriptor.Message)
-		if !ok {
-			continue
-		}
-
-		if resolved := ResourceNames(message); resolved != nil {
-			resources = append(resources, resolved...)
-		}
+	for i := 0; i < list.Len(); i++ {
+		v := list.Get(i)
+		resources = append(resources, ResourceNames(v.Message().Interface())...)
 	}
 	return resources
 }
 
-func resolvePattern(message descriptor.Message, pattern *apiv1.Pattern) *auditv1.Resource {
-	rvalue := reflect.ValueOf(message)
-	if rvalue.Kind() == reflect.Ptr {
-		rvalue = rvalue.Elem()
-	}
-
-	// Somehow we haven't ended up with a proto message, kick out.
-	if rvalue.Kind() != reflect.Struct {
-		return nil
-	}
+func resolvePattern(pb proto.Message, pattern *apiv1.Pattern) *auditv1.Resource {
+	m := pb.ProtoReflect()
+	fields := m.Descriptor().Fields()
 
 	resourceName := pattern.Pattern
 
-	substitutions := fieldNameRegexp.FindAllStringSubmatch(resourceName, -1)
+	substitutions := fieldNameRegexp.FindAllStringSubmatch(pattern.Pattern, -1)
 	for _, name := range substitutions {
-		// TODO: precompute name to field number? Would speed this up.
-		title := strcase.ToCamel(name[1])
-		// Get field by title
-		resolved := rvalue.FieldByName(title).String()
-		resourceName = strings.Replace(resourceName, name[0], resolved, 1)
+		fd := fields.ByName(protoreflect.Name(name[1]))
+		if fd == nil {
+			continue
+		}
+		if m.Has(fd) {
+			v := m.Get(fd)
+			resourceName = strings.Replace(resourceName, name[0], v.String(), 1)
+		}
 	}
-
 	return &auditv1.Resource{TypeUrl: pattern.TypeUrl, Id: resourceName}
 }

--- a/backend/gateway/meta/meta_test.go
+++ b/backend/gateway/meta/meta_test.go
@@ -38,6 +38,9 @@ func TestGetAction(t *testing.T) {
 	_ = &healthcheckv1.HealthcheckRequest{} // Ensure it's imported.
 	action := GetAction("/clutch.healthcheck.v1.HealthcheckAPI/Healthcheck")
 	assert.Equal(t, apiv1.ActionType_READ, action)
+
+	action = GetAction("/nonexistent/doesnotexist")
+	assert.Equal(t, apiv1.ActionType_UNSPECIFIED, action)
 }
 
 func TestResourceNames(t *testing.T) {

--- a/backend/gateway/meta/meta_test.go
+++ b/backend/gateway/meta/meta_test.go
@@ -3,10 +3,9 @@ package meta
 import (
 	"testing"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	apiv1 "github.com/lyft/clutch/backend/api/api/v1"
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"

--- a/backend/gateway/meta/meta_test.go
+++ b/backend/gateway/meta/meta_test.go
@@ -3,7 +3,8 @@ package meta
 import (
 	"testing"
 
-	"github.com/golang/protobuf/descriptor"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 
@@ -50,7 +51,7 @@ func TestResourceNames(t *testing.T) {
 
 	tests := []struct {
 		id      string
-		message descriptor.Message
+		message proto.Message
 		names   []*auditv1.Resource
 	}{
 		{
@@ -99,7 +100,6 @@ func TestResourceNames(t *testing.T) {
 		tt := tt
 		t.Run(tt.id, func(t *testing.T) {
 			t.Parallel()
-
 			resolvedNames := ResourceNames(tt.message)
 			assert.Len(t, resolvedNames, len(tt.names))
 			for i := range resolvedNames {

--- a/backend/middleware/audit/audit.go
+++ b/backend/middleware/audit/audit.go
@@ -8,14 +8,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"
 	"github.com/lyft/clutch/backend/gateway/log"

--- a/backend/middleware/audit/audit.go
+++ b/backend/middleware/audit/audit.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/golang/protobuf/descriptor"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -28,7 +28,7 @@ import (
 
 const Name = "clutch.middleware.audit"
 
-func New(_ *any.Any, logger *zap.Logger, scope tally.Scope) (middleware.Middleware, error) {
+func New(_ *anypb.Any, logger *zap.Logger, scope tally.Scope) (middleware.Middleware, error) {
 	svc, ok := service.Registry[auditservice.Name]
 	if !ok {
 		return nil, fmt.Errorf("no audit svc with path '%s' registered for middleware", auditservice.Name)
@@ -91,7 +91,7 @@ func (m *mid) eventFromRequest(ctx context.Context, req interface{}, info *grpc.
 		ServiceName: svc,
 		MethodName:  method,
 		Type:        meta.GetAction(info.FullMethod),
-		Resources:   meta.ResourceNames(req.(descriptor.Message)),
+		Resources:   meta.ResourceNames(req.(proto.Message)),
 	}
 }
 
@@ -103,6 +103,6 @@ func (m *mid) eventFromResponse(resp interface{}, err error) *auditv1.RequestEve
 
 	return &auditv1.RequestEvent{
 		Status:    s.Proto(),
-		Resources: meta.ResourceNames(resp.(descriptor.Message)),
+		Resources: meta.ResourceNames(resp.(proto.Message)),
 	}
 }

--- a/backend/middleware/authz/authz.go
+++ b/backend/middleware/authz/authz.go
@@ -7,8 +7,8 @@ package authz
 import (
 	"context"
 	"errors"
+	"google.golang.org/protobuf/proto"
 
-	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
@@ -79,7 +79,7 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 		}
 
 		actionType := meta.GetAction(info.FullMethod)
-		resources := meta.ResourceNames(req.(descriptor.Message))
+		resources := meta.ResourceNames(req.(proto.Message))
 
 		subject := &authzv1.Subject{
 			User:   claims.Subject,

--- a/backend/middleware/authz/authz.go
+++ b/backend/middleware/authz/authz.go
@@ -7,14 +7,14 @@ package authz
 import (
 	"context"
 	"errors"
-	"google.golang.org/protobuf/proto"
 
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	authzv1 "github.com/lyft/clutch/backend/api/authz/v1"
 	"github.com/lyft/clutch/backend/gateway/meta"
@@ -33,7 +33,7 @@ var allowlist = []string{
 	"/clutch.healthcheck.v1.HealthcheckAPI/*",
 }
 
-func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (middleware.Middleware, error) {
+func New(cfg *anypb.Any, logger *zap.Logger, scope tally.Scope) (middleware.Middleware, error) {
 	svc, ok := service.Registry["clutch.service.authz"]
 	if !ok {
 		return nil, errors.New("unable to get authz service")


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
After moving to grpc-gateway v2, we can now start moving to the v2 protobuf Go APIs detailed at https://blog.golang.org/protobuf-apiv2

### Testing Performed
Unit

### TODOs
- [x] review coverage and add tests as needed