### PR TITLE
storybook: add expansion panel story

### DIFF
--- a/frontend/packages/core/src/panel.tsx
+++ b/frontend/packages/core/src/panel.tsx
@@ -12,7 +12,7 @@ const FullWidthExpansionPanel = styled(MuiExpansionPanel)`
   width: 100%;
 `;
 
-interface ExpansionPanelProps {
+export interface ExpansionPanelProps {
   heading: string;
   summary: string;
   expanded?: boolean;
@@ -25,7 +25,7 @@ const ExpansionPanel: React.FC<ExpansionPanelProps> = ({
   children,
 }) => {
   return (
-    <FullWidthExpansionPanel expanded={expanded}>
+    <FullWidthExpansionPanel defaultExpanded={expanded}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <Typography>{heading}</Typography>
         <div style={{ flexGrow: 1 }} />

--- a/frontend/packages/core/src/stories/panel.stories.tsx
+++ b/frontend/packages/core/src/stories/panel.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import type { Meta } from "@storybook/react";
+
+import type { ExpansionPanelProps } from "../panel";
+import ExpansionPanel from "../panel";
+
+export default {
+  title: "Core/ExpansionPanel",
+  component: ExpansionPanel,
+} as Meta;
+
+const Template = (props: ExpansionPanelProps) => (
+  <ExpansionPanel {...props}>
+    <img alt="clutch logo" src="https://clutch.sh/img/navigation/logo.svg" height="100px" />
+  </ExpansionPanel>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  heading: "Check this out!",
+  summary: "This is an expansion panel.",
+};
+
+export const Expanded = Template.bind({});
+Expanded.args = {
+  ...Primary.args,
+  expanded: true,
+};


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add ExpansionPanel story. Includes a fix when passing in a expanded flag to only be the default and not the permanent.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![expansionPanel](https://user-images.githubusercontent.com/1004789/97477922-77cb1800-190d-11eb-9bde-243c27eb0687.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual with story
