### PR TITLE
serverexperimentation: combine all steps of start-experiment into one step

### DIFF
--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -22,6 +22,7 @@
     "@clutch-sh/core": "^0.0.0-beta",
     "@clutch-sh/data-layout": "^0.0.0-beta",
     "@clutch-sh/wizard": "^0.0.0-beta",
+    "@hookform/resolvers": "^1.0.0",
     "@material-ui/core": "^4.11.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -25,6 +25,8 @@
     "@material-ui/core": "^4.11.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
+    "react-hook-form": "^6.9.2",
+    "react-router-dom": "^6.0.0-beta",
     "styled-components": "^5.1.1",
     "yup": "^0.29.0"
   },

--- a/frontend/workflows/serverexperimentation/src/dialog.tsx
+++ b/frontend/workflows/serverexperimentation/src/dialog.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import Button from "@material-ui/core/Button";
+import MuiDialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Typography from "@material-ui/core/Typography";
+
+interface ButtonProps {
+  label: string;
+  onAction: () => void;
+}
+
+interface DialogProps {
+  title: string;
+  content: string;
+  open: boolean;
+  onClose: () => void;
+  buttons: ButtonProps[];
+}
+
+const Dialog: React.FC<DialogProps> = ({ title, content, open, onClose, buttons }) => {
+  return (
+    <MuiDialog open={open} onClose={onClose}>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <Typography gutterBottom>{content}</Typography>
+      </DialogContent>
+      <DialogActions>
+        {buttons.map(buttonProps => {
+          return (
+            <Button key={buttonProps.label} onClick={buttonProps.onAction}>
+              {buttonProps.label}
+            </Button>
+          );
+        })}
+      </DialogActions>
+    </MuiDialog>
+  );
+};
+
+export default Dialog;

--- a/frontend/workflows/serverexperimentation/src/form-content.tsx
+++ b/frontend/workflows/serverexperimentation/src/form-content.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { RadioGroup, Select, TextField } from "@clutch-sh/core";
+
+interface FormProps {
+  state: any;
+  items: FormItem[];
+  register: any;
+  errors: any;
+}
+
+interface TextFieldProps {
+  defaultValue: string | undefined;
+}
+
+interface SelectProps {
+  options: SelectOption[];
+}
+
+interface SelectOption {
+  label: string;
+  value: string;
+}
+
+interface RadioGroupProps {
+  options: RadioGroupOption[];
+}
+
+interface RadioGroupOption {
+  label: string;
+  value: string;
+}
+
+interface FormItem {
+  name: string;
+  label: string;
+  type: string;
+  inputProps: SelectProps | TextFieldProps;
+}
+
+const FormContent: React.FC<FormProps> = ({ state, items, register, errors }) => {
+  const [data, setData] = state;
+
+  return items.map(field => {
+    if (["text", "number"].indexOf(field.type) >= 0) {
+      const customProps: TextFieldProps = field.inputProps as TextFieldProps;
+      return (
+        <TextField
+          key={field.name}
+          name={field.name}
+          label={field.label}
+          defaultValue={customProps.defaultValue}
+          type={field.type}
+          onChange={e => {
+            const copiedData = { ...data };
+            copiedData[field.name] = e.target.value;
+            setData(copiedData);
+          }}
+          inputRef={register}
+          error={!!errors[field.name]}
+          helperText={errors[field.name] ? errors[field.name].message : ""}
+          InputLabelProps={{
+            shrink: true,
+          }}
+        />
+      );
+    }
+    if (field.type === "radio-group") {
+      const customProps: RadioGroupProps = field.inputProps as RadioGroupProps;
+      return (
+        <RadioGroup
+          key={field.name}
+          name={field.name}
+          label={field.label}
+          options={customProps.options}
+          onChange={value => {
+            const copiedData = { ...data };
+            copiedData[field.name] = value;
+            setData(copiedData);
+          }}
+        />
+      );
+    }
+    if (field.type === "select") {
+      const customProps: SelectProps = field.inputProps as SelectProps;
+      return (
+        <div key={field.name} style={{ margin: "15px 0" }}>
+          <Select
+            name={field.name}
+            key={field.name}
+            label={field.label}
+            options={customProps.options}
+            onChange={value => {
+              const copiedData = { ...data };
+              copiedData[field.name] = value;
+              setData(copiedData);
+            }}
+          />
+        </div>
+      );
+    }
+
+    return <div key="blank" />;
+  });
+};
+
+export { FormContent, FormItem, SelectOption, SelectProps, TextFieldProps };

