### PR TITLE
core: add disabled property to RadioGroup

### DIFF
--- a/frontend/packages/core/src/Input/radio-group.tsx
+++ b/frontend/packages/core/src/Input/radio-group.tsx
@@ -6,6 +6,7 @@ import {
   Radio as MuiRadio,
   RadioGroup as MuiRadioGroup,
 } from "@material-ui/core";
+import { fade } from "@material-ui/core/styles/colorManipulator";
 import styled from "styled-components";
 
 const FormLabel = styled(MuiFormLabel)`
@@ -15,6 +16,9 @@ const FormLabel = styled(MuiFormLabel)`
   }
   font-weight: bold;
   position: relative;
+  &.Mui-disabled {
+    opacity: 0.75;
+  }
   `}
 `;
 
@@ -39,6 +43,9 @@ const Radio = styled(MuiRadio)`
   &.Mui-checked {
     color: ${theme.palette.accent.main};
   }
+  &.Mui-disabled {
+    opacity: 0.75;
+  }
   `}
 `;
 
@@ -50,6 +57,7 @@ interface RadioGroupOption {
 interface RadioGroupProps {
   defaultOption?: number;
   label?: string;
+  disabled?: boolean;
   maxWidth?: string;
   name: string;
   options: RadioGroupOption[];
@@ -59,6 +67,7 @@ interface RadioGroupProps {
 const RadioGroup: React.FC<RadioGroupProps> = ({
   defaultOption = 0,
   label,
+  disabled,
   maxWidth,
   name,
   options,
@@ -87,7 +96,7 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
   }, []);
 
   return (
-    <FormControl key={name} data-max-width={maxWidth}>
+    <FormControl key={name} disabled={disabled} data-max-width={maxWidth}>
       {label && <FormLabel>{label}</FormLabel>}
       <StyledRadioGroup
         aria-label={label}

--- a/frontend/packages/core/src/Input/radio-group.tsx
+++ b/frontend/packages/core/src/Input/radio-group.tsx
@@ -6,7 +6,6 @@ import {
   Radio as MuiRadio,
   RadioGroup as MuiRadioGroup,
 } from "@material-ui/core";
-import { fade } from "@material-ui/core/styles/colorManipulator";
 import styled from "styled-components";
 
 const FormLabel = styled(MuiFormLabel)`

--- a/frontend/packages/core/src/Input/radio-group.tsx
+++ b/frontend/packages/core/src/Input/radio-group.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   FormControl as MuiFormControl,
   FormControlLabel,


### PR DESCRIPTION
### Description
Make it possible to disable `RadioGroup`.

![ezgif com-gif-maker (29)](https://user-images.githubusercontent.com/4410346/100178860-a646ff00-2e89-11eb-8e7d-0863d29ba3c0.gif)

<img width="695" alt="Screen Shot 2020-11-24 at 7 22 16 PM" src="https://user-images.githubusercontent.com/4410346/100179234-646a8880-2e8a-11eb-876b-e4d5d7c4e8c7.png">


### Testing Performed
See attached GIF.
