### PR TITLE
frontend: add types for JWT Token

### DIFF
--- a/frontend/packages/core/src/AppLayout/user.tsx
+++ b/frontend/packages/core/src/AppLayout/user.tsx
@@ -33,6 +33,10 @@ const Initials = styled(Typography)`
   `}
 `;
 
+interface JwtToken {
+  sub: string;
+}
+
 const userId = (): string => {
   // Check JWT token for subject and display if available.
   const token = Cookies.get("token");
@@ -41,7 +45,7 @@ const userId = (): string => {
   }
   let subject = "Unknown user";
   try {
-    const decoded = jwtDecode(token);
+    const decoded = jwtDecode(token) as JwtToken;
     if (decoded?.sub) {
       subject = decoded.sub;
     }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
jwt-decode released v3.1.1 this morning which included [type support](https://github.com/auth0/jwt-decode/commit/c9eaa4f880bb3638eddc631371010f7022436b10). `jwtDecode` now returns unknown and therefore fails typescript builds.

This defines the expected token props we rely on.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manually built
