### PR TITLE
logging: log 5xx server errors

### DIFF
--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -164,7 +164,7 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 	}
 
 	// Instantiate and register modules listed in the configuration.
-	rpcMux, err := mux.New(interceptors, assets, cfg.Gateway.Assets)
+	rpcMux, err := mux.New(interceptors, assets, cfg.Gateway.Assets, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -46,14 +46,14 @@ func copyHTTPResponse(resp *http.Response, w http.ResponseWriter, logger *zap.Lo
 			w.Header().Add(key, val)
 		}
 	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
 		body, _ := ioutil.ReadAll(resp.Body)
 		if len(body) > 0 {
 			logger.Error("HTTP 5xx error:", zap.Int("status code", resp.StatusCode), zap.String("response body", string(body)))
 		}
 	}
-	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
 }
 
 func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/backend/gateway/mux/mux_test.go
+++ b/backend/gateway/mux/mux_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 
 	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
 )
@@ -26,7 +27,7 @@ func TestCopyHTTPResponse(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	copyHTTPResponse(resp, rec)
+	copyHTTPResponse(resp, rec, zaptest.NewLogger(t))
 	result := rec.Result()
 	assert.Equal(t, status, result.StatusCode)
 	assert.Equal(t, headers, rec.Header())


### PR DESCRIPTION
### Description
Log 5xx HTTP errors in the server code along with the response body

This PR updated the mux.New method to take in a logger as a parameter and looks for a 5xx error in the `copyHTTPResponse` method that is invoked when `StatusCode != http.StatusOK`