### PR TITLE
ui v2: disable transitions

### DIFF
--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -59,7 +59,12 @@ const lightPalette = (): ClutchPalette => {
 const lightTheme = () => {
   return createMuiTheme({
     palette: lightPalette(),
+    transitions: {
+      // https://material-ui.com/getting-started/faq/#how-can-i-disable-transitions-globally
+      create: () => "none"
+    },
     props: {
+
       MuiButtonBase: {
         // https://material-ui.com/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally
         disableRipple: true,

--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -64,7 +64,6 @@ const lightTheme = () => {
       create: () => "none"
     },
     props: {
-
       MuiButtonBase: {
         // https://material-ui.com/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally
         disableRipple: true,


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The built-in transitions for MUI components are largely incompatible with V2 components and require a lot of extra work to get right. We will disable transitions globally for MUI components in UI V2.

Theme props from https://material-ui.com/getting-started/faq/#how-can-i-disable-transitions-globally