### PR TITLE
storybook: remove iframe deny header

### DIFF
--- a/frontend/netlify/netlify.toml
+++ b/frontend/netlify/netlify.toml
@@ -7,5 +7,4 @@
   for = "/*"
 
   [headers.values]
-    X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes the [component website](https://clutch-components.netlify.app/) that can't load at the moment since Storybook loads it's content in an iframe.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