--- a/frontend/workflows/serverexperimentation/src/form-content.tsx
+++ b/frontend/workflows/serverexperimentation/src/form-content.tsx
@@ -1,5 +1,13 @@
 import React from "react";
 import { RadioGroup, Select, TextField } from "@clutch-sh/core";
+import styled from "styled-components";
+
+const StyledDiv = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
 
 interface FormProps {
   state: any;
@@ -40,67 +48,71 @@ interface FormItem {
 const FormContent: React.FC<FormProps> = ({ state, items, register, errors }) => {
   const [data, setData] = state;
 
-  return items.map(field => {
-    if (["text", "number"].indexOf(field.type) >= 0) {
-      const customProps: TextFieldProps = field.inputProps as TextFieldProps;
-      return (
-        <TextField
-          key={field.name}
-          name={field.name}
-          label={field.label}
-          defaultValue={customProps.defaultValue}
-          type={field.type}
-          onChange={e => {
-            const copiedData = { ...data };
-            copiedData[field.name] = e.target.value;
-            setData(copiedData);
-          }}
-          inputRef={register}
-          error={!!errors[field.name]}
-          helperText={errors[field.name] ? errors[field.name].message : ""}
-          InputLabelProps={{
-            shrink: true,
-          }}
-        />
-      );
-    }
-    if (field.type === "radio-group") {
-      const customProps: RadioGroupProps = field.inputProps as RadioGroupProps;
-      return (
-        <RadioGroup
-          key={field.name}
-          name={field.name}
-          label={field.label}
-          options={customProps.options}
-          onChange={value => {
-            const copiedData = { ...data };
-            copiedData[field.name] = value;
-            setData(copiedData);
-          }}
-        />
-      );
-    }
-    if (field.type === "select") {
-      const customProps: SelectProps = field.inputProps as SelectProps;
-      return (
-        <div key={field.name} style={{ margin: "15px 0" }}>
-          <Select
-            name={field.name}
-            key={field.name}
-            label={field.label}
-            options={customProps.options}
-            onChange={value => {
-              const copiedData = { ...data };
-              copiedData[field.name] = value;
-              setData(copiedData);
-            }}
-          />
-        </div>
-      );
-    }
+  return (
+    <StyledDiv>
+      {items.map(field => {
+        if (["text", "number"].indexOf(field.type) >= 0) {
+          const customProps: TextFieldProps = field.inputProps as TextFieldProps;
+          return (
+            <TextField
+              key={field.name}
+              name={field.name}
+              label={field.label}
+              defaultValue={customProps.defaultValue}
+              type={field.type}
+              onChange={e => {
+                const copiedData = { ...data };
+                copiedData[field.name] = e.target.value;
+                setData(copiedData);
+              }}
+              inputRef={register}
+              error={!!errors[field.name]}
+              helperText={errors[field.name] ? errors[field.name].message : ""}
+              InputLabelProps={{
+                shrink: true,
+              }}
+            />
+          );
+        }
+        if (field.type === "radio-group") {
+          const customProps: RadioGroupProps = field.inputProps as RadioGroupProps;
+          return (
+            <RadioGroup
+              key={field.name}
+              name={field.name}
+              label={field.label}
+              options={customProps.options}
+              onChange={value => {
+                const copiedData = { ...data };
+                copiedData[field.name] = value;
+                setData(copiedData);
+              }}
+            />
+          );
+        }
+        if (field.type === "select") {
+          const customProps: SelectProps = field.inputProps as SelectProps;
+          return (
+            <div key={field.name} style={{ margin: "15px 0" }}>
+              <Select
+                name={field.name}
+                key={field.name}
+                label={field.label}
+                options={customProps.options}
+                onChange={value => {
+                  const copiedData = { ...data };
+                  copiedData[field.name] = value;
+                  setData(copiedData);
+                }}
+              />
+            </div>
+          );
+        }
 
-    return <div key="blank" />;
-  });
+        return <div key="blank" />;
+      })}
+    </StyledDiv>
+  );
 };
 
 export { FormContent, FormItem, SelectOption, SelectProps, TextFieldProps };

--- a/frontend/workflows/serverexperimentation/src/form-page.tsx
+++ b/frontend/workflows/serverexperimentation/src/form-page.tsx
@@ -30,9 +30,7 @@ const FormPage: React.FC<FormPageProps> = ({ heading, error, children }) => {
         <Heading variant="h5">
           <strong>{heading}</strong>
         </Heading>
-        <SizedGrid>
-          <SizedGrid>{children}</SizedGrid>
-        </SizedGrid>
+        <SizedGrid>{children}</SizedGrid>
       </Container>
     </Spacer>
   );

--- a/frontend/workflows/serverexperimentation/src/form-page.tsx
+++ b/frontend/workflows/serverexperimentation/src/form-page.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Error } from "@clutch-sh/core";
+import { Container, Grid, Typography } from "@material-ui/core";
+import styled from "styled-components";
+
+const Heading = styled(Typography)`
+  padding-left: 1.25rem;
+`;
+
+const Spacer = styled.div`
+  margin: 30px;
+`;
+
+const SizedGrid = styled(Grid)`
+  width: 100%;
+  padding: 24px;
+`;
+
+interface FormPageProps {
+  heading: string;
+  error: any;
+}
+
+const FormPage: React.FC<FormPageProps> = ({ heading, error, children }) => {
+  const hasError = error !== undefined && error !== "" && error !== null;
+  return (
+    <Spacer>
+      {hasError && <Error message={error} />}
+      <Container maxWidth="lg">
+        <Heading variant="h5">
+          <strong>{heading}</strong>
+        </Heading>
+        <SizedGrid>
+          <SizedGrid>{children}</SizedGrid>
+        </SizedGrid>
+      </Container>
+    </Spacer>
+  );
+};
+
+export default FormPage;

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -5,7 +5,6 @@ import { clutch as IClutch } from "@clutch-sh/api";
 import type { BaseWorkflowProps } from "@clutch-sh/core";
 import { ButtonGroup, client } from "@clutch-sh/core";
 import { yupResolver } from "@hookform/resolvers/yup";
-import styled from "styled-components";
 import * as yup from "yup";
 
 import Dialog from "./dialog";
@@ -16,13 +15,6 @@ enum FaultType {
   ABORT = "Abort",
   LATENCY = "Latency",
 }
-
-const StyledForm = styled.form`
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-`;
 
 const faultInjectionTypeItems = [
   {
@@ -132,7 +124,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
   });
 
   return (
-    <StyledForm onSubmit={handleSubmit(handleOnSubmit)}>
+    <form onSubmit={handleSubmit(handleOnSubmit)}>
       <FormContent state={experimentDataState} items={fields} register={register} errors={errors} />
       <ButtonGroup
         buttons={[
@@ -148,7 +140,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
           },
         ]}
       />
-    </StyledForm>
+    </form>
   );
 };
 

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -1,23 +1,32 @@
-import React from "react";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import { clutch as IClutch } from "@clutch-sh/api";
 import type { BaseWorkflowProps } from "@clutch-sh/core";
