### PR TITLE
experimentation: consistent page layout

### DIFF
--- a/frontend/workflows/experimentation/src/core/page-layout.tsx
+++ b/frontend/workflows/experimentation/src/core/page-layout.tsx
@@ -16,12 +16,12 @@ const SizedGrid = styled(Grid)`
   padding: 24px;
 `;
 
-interface FormPageProps {
+interface PageLayoutProps {
   heading: string;
-  error: any;
+  error?: any;
 }
 
-const FormPage: React.FC<FormPageProps> = ({ heading, error, children }) => {
+const PageLayout: React.FC<PageLayoutProps> = ({ heading, error, children }) => {
   const hasError = error !== undefined && error !== "" && error !== null;
   return (
     <Spacer>
@@ -36,4 +36,4 @@ const FormPage: React.FC<FormPageProps> = ({ heading, error, children }) => {
   );
 };
 
-export default FormPage;
+export default PageLayout;

--- a/frontend/workflows/experimentation/src/index.tsx
+++ b/frontend/workflows/experimentation/src/index.tsx
@@ -1,5 +1,6 @@
 import type { WorkflowConfiguration } from "@clutch-sh/core";
 
+import PageLayout from "./core/page-layout";
 import ListExperiments from "./list-experiments";
 import ViewExperimentRun from "./view-experiment-run";
 
@@ -31,3 +32,5 @@ const register = (): WorkflowConfiguration => {
 };
 
 export default register;
+
+export { PageLayout };

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { ButtonGroup, client, Error } from "@clutch-sh/core";
+import { BaseWorkflowProps, ButtonGroup, client, Error } from "@clutch-sh/core";
+import { PageLayout } from "@clutch-sh/experimentation";
 import { Container } from "@material-ui/core";
 import styled from "styled-components";
 
@@ -16,12 +17,12 @@ interface ExperimentTypeLinkProps {
   path: string;
 }
 
-interface ListExperimentsProps {
+interface ListExperimentsProps extends BaseWorkflowProps {
   columns: Column[];
   links: ExperimentTypeLinkProps[];
 }
 
-const ListExperiments: React.FC<ListExperimentsProps> = ({ columns, links }) => {
+const ListExperiments: React.FC<ListExperimentsProps> = ({ heading, columns, links }) => {
   const [experiments, setExperiments] = useState<
     IClutch.chaos.experimentation.v1.ListViewItem[] | undefined
   >(undefined);
@@ -52,8 +53,7 @@ const ListExperiments: React.FC<ListExperimentsProps> = ({ columns, links }) => 
   });
 
   return (
-    <Layout>
-      {error && <Error message={error} />}
+    <PageLayout heading={heading} error={error}>
       <ButtonGroup buttons={buttons} />
       <ListView
         columns={columns}
@@ -62,7 +62,7 @@ const ListExperiments: React.FC<ListExperimentsProps> = ({ columns, links }) => 
           handleRowSelection(event, item);
         }}
       />
-    </Layout>
+    </PageLayout>
   );
 };
 

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -1,16 +1,10 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { BaseWorkflowProps, ButtonGroup, client, Error } from "@clutch-sh/core";
-import { PageLayout } from "@clutch-sh/experimentation";
-import { Container } from "@material-ui/core";
-import styled from "styled-components";
+import { BaseWorkflowProps, ButtonGroup, client } from "@clutch-sh/core";
 
+import PageLayout from "./core/page-layout";
 import { Column, ListView } from "./list-view";
-
-const Layout = styled(Container)`
-  padding: 5% 0;
-`;
 
 interface ExperimentTypeLinkProps {
   displayName: string;

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { clutch as IClutch } from "@clutch-sh/api";
-import { BaseWorkflowProps, ButtonGroup, client, Error, TextField } from "@clutch-sh/core";
-import { PageLayout } from "@clutch-sh/experimentation";
+import { BaseWorkflowProps, ButtonGroup, client, TextField } from "@clutch-sh/core";
 import styled from "styled-components";
 
+import PageLayout from "./core/page-layout";
 import { propertyToString } from "./property-helpers";
 
 export const Form = styled.form`

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { clutch as IClutch } from "@clutch-sh/api";
-import { ButtonGroup, client, Error, TextField } from "@clutch-sh/core";
+import { BaseWorkflowProps, ButtonGroup, client, Error, TextField } from "@clutch-sh/core";
+import { PageLayout } from "@clutch-sh/experimentation";
 import styled from "styled-components";
 
 import { propertyToString } from "./property-helpers";
@@ -13,7 +14,7 @@ export const Form = styled.form`
   width: 100%;
 `;
 
-const ViewExperimentRun: React.FC = () => {
+const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
   const [experiment, setExperiment] = useState<
     IClutch.chaos.experimentation.v1.ExperimentRunDetails | undefined
   >(undefined);
@@ -77,28 +78,29 @@ const ViewExperimentRun: React.FC = () => {
   }
 
   return (
-    <Form>
-      {error && <Error message={error} />}
-      {experiment && (
-        <>
-          {experiment.properties.items.map(property => (
+    <PageLayout heading={heading} error={error}>
+      <Form>
+        {experiment && (
+          <>
+            {experiment.properties.items.map(property => (
+              <TextField
+                key={property.label}
+                label={property.label}
+                defaultValue={propertyToString(property)}
+                InputProps={{ readOnly: true }}
+              />
+            ))}
             <TextField
-              key={property.label}
-              label={property.label}
-              defaultValue={propertyToString(property)}
+              multiline
+              label="Config"
+              defaultValue={JSON.stringify(experiment.config, null, 4)}
               InputProps={{ readOnly: true }}
             />
-          ))}
-          <TextField
-            multiline
-            label="Config"
-            defaultValue={JSON.stringify(experiment.config, null, 4)}
-            InputProps={{ readOnly: true }}
-          />
-          <ButtonGroup buttons={makeButtons()} />
-        </>
-      )}
-    </Form>
+            <ButtonGroup buttons={makeButtons()} />
+          </>
+        )}
+      </Form>
+    </PageLayout>
   );
 };
 

--- a/frontend/workflows/experimentation/tsconfig.json
+++ b/frontend/workflows/experimentation/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./dist",
     "rootDir": "./src"
   },

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -21,6 +21,7 @@
     "@clutch-sh/api": "^0.0.0-beta",
     "@clutch-sh/core": "^0.0.0-beta",
     "@clutch-sh/data-layout": "^0.0.0-beta",
+    "@clutch-sh/experimentation": "^0.0.0-beta",
     "@clutch-sh/wizard": "^0.0.0-beta",
     "@hookform/resolvers": "^1.0.0",
     "@material-ui/core": "^4.11.0",

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -4,12 +4,12 @@ import { useNavigate } from "react-router-dom";
 import { clutch as IClutch } from "@clutch-sh/api";
 import type { BaseWorkflowProps } from "@clutch-sh/core";
 import { ButtonGroup, client } from "@clutch-sh/core";
+import { PageLayout } from "@clutch-sh/experimentation";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
 import Dialog from "./dialog";
 import { FormContent } from "./form-content";
-import FormPage from "./form-page";
 
 enum FaultType {
   ABORT = "Abort",
@@ -195,7 +195,7 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
   };
 
   return (
-    <FormPage heading={heading} error={error}>
+    <PageLayout heading={heading} error={error}>
       <ExperimentDetails
         upstreamClusterTypeSelectionEnabled={upstreamClusterTypeSelectionEnabled}
         onStart={experimentDetails => setExperimentData(experimentDetails)}
@@ -215,7 +215,7 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
           { label: "No", onAction: () => setExperimentData(undefined) },
         ]}
       />
-    </FormPage>
+    </PageLayout>
   );
 };
 

--- a/frontend/workflows/serverexperimentation/tsconfig.json
+++ b/frontend/workflows/serverexperimentation/tsconfig.json
@@ -15,6 +15,7 @@
     {"path": "../../api"},
     {"path": "../../packages/core"},
     {"path": "../../packages/data-layout"},
+    {"path": "../../packages/experimentation"},
     {"path": "../../packages/wizard"},
   ]
 }

--- a/frontend/workflows/serverexperimentation/tsconfig.json
+++ b/frontend/workflows/serverexperimentation/tsconfig.json
@@ -12,10 +12,10 @@
     "src/tests/**/*"
   ],
   "references": [
+    {"path": "../experimentation"},
     {"path": "../../api"},
     {"path": "../../packages/core"},
     {"path": "../../packages/data-layout"},
-    {"path": "../../packages/experimentation"},
     {"path": "../../packages/wizard"},
   ]
 }


### PR DESCRIPTION
### Description
Use the same page layout with a heading positioned in the top-left corner in all of the screens that are implemented as part of `experimentation` and `serverexperimentation` packages.

| Before | After |
| ----- | ----- |
|<img width="1144" alt="Screen Shot 2020-11-04 at 7 16 28 PM" src="https://user-images.githubusercontent.com/4410346/98193818-e4788080-1ed2-11eb-8d09-b231f42808c8.png">|<img width="1139" alt="Screen Shot 2020-11-04 at 6 54 54 PM" src="https://user-images.githubusercontent.com/4410346/98193849-ef331580-1ed2-11eb-9a8e-52eece52f271.png">|
|<img width="1135" alt="Screen Shot 2020-11-04 at 7 16 36 PM" src="https://user-images.githubusercontent.com/4410346/98193865-f823e700-1ed2-11eb-93c3-8880adeeaf11.png">|<img width="1140" alt="Screen Shot 2020-11-04 at 7 17 54 PM" src="https://user-images.githubusercontent.com/4410346/98193877-fd813180-1ed2-11eb-9042-9f2a3e941a3b.png">|

### Testing Performed
Went through all of the modified screens.
