### PR TITLE
k8s: improve docs and error handling

### DIFF
--- a/api/config/service/k8s/v1/k8s.proto
+++ b/api/config/service/k8s/v1/k8s.proto
@@ -11,10 +11,11 @@ message Config {
   // A list of paths for `kubeconfig` files. Each config will be read and each context will become a clientset
   // in the clientset manager. If no files are provided, the service will use the K8s SDK default loading rules
   // which are detailed here: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/,
-  // i.e. look for configs: 
+  // i.e. look for configs:
   // - in a comma-separated `KUBECONFIG` environment variable
   // - else `$HOME/.kube/config`
-  // - else in-cluster config https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
+  // - else in-cluster config
+  // https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
   repeated string kubeconfigs = 1 [ (validate.rules).repeated = {unique : true} ];
 
   RestClientConfig rest_client_config = 2;

--- a/api/config/service/k8s/v1/k8s.proto
+++ b/api/config/service/k8s/v1/k8s.proto
@@ -11,7 +11,10 @@ message Config {
   // A list of paths for `kubeconfig` files. Each config will be read and each context will become a clientset
   // in the clientset manager. If no files are provided, the service will use the K8s SDK default loading rules
   // which are detailed here: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/,
-  // i.e. look for comma-separated configs in the KUBECONFIG environment variable, otherwise read `$HOME/.kube/config`.
+  // i.e. look for configs: 
+  // - in a comma-separated `KUBECONFIG` environment variable
+  // - else `$HOME/.kube/config`
+  // - else in-cluster config https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
   repeated string kubeconfigs = 1 [ (validate.rules).repeated = {unique : true} ];
 
   RestClientConfig rest_client_config = 2;

--- a/api/config/service/k8s/v1/k8s.proto
+++ b/api/config/service/k8s/v1/k8s.proto
@@ -8,7 +8,12 @@ import "validate/validate.proto";
 import "google/protobuf/duration.proto";
 
 message Config {
+  // A list of paths for `kubeconfig` files. Each config will be read and each context will become a clientset
+  // in the clientset manager. If no files are provided, the service will use the K8s SDK default loading rules
+  // which are detailed here: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/,
+  // i.e. look for comma-separated configs in the KUBECONFIG environment variable, otherwise read `$HOME/.kube/config`.
   repeated string kubeconfigs = 1 [ (validate.rules).repeated = {unique : true} ];
+
   RestClientConfig rest_client_config = 2;
 }
 

--- a/backend/api/config/service/k8s/v1/k8s.pb.go
+++ b/backend/api/config/service/k8s/v1/k8s.pb.go
@@ -32,6 +32,14 @@ type Config struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// A list of paths for `kubeconfig` files. Each config will be read and each context will become a clientset
+	// in the clientset manager. If no files are provided, the service will use the K8s SDK default loading rules
+	// which are detailed here: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/,
+	// i.e. look for configs:
+	// - in a comma-separated `KUBECONFIG` environment variable
+	// - else `$HOME/.kube/config`
+	// - else in-cluster config
+	// https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration
 	Kubeconfigs      []string          `protobuf:"bytes,1,rep,name=kubeconfigs,proto3" json:"kubeconfigs,omitempty"`
 	RestClientConfig *RestClientConfig `protobuf:"bytes,2,opt,name=rest_client_config,json=restClientConfig,proto3" json:"rest_client_config,omitempty"`
 }

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -101,7 +101,7 @@ func newClientsetManager(rules *clientcmd.ClientConfigLoadingRules, restClientCo
 			lookup[inCluster] = &ctxClientsetImpl{Interface: clientset, namespace: "default", cluster: inCluster}
 		case rest.ErrNotInCluster:
 			// Warn but allow to continue.
-			logger.Warn("not in a kubernetes cluster, unable to configure kube clientset")
+			logger.Warn("unable to load configuration for kube clientset")
 		default:
 			return nil, fmt.Errorf("encountered unexpected issue with InClusterConfig, config detected but incomplete: %w", err)
 		}

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -86,21 +86,24 @@ func newClientsetManager(rules *clientcmd.ClientConfigLoadingRules, restClientCo
 		logger.Info("no kubeconfig was found, falling back to InClusterConfig")
 
 		restConfig, err := rest.InClusterConfig()
-		if err := ApplyRestClientConfig(restConfig, restClientConfig); err != nil {
-			return nil, err
-		}
 
 		switch err {
-		case rest.ErrNotInCluster:
-			logger.Warn("not in a kubernetes cluster, unable to configure kube clientset")
 		case nil:
+			if err := ApplyRestClientConfig(restConfig, restClientConfig); err != nil {
+				return nil, err
+			}
+
 			clientset, err := k8s.NewForConfig(restConfig)
 			if err != nil {
 				return nil, fmt.Errorf("could not create k8s InClusterConfig: %w", err)
 			}
+
 			lookup[inCluster] = &ctxClientsetImpl{Interface: clientset, namespace: "default", cluster: inCluster}
+		case rest.ErrNotInCluster:
+			// Warn but allow to continue.
+			logger.Warn("not in a kubernetes cluster, unable to configure kube clientset")
 		default:
-			return nil, err
+			return nil, fmt.Errorf("encountered unexpected issue with InClusterConfig, config detected but incomplete: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Add additional config documentation. Also make the code a little easier to read, wrap error conditions for easier location of error origin.

Result of Slack thread https://lyftoss.slack.com/archives/C015UJ6LED9/p1604370159024700:
```
2020-11-03T02:07:29.406Z	INFO	k8s/clientset.go:86	no kubeconfig was found, falling back to InClusterConfig	{"serviceName": "clutch.service.k8s"}
2020-11-03T02:07:29.406Z	FATAL	gateway/gateway.go:109	service instantiation failed	{"serviceName": "clutch.service.k8s", "error": "open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory"}
github.com/lyft/clutch/backend/gateway.RunWithConfig
	/go/src/github.com/lyft/clutch/backend/gateway/gateway.go:109
github.com/lyft/clutch/backend/gateway.Run
	/go/src/github.com/lyft/clutch/backend/gateway/gateway.go:41
main.main
	/go/src/github.com/lyft/clutch/backend/main.go:12
runtime.main
	/usr/local/go/src/runtime/proc.go:204
```

### Testing Performed
CI