### PR TITLE
tools: refactor db migration logic

### DIFF
--- a/backend/cmd/migrate/migrate.go
+++ b/backend/cmd/migrate/migrate.go
@@ -83,13 +83,13 @@ func (m *Migrator) setupSqlClient() (*sql.DB, string) {
 	return sqlDB, hostInfo
 }
 
-func (m *Migrator) Up() {
-	sqlDB, hostInfo := m.setupSqlClient()
-
+// Asks the user to confrim an action, this can be skipped by using the force flag.
+// If the input is not 'y' we log fatal and exit.
+func (m *Migrator) confirmWithUser(msg string, hostInfo string) {
 	// Verify that user wants to continue (unless -f for force is passed as a flag).
 	m.log.Info("using database", zap.String("hostInfo", hostInfo))
 	if !m.flags.Force {
-		m.log.Warn("migration has the potential to cause irrevocable data loss, verify host information above")
+		m.log.Warn(msg)
 
 		fmt.Printf("\n*** Continue with migration? [y/N] ")
 		var answer string
@@ -101,6 +101,13 @@ func (m *Migrator) Up() {
 		}
 		fmt.Println()
 	}
+}
+
+func (m *Migrator) Up() {
+	sqlDB, hostInfo := m.setupSqlClient()
+
+	msg := "migration has the potential to cause irrevocable data loss, verify host information above"
+	m.confirmWithUser(msg, hostInfo)
 
 	// Ping database and bring up driver.
 	if err := sqlDB.Ping(); err != nil {

--- a/backend/cmd/migrate/migrate.go
+++ b/backend/cmd/migrate/migrate.go
@@ -47,6 +47,13 @@ func (m *migrateLogger) Verbose() bool {
 	return true
 }
 
+// Migrator handles all migration operations both up and down.
+type Migrator struct {
+	log   *zap.Logger
+	flags *MigrateFlags
+	cfg   *gatewayv1.Config
+}
+
 func (m *Migrator) setupSqlClient() (*sql.DB, string) {
 	// Find the database in config and instantiate the service.
 	var sqlDB *sql.DB
@@ -129,13 +136,6 @@ func (m *Migrator) Up() {
 	if err != nil && err != migrate.ErrNoChange {
 		m.log.Fatal("failed running migrations", zap.Error(err))
 	}
-}
-
-// Migrator handles all migration operations both up and down.
-type Migrator struct {
-	log   *zap.Logger
-	flags *MigrateFlags
-	cfg   *gatewayv1.Config
 }
 
 func main() {

--- a/backend/cmd/migrate/migrate_test.go
+++ b/backend/cmd/migrate/migrate_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/lyft/clutch/backend/gateway"
+)
+
+func TestSetupSqlClient(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	pwd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	flags := &gateway.Flags{
+		ConfigPath: path.Join(pwd, "testdata/clutch-config-test.yaml"),
+	}
+
+	cfg := gateway.MustReadOrValidateConfig(flags)
+
+	migrate := &Migrator{
+		log: log,
+		cfg: cfg,
+	}
+
+	sqlDB, hostInfo := migrate.setupSqlClient()
+	assert.NotNil(t, sqlDB)
+	assert.Equal(t, "clutch@0.0.0.0:5432", hostInfo)
+}

--- a/backend/cmd/migrate/testdata/clutch-config-test.yaml
+++ b/backend/cmd/migrate/testdata/clutch-config-test.yaml
@@ -1,0 +1,25 @@
+gateway:
+  logger:
+    pretty: true
+    level: DEBUG
+  stats:
+    flush_interval: 1s
+    log_reporter: {}
+  timeouts:
+    default: 15s
+  listener:
+    tcp:
+      address: 0.0.0.0
+      port: 8080
+      secure: false
+services:
+  - name: clutch.service.db.postgres
+    typed_config:
+      "@type": types.google.com/clutch.config.service.db.postgres.v1.Config
+      connection:
+        host: 0.0.0.0
+        port: 5432
+        user: clutch
+        ssl_mode: DISABLE
+        dbname: clutch
+        password: clutch


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Refactoring the db migration tool to make it easier to implement the `down` migration, the behavior is exactly the same.


### Testing Performed
unit / local.

Starting with an empty db
```
clutch=# \dt
Did not find any relations.
```

```
➜ go run migrate.go -c ./testdata/clutch-config-test.yaml
2020-11-18T16:08:32.334-0800	INFO	migrate/migrate.go:90	using database	{"hostInfo": "clutch@0.0.0.0:5432"}
2020-11-18T16:08:32.335-0800	WARN	migrate/migrate.go:92	migration has the potential to cause irrevocable data loss, verify host information above

*** Continue with migration? [y/N] y

2020-11-18T16:08:48.355-0800	INFO	migrate/migrate.go:134	applying migrations	{"migrationDir": "/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/cmd/migrate/migrations"}
2020-11-18T16:08:48.361-0800	INFO	migrate/migrate.go:43	Start buffering 1/u create_audit_event_table
2020-11-18T16:08:48.361-0800	INFO	migrate/migrate.go:43	Start buffering 2/u create_experiments_table
2020-11-18T16:08:48.361-0800	INFO	migrate/migrate.go:43	Start buffering 3/u add_audit_pending_column
2020-11-18T16:08:48.361-0800	INFO	migrate/migrate.go:43	Start buffering 4/u experiments_schema_changes
2020-11-18T16:08:48.362-0800	INFO	migrate/migrate.go:43	Start buffering 5/u create_topology_cache_table
2020-11-18T16:08:48.362-0800	INFO	migrate/migrate.go:43	Start buffering 6/u experimentation_add_canceled_at_column
2020-11-18T16:08:48.374-0800	INFO	migrate/migrate.go:43	Read and execute 1/u create_audit_event_table
2020-11-18T16:08:48.394-0800	INFO	migrate/migrate.go:43	Finished 1/u create_audit_event_table (read 12.919147ms, ran 20.165595ms)
2020-11-18T16:08:48.405-0800	INFO	migrate/migrate.go:43	Read and execute 2/u create_experiments_table
2020-11-18T16:08:48.420-0800	INFO	migrate/migrate.go:43	Finished 2/u create_experiments_table (read 43.754383ms, ran 14.445821ms)
2020-11-18T16:08:48.427-0800	INFO	migrate/migrate.go:43	Read and execute 3/u add_audit_pending_column
2020-11-18T16:08:48.442-0800	INFO	migrate/migrate.go:43	Finished 3/u add_audit_pending_column (read 66.015821ms, ran 14.228279ms)
2020-11-18T16:08:48.451-0800	INFO	migrate/migrate.go:43	Read and execute 4/u experiments_schema_changes
2020-11-18T16:08:48.469-0800	INFO	migrate/migrate.go:43	Finished 4/u experiments_schema_changes (read 89.076165ms, ran 18.138613ms)
2020-11-18T16:08:48.482-0800	INFO	migrate/migrate.go:43	Read and execute 5/u create_topology_cache_table
2020-11-18T16:08:48.506-0800	INFO	migrate/migrate.go:43	Finished 5/u create_topology_cache_table (read 120.01719ms, ran 24.055709ms)
2020-11-18T16:08:48.518-0800	INFO	migrate/migrate.go:43	Read and execute 6/u experimentation_add_canceled_at_column
2020-11-18T16:08:48.532-0800	INFO	migrate/migrate.go:43	Finished 6/u experimentation_add_canceled_at_column (read 155.998217ms, ran 14.259879ms)
```

Tables are created and the migration version is 6, which is all we have at the time of writing.
```
clutch=# \dt
              List of relations
 Schema |       Name        | Type  | Owner
--------+-------------------+-------+--------
 public | audit_events      | table | clutch
 public | experiment_config | table | clutch
 public | experiment_run    | table | clutch
 public | schema_migrations | table | clutch
 public | topology_cache    | table | clutch
(5 rows)

clutch=# select * from schema_migrations;
 version | dirty
---------+-------
       6 | f
(1 row)
```

Also just to show that `force` is still working as expected
```
➜ go run migrate.go -f -c ./testdata/clutch-config-test.yaml
2020-11-18T16:10:27.249-0800	INFO	migrate/migrate.go:90	using database	{"hostInfo": "clutch@0.0.0.0:5432"}
2020-11-18T16:10:27.272-0800	INFO	migrate/migrate.go:134	applying migrations	{"migrationDir": "/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/cmd/migrate/migrations"}
```

Testing around the user conformation input

Abort migration
```
➜  go run migrate.go -c ./testdata/clutch-config-test.yaml
2020-11-19T09:32:15.747-0800	INFO	migrate/migrate.go:90	using database	{"hostInfo": "clutch@0.0.0.0:5432"}
2020-11-19T09:32:15.747-0800	WARN	migrate/migrate.go:92	migration has the potential to cause irrevocable data loss, verify host information above

*** Continue with migration? [y/N] n
2020-11-19T09:32:17.789-0800	FATAL	migrate/migrate.go:100	aborting, enter 'y' to continue or use the '-f' (force) option
exit status 1
```

Invalid input
```
➜  go run migrate.go -c ./testdata/clutch-config-test.yaml
2020-11-19T09:32:24.588-0800	INFO	migrate/migrate.go:90	using database	{"hostInfo": "clutch@0.0.0.0:5432"}
2020-11-19T09:32:24.588-0800	WARN	migrate/migrate.go:92	migration has the potential to cause irrevocable data loss, verify host information above

*** Continue with migration? [y/N] yyyyy
2020-11-19T09:32:27.120-0800	FATAL	migrate/migrate.go:100	aborting, enter 'y' to continue or use the '-f' (force) option
exit status 1
```

Valid input 
```
➜ go run migrate.go -c ./testdata/clutch-config-test.yaml
2020-11-19T09:32:34.111-0800	INFO	migrate/migrate.go:90	using database	{"hostInfo": "clutch@0.0.0.0:5432"}
2020-11-19T09:32:34.111-0800	WARN	migrate/migrate.go:92	migration has the potential to cause irrevocable data loss, verify host information above

*** Continue with migration? [y/N] y

2020-11-19T09:32:35.074-0800	INFO	migrate/migrate.go:141	applying migrations	{"migrationDir": "/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/cmd/migrate/migrations"}
```
