### PR TITLE
storybook: add icon stories

### DIFF
--- a/frontend/packages/core/src/icon.tsx
+++ b/frontend/packages/core/src/icon.tsx
@@ -48,11 +48,13 @@ const Status: React.FC<StatusProps> = ({
   );
 };
 
-const TrendingUpIcon = styled(MuiTrendingUpIcon)`
+const StyledTrendingUpIcon = styled(MuiTrendingUpIcon)`
   ${({ theme }) => `
   color: ${theme.palette.accent.main};
   margin: 1%;
   `}
 `;
+
+const TrendingUpIcon: React.FC = () => <StyledTrendingUpIcon />;
 
 export { Status, TrendingUpIcon };

--- a/frontend/packages/core/src/icon.tsx
+++ b/frontend/packages/core/src/icon.tsx
@@ -12,10 +12,15 @@ const StatusIcon = styled(FiberManualRecordTwoToneIcon)`
 
 export interface StatusProps {
   variant?: "neutral" | "success" | "failure";
-  align?: "right" | "center";
+  align?: "left" | "center" | "right";
 }
 
-const Status: React.FC<StatusProps> = ({ children, variant = "neutral", align, ...props }) => {
+const Status: React.FC<StatusProps> = ({
+  children,
+  variant = "neutral",
+  align = "left",
+  ...props
+}) => {
   let justifyContent: GridJustification = "flex-start";
   if (align === "right") {
     justifyContent = "flex-end";

--- a/frontend/packages/core/src/stories/status.stories.tsx
+++ b/frontend/packages/core/src/stories/status.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import type { Meta } from "@storybook/react";
+
+import type { StatusProps } from "../icon";
+import { Status } from "../icon";
+
+export default {
+  title: "Core/Icon/Status",
+  component: Status,
+} as Meta;
+
+const Template = (props: StatusProps) => <Status {...props} />;
+
+export const Primary = Template.bind({});
+
+export const Success = Template.bind({});
+Success.args = {
+  variant: "success",
+};
+
+export const Failure = Template.bind({});
+Failure.args = {
+  variant: "failure",
+};

--- a/frontend/packages/core/src/stories/trending-up.stories.tsx
+++ b/frontend/packages/core/src/stories/trending-up.stories.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import type { Meta } from "@storybook/react";
+
+import { TrendingUpIcon } from "../icon";
+
+export default {
+  title: "Core/Icon/TrendingUp",
+  component: TrendingUpIcon,
+} as Meta;
+
+const Template = () => <TrendingUpIcon />;
+
+export const Primary = Template.bind({});


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add icon stories for `Status` and `TrendingupIcon`. This also removes the exposed material props of the trending up icon.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![icons](https://user-images.githubusercontent.com/1004789/97493218-de5a3100-1921-11eb-9f92-737049a61a7c.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual with stories.
