### PR TITLE
k8s: utilize lightweightinformer for topology caching

### DIFF
--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -69,35 +69,49 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 	// deploymentInformer.AddEventHandler(informerHandlers)
 	// hpaInformer.AddEventHandler(informerHandlers)
 
-	_, podInformer := cache.NewInformer(
-		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything()),
-		&v1.Pod{},
-		informerResyncTime,
-		informerHandlers,
-	)
-	_, deploymentInformer := cache.NewInformer(
-		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", v1.NamespaceAll, fields.Everything()),
-		&appsv1.Deployment{},
-		informerResyncTime,
-		informerHandlers,
-	)
-
-	_, hpaInformer := cache.NewInformer(
-		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", v1.NamespaceAll, fields.Everything()),
-		&autoscalingv1.HorizontalPodAutoscaler{},
-		informerResyncTime,
-		informerHandlers,
-	)
-
-	// idx, informer := cache.NewIndexerInformer(
+	// _, podInformer := cache.NewInformer(
 	// 	cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything()),
 	// 	&v1.Pod{},
 	// 	informerResyncTime,
 	// 	informerHandlers,
-	// 	// empty indexer? do nothing? idk
-	// 	cache.Indexers{},
 	// )
-	// go informer.Run(stop)
+	// _, deploymentInformer := cache.NewInformer(
+	// 	cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", v1.NamespaceAll, fields.Everything()),
+	// 	&appsv1.Deployment{},
+	// 	informerResyncTime,
+	// 	informerHandlers,
+	// )
+
+	// _, hpaInformer := cache.NewInformer(
+	// 	cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", v1.NamespaceAll, fields.Everything()),
+	// 	&autoscalingv1.HorizontalPodAutoscaler{},
+	// 	informerResyncTime,
+	// 	informerHandlers,
+	// )
+
+	_, podInformer := cache.NewIndexerInformer(
+		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything()),
+		&v1.Pod{},
+		informerResyncTime,
+		informerHandlers,
+		cache.Indexers{},
+	)
+
+	_, deploymentInformer := cache.NewIndexerInformer(
+		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", v1.NamespaceAll, fields.Everything()),
+		&appsv1.Deployment{},
+		informerResyncTime,
+		informerHandlers,
+		cache.Indexers{},
+	)
+
+	_, hpaInformer := cache.NewIndexerInformer(
+		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", v1.NamespaceAll, fields.Everything()),
+		&autoscalingv1.HorizontalPodAutoscaler{},
+		informerResyncTime,
+		informerHandlers,
+		cache.Indexers{},
+	)
 
 	go podInformer.Run(stop)
 	go deploymentInformer.Run(stop)

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -52,67 +52,37 @@ func (s *svc) StartTopologyCaching(ctx context.Context) (<-chan *topologyv1.Upda
 }
 
 func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
-	// factory := informers.NewSharedInformerFactoryWithOptions(cs, informerResyncTime)
-	stop := make(chan struct{})
-
-	// podInformer := factory.Core().V1().Pods().Informer()
-	// deploymentInformer := factory.Apps().V1().Deployments().Informer()
-	// hpaInformer := factory.Autoscaling().V1().HorizontalPodAutoscalers().Informer()
-
 	informerHandlers := cache.ResourceEventHandlerFuncs{
 		AddFunc:    s.informerAddHandler,
 		UpdateFunc: s.informerUpdateHandler,
 		DeleteFunc: s.informerDeleteHandler,
 	}
 
-	// podInformer.AddEventHandler(informerHandlers)
-	// deploymentInformer.AddEventHandler(informerHandlers)
-	// hpaInformer.AddEventHandler(informerHandlers)
-
-	// _, podInformer := cache.NewInformer(
-	// 	cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything()),
-	// 	&v1.Pod{},
-	// 	informerResyncTime,
-	// 	informerHandlers,
-	// )
-	// _, deploymentInformer := cache.NewInformer(
-	// 	cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", v1.NamespaceAll, fields.Everything()),
-	// 	&appsv1.Deployment{},
-	// 	informerResyncTime,
-	// 	informerHandlers,
-	// )
-
-	// _, hpaInformer := cache.NewInformer(
-	// 	cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", v1.NamespaceAll, fields.Everything()),
-	// 	&autoscalingv1.HorizontalPodAutoscaler{},
-	// 	informerResyncTime,
-	// 	informerHandlers,
-	// )
-
-	_, podInformer := cache.NewIndexerInformer(
+	podInformer := NewCachelessInformer(
+		cs,
 		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything()),
 		&v1.Pod{},
 		informerResyncTime,
 		informerHandlers,
-		cache.Indexers{},
 	)
 
