### PR TITLE
github: add base name parameter for CreatePullRequest function

### DIFF
--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -27,7 +27,7 @@ func (s svc) CreateBranch(ctx context.Context, req *github.CreateBranchRequest) 
 	panic("implement me")
 }
 
-func (s svc) CreatePullRequest(ctx context.Context, ref *github.RemoteRef, title, base, body string) (*github.PullRequestInfo, error) {
+func (s svc) CreatePullRequest(ctx context.Context, ref *github.RemoteRef, base, title, body string) (*github.PullRequestInfo, error) {
 	panic("implement me")
 }
 

--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -27,7 +27,7 @@ func (s svc) CreateBranch(ctx context.Context, req *github.CreateBranchRequest) 
 	panic("implement me")
 }
 
-func (s svc) CreatePullRequest(ctx context.Context, ref *github.RemoteRef, title, body string) (*github.PullRequestInfo, error) {
+func (s svc) CreatePullRequest(ctx context.Context, ref *github.RemoteRef, title, base, body string) (*github.PullRequestInfo, error) {
 	panic("implement me")
 }
 

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -69,7 +69,7 @@ type File struct {
 type Client interface {
 	GetFile(ctx context.Context, ref *RemoteRef, path string) (*File, error)
 	CreateBranch(ctx context.Context, req *CreateBranchRequest) error
-	CreatePullRequest(ctx context.Context, ref *RemoteRef, title, base, body string) (*PullRequestInfo, error)
+	CreatePullRequest(ctx context.Context, ref *RemoteRef, base, title, body string) (*PullRequestInfo, error)
 	CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRepositoryRequest) (*sourcecontrolv1.CreateRepositoryResponse, error)
 	CreateIssueComment(ctx context.Context, ref *RemoteRef, number int, body string) error
 	CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*scgithubv1.CommitComparison, error)

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -69,7 +69,7 @@ type File struct {
 type Client interface {
 	GetFile(ctx context.Context, ref *RemoteRef, path string) (*File, error)
 	CreateBranch(ctx context.Context, req *CreateBranchRequest) error
-	CreatePullRequest(ctx context.Context, ref *RemoteRef, title, body string) (*PullRequestInfo, error)
+	CreatePullRequest(ctx context.Context, ref *RemoteRef, title, base, body string) (*PullRequestInfo, error)
 	CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRepositoryRequest) (*sourcecontrolv1.CreateRepositoryResponse, error)
 	CreateIssueComment(ctx context.Context, ref *RemoteRef, number int, body string) error
 	CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*scgithubv1.CommitComparison, error)
@@ -129,11 +129,11 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
-func (s *svc) CreatePullRequest(ctx context.Context, ref *RemoteRef, title, body string) (*PullRequestInfo, error) {
+func (s *svc) CreatePullRequest(ctx context.Context, ref *RemoteRef, title, base, body string) (*PullRequestInfo, error) {
 	req := &githubv3.NewPullRequest{
 		Title:               strPtr(title),
 		Head:                strPtr(ref.Ref),
-		Base:                strPtr("master"),
+		Base:                strPtr(base),
 		Body:                strPtr(body),
 		MaintainerCanModify: boolPtr(true),
 	}

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -129,7 +129,7 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
-func (s *svc) CreatePullRequest(ctx context.Context, ref *RemoteRef, title, base, body string) (*PullRequestInfo, error) {
+func (s *svc) CreatePullRequest(ctx context.Context, ref *RemoteRef, base, title, body string) (*PullRequestInfo, error) {
 	req := &githubv3.NewPullRequest{
 		Title:               strPtr(title),
 		Head:                strPtr(ref.Ref),


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add base name parameter to the Github `CreatePullRequest` function to replace hardcoded value. This enables clients to pass alternate names for the target base branch when creating pull requests. Primary purpose is to enable name convention swap from `master` to `main` while still supporting legacy repositories.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Local manual testing against two different repos with different base branch names.

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->
Fixes [issue #724](https://github.com/lyft/clutch/issues/724)


### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
