### PR TITLE
storybook: add loading story

### DIFF
--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import { DevTool } from "@hookform/devtools";
+import { Grid } from "@material-ui/core";
 import _ from "lodash";
 import styled from "styled-components";
 
@@ -119,35 +120,39 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
       {state.schemaFetchError !== "" ? (
         <Error message={state.schemaFetchError} onRetry={() => loadSchemas(type, dispatch)} />
       ) : (
-        <Loadable variant="overlay" isLoading={state.resolverLoading}>
-          {process.env.REACT_APP_DEBUG_FORMS === "true" && <DevTool control={validation.control} />}
-          {(variant === "dual" || variant === "query") && (
-            <Form onSubmit={validation.handleSubmit(submitHandler)} noValidate>
-              <QueryResolver
-                schemas={state.searchableSchemas}
-                onChange={updateResolverData}
-                validation={queryValidation}
-              />
-            </Form>
+        <Loadable overlay isLoading={state.resolverLoading}>
+          {process.env.REACT_APP_DEBUG_FORMS === "true" && (
+            <DevTool control={validation.control} />
           )}
-          {variant === "dual" && (
-            <>
-              <Spacer />- OR -
-            </>
-          )}
-          {(variant === "dual" || variant === "schema") && (
-            <Form onSubmit={validation.handleSubmit(submitHandler)} noValidate>
-              <SchemaResolver
-                schemas={state.allSchemas}
-                selectedSchema={state.selectedSchema}
-                onSelect={setSelectedSchema}
-                onChange={updateResolverData}
-                validation={schemaValidation}
-              />
-            </Form>
-          )}
-          <AdvanceButton text="Continue" onClick={validation.handleSubmit(submitHandler)} />
-          <CompressedError title="Error" message={state.resolverFetchError} />
+          <Grid container direction="column" alignItems="center">
+            {(variant === "dual" || variant === "query") && (
+              <Form onSubmit={validation.handleSubmit(submitHandler)} noValidate>
+                <QueryResolver
+                  schemas={state.searchableSchemas}
+                  onChange={updateResolverData}
+                  validation={queryValidation}
+                />
+              </Form>
+            )}
+            {variant === "dual" && (
+              <>
+                <Spacer />- OR -
+              </>
+            )}
+            {(variant === "dual" || variant === "schema") && (
+              <Form onSubmit={validation.handleSubmit(submitHandler)} noValidate>
+                <SchemaResolver
+                  schemas={state.allSchemas}
+                  selectedSchema={state.selectedSchema}
+                  onSelect={setSelectedSchema}
+                  onChange={updateResolverData}
+                  validation={schemaValidation}
+                />
+              </Form>
+            )}
+            <AdvanceButton text="Continue" onClick={validation.handleSubmit(submitHandler)} />
+            <CompressedError title="Error" message={state.resolverFetchError} />
+          </Grid>
         </Loadable>
       )}
     </Loadable>

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -121,9 +121,7 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
         <Error message={state.schemaFetchError} onRetry={() => loadSchemas(type, dispatch)} />
       ) : (
         <Loadable overlay isLoading={state.resolverLoading}>
-          {process.env.REACT_APP_DEBUG_FORMS === "true" && (
-            <DevTool control={validation.control} />
-          )}
+          {process.env.REACT_APP_DEBUG_FORMS === "true" && <DevTool control={validation.control} />}
           <Grid container direction="column" alignItems="center">
             {(variant === "dual" || variant === "query") && (
               <Form onSubmit={validation.handleSubmit(submitHandler)} noValidate>

--- a/frontend/packages/core/src/loading.tsx
+++ b/frontend/packages/core/src/loading.tsx
@@ -19,7 +19,6 @@ const Overlay = styled(Paper)`
   width: 100%;
   display: flex;
   justify-content: center;
-  align-items: center;
 `;
 const LoadingOveray = () => (
   <Overlay square elevation={0}>
@@ -27,14 +26,15 @@ const LoadingOveray = () => (
   </Overlay>
 );
 
-interface LoadableProps {
+export interface LoadableProps {
   isLoading: boolean;
-  variant?: "overlay";
+  overlay?: boolean;
 }
-const Loadable: React.FC<LoadableProps> = ({ isLoading, variant, children }) => {
-  if (variant === "overlay") {
+
+const Loadable: React.FC<LoadableProps> = ({ isLoading, overlay = false, children }) => {
+  if (overlay) {
     return (
-      <ContentContainer container direction="column" justify="center" alignItems="center">
+      <ContentContainer container>
         {children}
         {isLoading && <LoadingOveray />}
       </ContentContainer>

--- a/frontend/packages/core/src/stories/loading.stories.tsx
+++ b/frontend/packages/core/src/stories/loading.stories.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Grid } from "@material-ui/core";
+import type { Meta } from "@storybook/react";
+
+import type { LoadableProps } from "../loading";
+import Loadable from "../loading";
+
+export default {
+  title: "Core/Loading",
+  component: Loadable,
+} as Meta;
+
+const Template = (props: LoadableProps) => (
+  <Loadable {...props}>
+    <div>Hello World!</div>
+  </Loadable>
+);
+
+const LargeTemplate = (props: LoadableProps) => (
+  <Loadable {...props}>
+    <Grid container alignItems="center">
+      <img alt="clutch logo" src="https://clutch.sh/img/navigation/logo.svg" />
+    </Grid>
+  </Loadable>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  isLoading: true,
+};
+
+export const Overlay = LargeTemplate.bind({});
+Overlay.args = {
+  ...Primary.args,
+  overlay: true,
+};


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add loading story and a few updates to styling & props:
- Loadable will not longer center it's children by default. This allows each component to determine its own styling, in this case the resolver needed to be updated for this change in default behavior.
- The `variant` prop was turned into a flag on the loadable component.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![loading](https://user-images.githubusercontent.com/1004789/98182913-cbb0a080-1ebb-11eb-9b8f-7870046348dc.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual with story and local clutch build