-	_, deploymentInformer := cache.NewIndexerInformer(
+	deploymentInformer := NewCachelessInformer(
+		cs,
 		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", v1.NamespaceAll, fields.Everything()),
 		&appsv1.Deployment{},
 		informerResyncTime,
 		informerHandlers,
-		cache.Indexers{},
 	)
 
-	_, hpaInformer := cache.NewIndexerInformer(
+	hpaInformer := NewCachelessInformer(
+		cs,
 		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", v1.NamespaceAll, fields.Everything()),
 		&autoscalingv1.HorizontalPodAutoscaler{},
 		informerResyncTime,
 		informerHandlers,
-		cache.Indexers{},
 	)
 
+	stop := make(chan struct{})
 	go podInformer.Run(stop)
 	go deploymentInformer.Run(stop)
 	go hpaInformer.Run(stop)

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -58,7 +58,6 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 	}
 
 	podInformer := NewLightweightInformer(
-		cs,
 		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", corev1.NamespaceAll, fields.Everything()),
 		&corev1.Pod{},
 		informerResyncTime,
@@ -66,7 +65,6 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 	)
 
 	deploymentInformer := NewLightweightInformer(
-		cs,
 		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", corev1.NamespaceAll, fields.Everything()),
 		&appsv1.Deployment{},
 		informerResyncTime,
@@ -74,7 +72,6 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 	)
 
 	hpaInformer := NewLightweightInformer(
-		cs,
 		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", corev1.NamespaceAll, fields.Everything()),
 		&autoscalingv1.HorizontalPodAutoscaler{},
 		informerResyncTime,

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -58,7 +58,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		DeleteFunc: s.informerDeleteHandler,
 	}
 
-	podInformer := NewCachelessInformer(
+	podInformer := NewLightweightInformer(
 		cs,
 		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything()),
 		&v1.Pod{},
@@ -66,7 +66,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		informerHandlers,
 	)
 
-	deploymentInformer := NewCachelessInformer(
+	deploymentInformer := NewLightweightInformer(
 		cs,
 		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", v1.NamespaceAll, fields.Everything()),
 		&appsv1.Deployment{},
@@ -74,7 +74,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		informerHandlers,
 	)
 
-	hpaInformer := NewCachelessInformer(
+	hpaInformer := NewLightweightInformer(
 		cs,
 		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", v1.NamespaceAll, fields.Everything()),
 		&autoscalingv1.HorizontalPodAutoscaler{},

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -12,7 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -12,7 +12,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 
@@ -60,15 +59,15 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 
 	podInformer := NewLightweightInformer(
 		cs,
-		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything()),
-		&v1.Pod{},
+		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", corev1.NamespaceAll, fields.Everything()),
+		&corev1.Pod{},
 		informerResyncTime,
 		informerHandlers,
 	)
 
 	deploymentInformer := NewLightweightInformer(
 		cs,
-		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", v1.NamespaceAll, fields.Everything()),
+		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", corev1.NamespaceAll, fields.Everything()),
 		&appsv1.Deployment{},
 		informerResyncTime,
 		informerHandlers,
@@ -76,7 +75,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 
 	hpaInformer := NewLightweightInformer(
 		cs,
-		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", v1.NamespaceAll, fields.Everything()),
+		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", corev1.NamespaceAll, fields.Everything()),
 		&autoscalingv1.HorizontalPodAutoscaler{},
 		informerResyncTime,
 		informerHandlers,

--- a/backend/service/k8s/cachelessinformer.go
+++ b/backend/service/k8s/cachelessinformer.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+func NewCachelessInformer(
+	cs ContextClientset,
+	lw cache.ListerWatcher,
+	objType runtime.Object,
+	resync time.Duration,
+	h cache.ResourceEventHandler,
+) cache.Controller {
+	fifo := cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
+		// just to satisify the interface were not going to use this
+		KnownObjects:          cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{}),
+		EmitDeltaTypeReplaced: true,
+	})
+
+	return cache.New(&cache.Config{
+		Queue:            fifo,
+		ListerWatcher:    lw,
+		ObjectType:       objType,
+		FullResyncPeriod: resync,
+		RetryOnError:     false,
+		Process: func(obj interface{}) error {
+			for _, d := range obj.(cache.Deltas) {
+				switch d.Type {
+				case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
+					h.OnAdd(d.Object)
+				case cache.Deleted:
+					h.OnDelete(d.Object)
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/backend/service/k8s/cachelessinformer.go
+++ b/backend/service/k8s/cachelessinformer.go
@@ -1,23 +1,48 @@
 package k8s
 
 import (
+	"log"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 )
 
-func NewCachelessInformer(
+type lightweightObj struct {
+	metav1.Object
+	UID       types.UID
+	Name      string
+	Namespace string
+}
+
+func (cl *lightweightObj) GetUID() types.UID             { return cl.UID }
+func (cl *lightweightObj) SetUID(uid types.UID)          { cl.UID = uid }
+func (cl *lightweightObj) GetName() string               { return cl.Name }
+func (cl *lightweightObj) SetName(name string)           { cl.Name = name }
+func (cl *lightweightObj) GetNamespace() string          { return cl.Namespace }
+func (cl *lightweightObj) SetNamespace(namespace string) { cl.Namespace = namespace }
+
+func NewLightweightInformer(
 	cs ContextClientset,
 	lw cache.ListerWatcher,
 	objType runtime.Object,
 	resync time.Duration,
 	h cache.ResourceEventHandler,
 ) cache.Controller {
+	cacheStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
 	fifo := cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
-		// just to satisify the interface were not going to use this
-		KnownObjects:          cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{}),
+		KnownObjects:          cacheStore,
 		EmitDeltaTypeReplaced: true,
+		KeyFunction: func(obj interface{}) (string, error) {
+			theMeta, err := meta.Accessor(obj)
+			if err != nil {
+				return "", err
+			}
+			return string(theMeta.GetUID()), nil
+		},
 	})
 
 	return cache.New(&cache.Config{
@@ -28,10 +53,33 @@ func NewCachelessInformer(
 		RetryOnError:     false,
 		Process: func(obj interface{}) error {
 			for _, d := range obj.(cache.Deltas) {
+
+				incomeingObjectMeta, _ := meta.Accessor(d.Object)
+				lightweightObj := &lightweightObj{}
+				lightweightObj.SetUID(incomeingObjectMeta.GetUID())
+				lightweightObj.SetName(incomeingObjectMeta.GetName())
+				lightweightObj.SetNamespace(incomeingObjectMeta.GetNamespace())
+
 				switch d.Type {
 				case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
-					h.OnAdd(d.Object)
+					if _, exists, err := cacheStore.Get(lightweightObj); err == nil && exists {
+						if err := cacheStore.Update(lightweightObj); err != nil {
+							log.Printf("error updating %v", err)
+						}
+						log.Print("trying to update")
+						h.OnUpdate(nil, d.Object)
+					} else {
+						if err := cacheStore.Add(lightweightObj); err != nil {
+							log.Printf("error adding %v", err)
+						}
+						log.Print("trying to add")
+						h.OnAdd(d.Object)
+					}
 				case cache.Deleted:
+					log.Print("delete event")
+					if err := cacheStore.Delete(lightweightObj); err != nil {
+						return err
+					}
 					h.OnDelete(d.Object)
 				}
 			}

--- a/backend/service/k8s/lightweightinformer.go
+++ b/backend/service/k8s/lightweightinformer.go
@@ -57,7 +57,6 @@ func NewLightweightInformer(
 		RetryOnError:     false,
 		Process: func(obj interface{}) error {
 			for _, d := range obj.(cache.Deltas) {
-
 				incomeingObjectMeta, err := meta.Accessor(d.Object)
 				if err != nil {
 					return err

--- a/backend/service/k8s/lightweightinformer.go
+++ b/backend/service/k8s/lightweightinformer.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-type lightweightObj struct {
+type lightWeightCacheObject struct {
 	metav1.Object
 	UID        types.UID
 	Name       string
@@ -20,12 +20,12 @@ type lightweightObj struct {
 	Labels     map[string]string
 }
 
-func (cl *lightweightObj) GetUID() types.UID             { return cl.UID }
-func (cl *lightweightObj) SetUID(uid types.UID)          { cl.UID = uid }
-func (cl *lightweightObj) GetName() string               { return cl.Name }
-func (cl *lightweightObj) SetName(name string)           { cl.Name = name }
-func (cl *lightweightObj) GetNamespace() string          { return cl.Namespace }
-func (cl *lightweightObj) SetNamespace(namespace string) { cl.Namespace = namespace }
+func (cl *lightWeightCacheObject) GetUID() types.UID             { return cl.UID }
+func (cl *lightWeightCacheObject) SetUID(uid types.UID)          { cl.UID = uid }
+func (cl *lightWeightCacheObject) GetName() string               { return cl.Name }
+func (cl *lightWeightCacheObject) SetName(name string)           { cl.Name = name }
+func (cl *lightWeightCacheObject) GetNamespace() string          { return cl.Namespace }
+func (cl *lightWeightCacheObject) SetNamespace(namespace string) { cl.Namespace = namespace }
 
 func NewLightweightInformer(
 	cs ContextClientset,
@@ -67,26 +67,26 @@ func NewLightweightInformer(
 			for _, d := range obj.(cache.Deltas) {
 
 				incomeingObjectMeta, _ := meta.Accessor(d.Object)
-				lightweightObj := &lightweightObj{}
+				lightweightObj := &lightWeightCacheObject{}
 				lightweightObj.SetUID(incomeingObjectMeta.GetUID())
 				lightweightObj.SetName(incomeingObjectMeta.GetName())
 				lightweightObj.SetNamespace(incomeingObjectMeta.GetNamespace())
 
 				switch d.Type {
 				case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
-					if _, exists, err := cacheStore.Get(d.Object); err == nil && exists {
+					if _, exists, err := cacheStore.Get(lightweightObj); err == nil && exists {
 						if err := cacheStore.Update(d.Object); err != nil {
 							log.Printf("error updating %v", err)
 						}
 						h.OnUpdate(nil, d.Object)
 					} else {
-						if err := cacheStore.Add(d.Object); err != nil {
+						if err := cacheStore.Add(lightweightObj); err != nil {
 							log.Printf("error adding %v", err)
 						}
 						h.OnAdd(d.Object)
 					}
 				case cache.Deleted:
-					if err := cacheStore.Delete(d.Object); err != nil {
+					if err := cacheStore.Delete(lightweightObj); err != nil {
 						return err
 					}
 					h.OnDelete(d.Object)

--- a/backend/service/k8s/lightweightinformer.go
+++ b/backend/service/k8s/lightweightinformer.go
@@ -31,7 +31,7 @@ func (lw *lightweightCacheObject) GetNamespace() string { return lw.Namespace }
 //
 // Also to note the memory footprint of the cache store is only part of the story.
 // While the informers controller is receiving Kubernetes objects it stores that full object in the DeltaFIFO queue.
-// This queue while processed quickly does store a vast amount objects at any given time and contributes to memory usage greatly.
+// This queue while processed quickly does store a vast amount of objects at any given time and contributes to memory usage greatly.
 //
 // Drawbacks
 // - Update resource event handler does not function as expected, old objects will always return nil.
@@ -70,7 +70,7 @@ func NewLightweightInformer(
 				switch d.Type {
 				case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
 					if _, exists, err := cacheStore.Get(lightweightObj); err == nil && exists {
-						if err := cacheStore.Update(d.Object); err != nil {
+						if err := cacheStore.Update(lightweightObj); err != nil {
 							return err
 						}
 						h.OnUpdate(nil, d.Object)

--- a/backend/service/k8s/lightweightinformer_test.go
+++ b/backend/service/k8s/lightweightinformer_test.go
@@ -6,21 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	fakecontroller "k8s.io/client-go/tools/cache/testing"
 )
 
 func TestLightweightInformer(t *testing.T) {
-	cs := fake.NewSimpleClientset()
-	csm := &managerImpl{
-		clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
-			Interface: cs,
-			namespace: "default",
-			cluster:   "core-testing",
-		}},
-	}
-
 	addActionChan := make(chan int)
 	updateActionChan := make(chan int)
 	deleteActionChan := make(chan int)
@@ -44,7 +34,6 @@ func TestLightweightInformer(t *testing.T) {
 	defer close(stop)
 
 	podInformer := NewLightweightInformer(
-		csm.clientsets["foo"],
 		fc,
 		&v1.Pod{},
 		time.Minute,

--- a/backend/service/k8s/lightweightinformer_test.go
+++ b/backend/service/k8s/lightweightinformer_test.go
@@ -53,16 +53,12 @@ func TestLightweightInformer(t *testing.T) {
 
 	go podInformer.Run(stop)
 
-	// We sleep below to give some time for the informer to get the event and hit a handler
 	fc.Add(&v1.Pod{})
-	time.Sleep(time.Millisecond * 50)
 	assert.Greater(t, <-addActionChan, 0)
 
 	fc.Modify(&v1.Pod{})
-	time.Sleep(time.Millisecond * 50)
 	assert.Greater(t, <-updateActionChan, 0)
 
 	fc.Delete(&v1.Pod{})
-	time.Sleep(time.Millisecond * 50)
 	assert.Greater(t, <-deleteActionChan, 0)
 }

--- a/backend/service/k8s/lightweightinformer_test.go
+++ b/backend/service/k8s/lightweightinformer_test.go
@@ -1,0 +1,66 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	fakecontroller "k8s.io/client-go/tools/cache/testing"
+)
+
+func TestLightweightInformer(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	csm := &managerImpl{
+		clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			Interface: cs,
+			namespace: "default",
+			cluster:   "core-testing",
+		}},
+	}
+
+	numAddActions := 0
+	numUpdateActions := 0
+	numDeleteActions := 0
+
+	informerHandlers := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			numAddActions++
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			numUpdateActions++
+		},
+		DeleteFunc: func(obj interface{}) {
+			numDeleteActions++
+		},
+	}
+
+	// This fake controller is a fake source for listing and watching resources
+	fc := fakecontroller.NewFakeControllerSource()
+
+	stop := make(chan struct{})
+	podInformer := NewLightweightInformer(
+		csm.clientsets["foo"],
+		fc,
+		&v1.Pod{},
+		time.Minute,
+		informerHandlers,
+	)
+
+	go podInformer.Run(stop)
+
+	// We sleep below to give some time for the informer to get the event and hit a handler
+	fc.Add(&v1.Pod{})
+	time.Sleep(time.Millisecond * 10)
+	assert.Greater(t, numAddActions, 0)
+
+	fc.Modify(&v1.Pod{})
+	time.Sleep(time.Millisecond * 10)
+	assert.Greater(t, numUpdateActions, 0)
+
+	fc.Delete(&v1.Pod{})
+	time.Sleep(time.Millisecond * 10)
+	assert.Greater(t, numDeleteActions, 0)
+}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The motivation of this change is too reduce the memory footprint of the Kubernetes topology caching logic. A major contributor to the memory consumption was the informers cache store which we do not utilize for the Kubernetes topology caching functionality. 

This PR introduces a new type of an informer which sets to reduce the informer cache size by substituting the incoming kubernetes objects with smaller lightweight ones.

During internal testing with large scale Kubernetes deployments we easily saw 15Gb+ of memory usage, when switching to utilize this new `LightweightInfomer` we saw memory usage drop about ~65%.

I pulled out my description from the comments in the code for the reader convenience.

----

The LightweightInformer is an informer thats optimized for memory usage with drawbacks.

The reduction in memory consumption does come at a cost, to achieve this we store small objects
in the informers cache store. We do this by utilizing storing `lightweightCacheObject` instead
of the full Kubernetes object.
`lightweightCacheObject` has just enough metadata for the cache store and DeltaFIFO components to operate normally.

There are drawbacks too using a LightweightInformer and its does not fit all use cases.
For the Topology Caching this type of solution helped to reduce memory footprint significantly
for large scale Kubernetes deployments.

Also to note the memory footprint of the cache store is only part of the story.
While the informers controller is receiving Kubernetes objects it stores that full object in the DeltaFIFO queue.
This queue while processed quickly does store a vast amount objects at any given time and contributes to memory usage greatly.

Drawbacks
- Update resource event handler does not function as expected, old objects will always return nil.
  This is because we dont cache the full k8s object to compute deltas as we are using lightweightCacheObjects instead.

### Testing Performed
<!-- Describe how you tested this change below. -->

Unit test / locally / real deployment in Lyft staging environment. 
