### PR TITLE
experimentation: fix the selection of FaultInjectionCluster

### DIFF
--- a/frontend/workflows/serverexperimentation/src/form-fields.tsx
+++ b/frontend/workflows/serverexperimentation/src/form-fields.tsx
@@ -22,6 +22,7 @@ interface TextFieldProps {
 
 interface SelectProps {
   options: SelectOption[];
+  defaultValue: string;
 }
 
 interface SelectOption {
@@ -31,6 +32,7 @@ interface SelectOption {
 
 interface RadioGroupProps {
   options: RadioGroupOption[];
+  defaultValue: string;
 }
 
 interface RadioGroupOption {
@@ -45,7 +47,7 @@ interface FormItem {
   inputProps: SelectProps | TextFieldProps;
 }
 
-const FormContent: React.FC<FormProps> = ({ state, items, register, errors }) => {
+const FormFields: React.FC<FormProps> = ({ state, items, register, errors }) => {
   const [data, setData] = state;
 
   return (
@@ -82,6 +84,9 @@ const FormContent: React.FC<FormProps> = ({ state, items, register, errors }) =>
               name={field.name}
               label={field.label}
               options={customProps.options}
+              defaultOption={customProps.options
+                .map(o => o.value)
+                .indexOf(customProps.defaultValue)}
               onChange={value => {
                 const copiedData = { ...data };
                 copiedData[field.name] = value;
@@ -99,6 +104,9 @@ const FormContent: React.FC<FormProps> = ({ state, items, register, errors }) =>
                 key={field.name}
                 label={field.label}
                 options={customProps.options}
+                defaultOption={customProps.options
+                  .map(o => o.value)
+                  .indexOf(customProps.defaultValue)}
                 onChange={value => {
                   const copiedData = { ...data };
                   copiedData[field.name] = value;
@@ -115,4 +123,4 @@ const FormContent: React.FC<FormProps> = ({ state, items, register, errors }) =>
   );
 };
 
-export { FormContent, FormItem, SelectOption, SelectProps, TextFieldProps };
+export default FormFields;

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -9,27 +9,16 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
 import Dialog from "./dialog";
-import { FormContent } from "./form-content";
+import FormFields from "./form-fields";
 
 enum FaultType {
   ABORT = "Abort",
   LATENCY = "Latency",
 }
 
-const faultInjectionTypeItems = [
-  {
-    label: "Internal",
-    value: IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_UPSTREAM.toString(),
-  },
-  {
-    label: "External (3rd party)",
-    value: IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_DOWNSTREAM.toString(),
-  },
-];
-
 type ExperimentData = IClutch.chaos.serverexperimentation.v1.AbortFaultConfig &
   IClutch.chaos.serverexperimentation.v1.LatencyFaultConfig &
-  IClutch.chaos.serverexperimentation.v1.ClusterPairTarget & { type: FaultType };
+  IClutch.chaos.serverexperimentation.v1.ClusterPairTarget & { faultType: FaultType };
 
 interface ExperimentDetailsProps {
   upstreamClusterTypeSelectionEnabled: boolean;
@@ -40,7 +29,14 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
   upstreamClusterTypeSelectionEnabled,
   onStart,
 }) => {
-  const experimentDataState = useState<ExperimentData>({} as ExperimentData);
+  const initialExperimentData = {
+    faultInjectionCluster:
+      IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_UPSTREAM,
+    faultType: FaultType.ABORT,
+  } as ExperimentData;
+
+  const experimentDataState = useState<ExperimentData>(initialExperimentData);
+
   const experimentData = experimentDataState[0];
   const navigate = useNavigate();
 
@@ -52,7 +48,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
     onStart(experimentData);
   };
 
-  const isAbort = (experimentData?.type ?? FaultType.ABORT) === FaultType.ABORT;
+  const isAbort = experimentData.faultType === FaultType.ABORT;
   const fields = [
     {
       name: "downstreamCluster",
@@ -69,13 +65,25 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
       inputProps: { defaultValue: undefined },
     },
     upstreamClusterTypeSelectionEnabled && {
-      name: "upstreamClusterType",
+      name: "faultInjectionCluster",
       label: "Upstream Cluster Type",
       type: "radio-group",
-      inputProps: { options: faultInjectionTypeItems },
+      inputProps: {
+        options: [
+          {
+            label: "Internal",
+            value: IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_UPSTREAM.toString(),
+          },
+          {
+            label: "External (3rd party)",
+            value: IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_DOWNSTREAM.toString(),
+          },
+        ],
+        defaultValue: initialExperimentData.faultInjectionCluster.toString(),
+      },
     },
     {
-      name: "type",
+      name: "faultType",
       label: "Fault Type",
       type: "select",
       inputProps: {
@@ -83,6 +91,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
           { label: "Abort", value: FaultType.ABORT },
           { label: "Latency", value: FaultType.LATENCY },
         ],
+        defaultValue: initialExperimentData.faultType,
       },
     },
     {
@@ -125,7 +134,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
 
   return (
     <form onSubmit={handleSubmit(handleOnSubmit)}>
-      <FormContent state={experimentDataState} items={fields} register={register} errors={errors} />
+      <FormFields state={experimentDataState} items={fields} register={register} errors={errors} />
       <ButtonGroup
         buttons={[
           {
@@ -160,19 +169,16 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
     navigate(`/experimentation/run/${id}`);
   };
 
-  const createExperiment = (
-    data: IClutch.chaos.serverexperimentation.v1.AbortFaultConfig &
-      IClutch.chaos.serverexperimentation.v1.LatencyFaultConfig &
-      IClutch.chaos.serverexperimentation.v1.ClusterPairTarget & { type: FaultType }
-  ) => {
-    const isAbort = data.type === FaultType.ABORT;
+  const handleOnCreatedExperimentFailure = (err: string) => {
+    setExperimentData(undefined);
+    setError(err);
+  };
+
+  const createExperiment = (data: ExperimentData) => {
+    const isAbort = data.faultType === FaultType.ABORT;
     const fault = isAbort
       ? { abort: { httpStatus: data.httpStatus, percent: data.percent } }
       : { latency: { durationMs: data.durationMs, percent: data.percent } };
-
-    const faultInjectionCluster =
-      data.faultInjectionCluster ||
-      IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster.FAULTINJECTIONCLUSTER_UPSTREAM;
 
     return client
       .post("/v1/chaos/experimentation/createExperiment", {
@@ -181,7 +187,10 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
           clusterPair: {
             downstreamCluster: data.downstreamCluster,
             upstreamCluster: data.upstreamCluster,
-            faultInjectionCluster,
+            faultInjectionCluster:
+              IClutch.chaos.serverexperimentation.v1.FaultInjectionCluster[
+                data.faultInjectionCluster
+              ],
           },
           ...fault,
         },
@@ -190,7 +199,7 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
         handleOnCreatedExperiment(response?.data.experiment.id);
       })
       .catch(err => {
-        setError(err.response.statusText);
+        handleOnCreatedExperimentFailure(err.response.statusText);
       });
   };
 


### PR DESCRIPTION
### Description

- Fix an issue that made all server experiments to inject faults on upstream, even if an upstream cluster was an external cluster.
- Add default values for `faultInjectionCluster` and `faultType` to make it easier to reason about the state of start experimentation screen.

### Testing Performed
Manual testing.

