### PR TITLE
storybook: add warning story

### DIFF
--- a/frontend/packages/core/src/Feedback/index.tsx
+++ b/frontend/packages/core/src/Feedback/index.tsx
@@ -1,4 +1,5 @@
 import Hint from "./hint";
 import { Note, NoteConfig, NotePanel } from "./note";
+import Warning from "./warning";
 
-export { Hint, Note, NoteConfig, NotePanel };
+export { Hint, Note, NoteConfig, NotePanel, Warning };

--- a/frontend/packages/core/src/Feedback/stories/warning.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/warning.stories.tsx
@@ -8,7 +8,7 @@ import type { WarningProps } from "../warning";
 import Warning from "../warning";
 
 export default {
-  title: "Core/Warning",
+  title: "Core/Feedback/Warning",
   component: Warning,
 } as Meta;
 

--- a/frontend/packages/core/src/Feedback/stories/warning.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/warning.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+// TODO: remove when https://github.com/lyft/clutch/pull/607/files#r512255592 lands
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from "@storybook/addon-actions";
+import type { Meta } from "@storybook/react";
+
+import type { WarningProps } from "../warning";
+import Warning from "../warning";
+
+export default {
+  title: "Core/Warning",
+  component: Warning,
+} as Meta;
+
+const Template = (props: WarningProps) => <Warning {...props} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  message: "Informational warning",
+};
+
+export const CloseAction = Template.bind({});
+CloseAction.args = {
+  ...Primary.args,
+  onClose: action("on-close"),
+};

--- a/frontend/packages/core/src/Feedback/warning.tsx
+++ b/frontend/packages/core/src/Feedback/warning.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Snackbar } from "@material-ui/core";
+import { Alert as MuiAlert } from "@material-ui/lab";
+import styled from "styled-components";
+
+const Alert = styled(MuiAlert)`
+  margin: 5px;
+`;
+
+export interface WarningProps {
+  message: any;
+  onClose?: () => void;
+}
+
+const Warning: React.FC<WarningProps> = ({ message, onClose }) => {
+  const [open, setOpen] = React.useState(true);
+
+  const onDismiss = () => {
+    if (onClose !== undefined) {
+      onClose();
+    }
+    setOpen(false);
+  };
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={6000}
+      onClose={() => setOpen(false)}
+      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+    >
+      <Alert elevation={6} variant="filled" onClose={onDismiss} severity="warning">
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+};
+
+export default Warning;

--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -5,7 +5,6 @@ import {
   Collapse as MuiCollapse,
   ExpansionPanel,
   IconButton,
-  Snackbar,
   Typography,
 } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
@@ -90,34 +89,4 @@ const CompressedError = ({ title, message }) => {
   );
 };
 
-interface WarningProps {
-  message: any;
-  onClose?: () => void;
-}
-
-const Warning: React.FC<WarningProps> = ({ message, onClose }) => {
-  const [open, setOpen] = React.useState(true);
-
-  const onDismiss = () => {
-    if (onClose !== undefined) {
-      onClose();
-    }
-    setOpen(false);
-  };
-
-  return (
-    <Snackbar
-      open={open}
-      autoHideDuration={6000}
-      onExit={onDismiss}
-      onClose={() => setOpen(false)}
-      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-    >
-      <Alert elevation={6} variant="filled" onClose={onDismiss} severity="warning">
-        {message}
-      </Alert>
-    </Snackbar>
-  );
-};
-
-export { CompressedError, Error, Warning };
+export { CompressedError, Error };

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -14,8 +14,8 @@ import {
 } from "./button";
 import Confirmation from "./confirmation";
 import { useWizardContext, WizardContext } from "./Contexts";
-import { Error, Warning } from "./error";
-import { Hint, Note, NoteConfig, NotePanel } from "./Feedback";
+import { Error } from "./error";
+import { Hint, Note, NoteConfig, NotePanel, Warning } from "./Feedback";
 import { Status } from "./icon";
 import Loadable from "./loading";
 import { client, ClientError } from "./network";


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
- Add `Warning` story.
- Extracted the `Warning` component into its own file within the feedback folder.
- Fixed a bug where `onClose` was being called twice when warnings were dismissed.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![warning](https://user-images.githubusercontent.com/1004789/97233411-28b1a580-179c-11eb-9ad7-3d04275a8f18.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual with story
