### PR TITLE
storybook: add error stories

### DIFF
--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -117,7 +117,7 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
   return (
     <Loadable isLoading={state.schemasLoading}>
       {state.schemaFetchError !== "" ? (
-        <Error message={state.schemaFetchError} retry={() => loadSchemas(type, dispatch)} />
+        <Error message={state.schemaFetchError} onRetry={() => loadSchemas(type, dispatch)} />
       ) : (
         <Loadable variant="overlay" isLoading={state.resolverLoading}>
           {process.env.REACT_APP_DEBUG_FORMS === "true" && <DevTool control={validation.control} />}

--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -15,19 +15,19 @@ import styled from "styled-components";
 
 const PANEL_MESSAGE_BREAKPOINT = 150;
 
-interface ErrorProps {
+export interface ErrorProps {
   message: string;
-  retry?: () => void;
+  onRetry?: () => void;
 }
 
 const Alert = styled(MuiAlert)`
   margin: 5px;
 `;
 
-const Error: React.FC<ErrorProps> = ({ message, retry }) => {
+const Error: React.FC<ErrorProps> = ({ message, onRetry }) => {
   const action =
-    retry !== undefined ? (
-      <IconButton aria-label="retry" color="inherit" size="small" onClick={() => retry()}>
+    onRetry !== undefined ? (
+      <IconButton aria-label="retry" color="inherit" size="small" onClick={() => onRetry()}>
         <RefreshIcon />
       </IconButton>
     ) : null;

--- a/frontend/packages/core/src/stories/error.stories.tsx
+++ b/frontend/packages/core/src/stories/error.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+// TODO: remove when https://github.com/lyft/clutch/pull/607/files#r512255592 lands
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from "@storybook/addon-actions";
+import type { Meta } from "@storybook/react";
+
+import type { ErrorProps } from "../error";
+import { Error } from "../error";
+
+export default {
+  title: "Core/Error",
+  component: Error,
+} as Meta;
+
+const Template = (props: ErrorProps) => <Error {...props} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  message: "An error occurred",
+};
+
+export const Retry = Template.bind({});
+Retry.args = {
+  ...Primary.args,
+  onRetry: action("retry-click"),
+};


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add Error stories.

Also, updated interface (and consumers) of Error for consistency. `retry` -> `onRetry`.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![error](https://user-images.githubusercontent.com/1004789/97231065-2fd6b480-1798-11eb-9b96-3ee82045fe2b.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
