### PR TITLE
gateway: fix GetAction panic when no annotation is present

### DIFF
--- a/backend/gateway/meta/meta.go
+++ b/backend/gateway/meta/meta.go
@@ -50,10 +50,12 @@ func GetAction(method string) apiv1.ActionType {
 	if !ok {
 		return apiv1.ActionType_UNSPECIFIED
 	}
-	opts := md.GetMethodOptions()
+	opts := md.GetMethodOptions().ProtoReflect()
 
-	v := opts.ProtoReflect().Get(actionTypeDescriptor)
-	return v.Message().Interface().(*apiv1.Action).Type
+	if !opts.Has(actionTypeDescriptor) {
+		return apiv1.ActionType_UNSPECIFIED
+	}
+	return opts.Get(actionTypeDescriptor).Message().Interface().(*apiv1.Action).Type
 }
 
 func ResourceNames(pb proto.Message) []*auditv1.Resource {

--- a/backend/gateway/meta/meta_test.go
+++ b/backend/gateway/meta/meta_test.go
@@ -1,11 +1,11 @@
 package meta
 
 import (
-	"google.golang.org/grpc/health/grpc_health_v1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/proto"
 
 	apiv1 "github.com/lyft/clutch/backend/api/api/v1"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x4667ab5]
goroutine 46 [running]:
github.com/lyft/clutch/backend/gateway/meta.GetAction(0x6b7af17, 0x2a, 0x0)
    /Users/mjang/src/go/src/github.com/lyft/clutch-private/backend/vendor/github.com/lyft/clutch/backend/gateway/meta/meta.go:55 +0x135
```

### Testing Performed
Unit