### PR TITLE
docs: fix key name for in-memory audit config

### DIFF
--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -195,7 +195,7 @@ services:
   - name: clutch.service.audit
     typed_config:
       "@type": types.google.com/clutch.config.service.audit.v1.Config
-      local_auditing: true
+      in_memory: true
       filter:
         denylist: true
         rules:


### PR DESCRIPTION
### Description

Updating to correct key name: https://github.com/lyft/clutch/blob/d0d808ed0c6a5798d991be00eac19fb96a0dc301/api/config/service/audit/v1/audit.proto#L52