-import {
-  ButtonGroup,
-  client,
-  Confirmation,
-  MetadataTable,
-  RadioGroup,
-  Select,
-  useWizardContext,
-} from "@clutch-sh/core";
-import { useDataLayout } from "@clutch-sh/data-layout";
-import type { WizardChild } from "@clutch-sh/wizard";
-import { Wizard, WizardStep } from "@clutch-sh/wizard";
+import { ButtonGroup, client } from "@clutch-sh/core";
+import { yupResolver } from "@hookform/resolvers/yup";
+import styled from "styled-components";
 import * as yup from "yup";
+
+import Dialog from "./dialog";
+import { FormContent } from "./form-content";
+import FormPage from "./form-page";
+
+enum FaultType {
+  ABORT = "Abort",
+  LATENCY = "Latency",
+}
+
+const StyledForm = styled.form`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
 
 const faultInjectionTypeItems = [
   {
-    label: "Internal (Lyft owned)",
+    label: "Internal",
     value: IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_UPSTREAM.toString(),
   },
   {
@@ -26,141 +35,120 @@ const faultInjectionTypeItems = [
   },
 ];
 
-interface ClusterPairTargetDetailsProps extends WizardChild {
+type ExperimentData = IClutch.chaos.serverexperimentation.v1.AbortFaultConfig &
+  IClutch.chaos.serverexperimentation.v1.LatencyFaultConfig &
+  IClutch.chaos.serverexperimentation.v1.ClusterPairTarget & { type: FaultType };
+
+interface ExperimentDetailsProps {
   upstreamClusterTypeSelectionEnabled: boolean;
+  onStart: (ExperimentData) => void;
 }
 
-const ClusterPairTargetDetails: React.FC<ClusterPairTargetDetailsProps> = ({
+const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
   upstreamClusterTypeSelectionEnabled,
+  onStart,
 }) => {
-  const { onSubmit } = useWizardContext();
-  const clusterPairData = useDataLayout("clusterPairTargetData");
-  const clusterPair = clusterPairData.displayValue();
+  const experimentDataState = useState<ExperimentData>({} as ExperimentData);
+  const experimentData = experimentDataState[0];
+  const navigate = useNavigate();
 
-  return (
-    <WizardStep error={clusterPairData.error} isLoading={false}>
-      <MetadataTable
-        onUpdate={(key, value: string) => clusterPairData.updateData(key, value)}
-        data={[
-          {
-            name: "Downstream Cluster",
-            value: clusterPair.downstreamCluster,
-            input: {
-              key: "downstreamCluster",
-              validation: yup.string().required(),
-            },
-          },
-          {
-            name: "Upstream Cluster",
-            value: clusterPair.upstreamCluster,
-            input: {
-              key: "upstreamCluster",
-              validation: yup.string().required(),
-            },
-          },
-        ]}
-      />
-      {upstreamClusterTypeSelectionEnabled && (
-        <RadioGroup
-          name="upstream_cluster_type"
-          label="Upstream Cluster Type"
-          options={faultInjectionTypeItems}
-          onChange={(value: string) =>
-            clusterPairData.updateData("faultInjectionCluster", parseInt(value, 10))
-          }
-        />
-      )}
-      <ButtonGroup
-        buttons={[
-          {
-            text: "Next",
-            onClick: onSubmit,
-          },
-        ]}
-      />
-    </WizardStep>
-  );
-};
+  const handleOnCancel = () => {
+    navigate("/experimentation/list");
+  };
 
-enum FaultType {
-  ABORT = "Abort",
-  LATENCY = "Latency",
-}
+  const handleOnSubmit = () => {
+    onStart(experimentData);
+  };
 
-const ExperimentDetails: React.FC<WizardChild> = () => {
-  const { onSubmit, onBack } = useWizardContext();
-  const experimentData = useDataLayout("experimentData");
-  const experiment = experimentData.value;
-
-  const isAbort = (experiment?.type ?? FaultType.ABORT) === FaultType.ABORT;
-  return (
-    <WizardStep error={experimentData.error} isLoading={false}>
-      <Select
-        name="Type"
-        label="Fault Type"
-        options={[
+  const isAbort = (experimentData?.type ?? FaultType.ABORT) === FaultType.ABORT;
+  const fields = [
+    {
+      name: "downstreamCluster",
+      label: "Downstream Cluster",
+      type: "text",
+      validation: yup.string().label("Downstream Cluster").required(),
+      inputProps: { defaultValue: undefined },
+    },
+    {
+      name: "upstreamCluster",
+      label: "Upstream Cluster",
+      type: "text",
+      validation: yup.string().label("Upstream Cluster").required(),
+      inputProps: { defaultValue: undefined },
+    },
+    upstreamClusterTypeSelectionEnabled && {
+      name: "upstreamClusterType",
+      label: "Upstream Cluster Type",
+      type: "radio-group",
+      inputProps: { options: faultInjectionTypeItems },
+    },
+    {
+      name: "type",
+      label: "Fault Type",
+      type: "select",
+      inputProps: {
+        options: [
           { label: "Abort", value: FaultType.ABORT },
           { label: "Latency", value: FaultType.LATENCY },
-        ]}
-        onChange={value => experimentData.updateData("type", value)}
-      />
-      <MetadataTable
-        onUpdate={(key, value) => experimentData.updateData(key, value)}
-        data={[
-          {
-            name: "Percent",
-            value: experiment.percent,
-            input: {
-              type: "number",
-              key: "percent",
-              validation: yup.number().integer().min(1).max(100),
-            },
-          },
-          isAbort
-            ? {
-                name: "HTTP Status",
-                value: experiment.httpStatus,
-                input: {
-                  type: "number",
-                  key: "httpStatus",
-                  validation: yup.number().integer().min(100).max(599),
-                },
-              }
-            : {
-                name: "Duration (ms)",
-                value: experiment.durationMs,
-                input: {
-                  type: "number",
-                  key: "durationMs",
-                  validation: yup.number().integer().min(1),
-                },
-              },
-        ]}
-      />
+        ],
+      },
+    },
+    {
+      name: "percent",
+      label: "Percent",
+      type: "number",
+      validation: yup.number().label("Percent").integer().min(1).max(100).required(),
+      inputProps: { defaultValue: "0" },
+    },
+    isAbort
+      ? {
+          name: "httpStatus",
+          label: "HTTP Status",
+          type: "number",
+          validation: yup.number().label("HTTP status").integer().min(100).max(599).required(),
+          inputProps: { defaultValue: experimentData.httpStatus?.toString() },
+        }
+      : {
+          name: "durationMs",
+          label: "Duration (ms)",
+          type: "number",
+          validation: yup.number().label("Duration (ms)").integer().min(1).required(),
+          inputProps: { defaultValue: experimentData.durationMs?.toString() },
+        },
+  ];
+
+  const schema: { [name: string]: yup.StringSchema | yup.NumberSchema } = {};
+  fields
+    .filter(field => field.validation !== undefined)
+    .reduce((accumulator, field) => {
+      accumulator[field.name] = field.validation;
+      return accumulator;
+    }, schema);
+
+  const { register, errors, handleSubmit } = useForm({
+    mode: "onChange",
+    reValidateMode: "onChange",
+    resolver: yupResolver(yup.object().shape(schema)),
+  });
+
+  return (
+    <StyledForm onSubmit={handleSubmit(handleOnSubmit)}>
+      <FormContent state={experimentDataState} items={fields} register={register} errors={errors} />
       <ButtonGroup
         buttons={[
           {
-            text: "Back",
-            onClick: onBack,
+            text: "Cancel",
+            onClick: () => {
+              handleOnCancel();
+            },
           },
           {
-            text: "Next",
-            onClick: onSubmit,
-            destructive: true,
+            text: "Start",
+            type: "submit",
           },
         ]}
       />
-    </WizardStep>
-  );
-};
-
-const Confirm: React.FC<WizardChild> = () => {
-  const startData = useDataLayout("startData");
-
-  return (
-    <WizardStep error={startData.error} isLoading={startData.isLoading}>
-      <Confirmation action="Start" />
-    </WizardStep>
+    </StyledForm>
   );
 };
 
@@ -172,56 +160,70 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
   heading,
   upstreamClusterTypeSelectionEnabled = false,
 }) => {
-  const createExperiment = (data: IClutch.chaos.serverexperimentation.v1.ITestConfig) => {
-    const testConfig = data;
-    testConfig["@type"] = "type.googleapis.com/clutch.chaos.serverexperimentation.v1.TestConfig";
+  const navigate = useNavigate();
+  const [error, setError] = useState(undefined);
+  const [experimentData, setExperimentData] = useState<ExperimentData | undefined>(undefined);
 
-    return client.post("/v1/chaos/experimentation/createExperiment", {
-      config: testConfig,
-    });
+  const handleOnCreatedExperiment = (id: number) => {
+    navigate(`/experimentation/run/${id}`);
   };
 
-  const dataLayout = {
-    clusterPairTargetData: {},
-    experimentData: {},
-    startData: {
-      deps: ["clusterPairTargetData", "experimentData"],
-      hydrator: (
-        clusterPairTargetData: IClutch.chaos.serverexperimentation.v1.IClusterPairTarget,
-        experimentData: IClutch.chaos.serverexperimentation.v1.AbortFaultConfig &
-          IClutch.chaos.serverexperimentation.v1.LatencyFaultConfig & { type: FaultType }
-      ) => {
-        const isAbort = experimentData.type === FaultType.ABORT;
-        const fault = isAbort
-          ? { abort: { httpStatus: experimentData.httpStatus, percent: experimentData.percent } }
-          : { latency: { durationMs: experimentData.durationMs, percent: experimentData.percent } };
+  const createExperiment = (
+    data: IClutch.chaos.serverexperimentation.v1.AbortFaultConfig &
+      IClutch.chaos.serverexperimentation.v1.LatencyFaultConfig &
+      IClutch.chaos.serverexperimentation.v1.ClusterPairTarget & { type: FaultType }
+  ) => {
+    const isAbort = data.type === FaultType.ABORT;
+    const fault = isAbort
+      ? { abort: { httpStatus: data.httpStatus, percent: data.percent } }
+      : { latency: { durationMs: data.durationMs, percent: data.percent } };
 
-        const faultInjectionCluster =
-          clusterPairTargetData.faultInjectionCluster ||
-          IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster
-            .FAULTINJECTIONCLUSTER_UPSTREAM;
+    const faultInjectionCluster =
+      data.faultInjectionCluster ||
+      IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_UPSTREAM;
 
-        return createExperiment({
+    return client
+      .post("/v1/chaos/experimentation/createExperiment", {
+        config: {
+          "@type": "type.googleapis.com/clutch.chaos.serverexperimentation.v1.TestConfig",
           clusterPair: {
-            downstreamCluster: clusterPairTargetData.downstreamCluster,
-            upstreamCluster: clusterPairTargetData.upstreamCluster,
+            downstreamCluster: data.downstreamCluster,
+            upstreamCluster: data.upstreamCluster,
             faultInjectionCluster,
           },
           ...fault,
-        });
-      },
-    },
+        },
+      })
+      .then(response => {
+        handleOnCreatedExperiment(response?.data.experiment.id);
+      })
+      .catch(err => {
+        setError(err.response.statusText);
+      });
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
-      <ClusterPairTargetDetails
-        name="Target"
+    <FormPage heading={heading} error={error}>
+      <ExperimentDetails
         upstreamClusterTypeSelectionEnabled={upstreamClusterTypeSelectionEnabled}
+        onStart={experimentDetails => setExperimentData(experimentDetails)}
       />
-      <ExperimentDetails name="Experiment Data" />
-      <Confirm name="Confirmation" />
-    </Wizard>
+      <Dialog
+        title="Experiment Start Confirmation"
+        content="Are you sure you want to start an experiment? The experiment will start immediately and you will be moved to experiment details view page."
+        open={experimentData !== undefined}
+        onClose={() => setExperimentData(undefined)}
+        buttons={[
+          {
+            label: "Yes",
+            onAction: () => {
+              createExperiment(experimentData);
+            },
+          },
+          { label: "No", onAction: () => setExperimentData(undefined) },
+        ]}
+      />
+    </FormPage>
   );
 };
 


### PR DESCRIPTION
### Description

- Combine all steps of start-experiment flow (3 of them currently) into one step.
- Add a modal dialog that asks for the confirmation when a user clicks a button that's supposed to start an experiment.
- Move a user to experiment details view when a new experiment is created.


| Before | After |
| ------ | ------ |
|![ezgif com-gif-maker (20)](https://user-images.githubusercontent.com/4410346/98143383-e106da00-1e7d-11eb-83bf-5dfab68f6f76.gif)|![ezgif com-gif-maker (21)](https://user-images.githubusercontent.com/4410346/98143656-37741880-1e7e-11eb-8999-c35696dcfdf4.gif)|


### Testing Performed
Created and start a few server experiments with the use of new UI.


