### PR TITLE
k8s: option to receive informer updates

### DIFF
--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
@@ -22,7 +21,7 @@ import (
 // and the additional requests that we place on all configured kubernetes cluster.
 // We have to be mindful of our clients Burst & QPS configuration,
 // which is overrideable by the user.
-const informerResyncTime = time.Hour * 1
+const informerResyncTime = 0
 
 // Setting a large channel buffer mostly for first boot and the  resync timer,
 // this really should be sized according to the size of your k8s deployment.

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -61,6 +61,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		&corev1.Pod{},
 		informerResyncTime,
 		informerHandlers,
+		false,
 	)
 
 	deploymentInformer := NewLightweightInformer(
@@ -68,6 +69,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		&appsv1.Deployment{},
 		informerResyncTime,
 		informerHandlers,
+		true,
 	)
 
 	hpaInformer := NewLightweightInformer(
@@ -75,6 +77,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		&autoscalingv1.HorizontalPodAutoscaler{},
 		informerResyncTime,
 		informerHandlers,
+		true,
 	)
 
 	stop := make(chan struct{})

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
@@ -21,7 +22,7 @@ import (
 // and the additional requests that we place on all configured kubernetes cluster.
 // We have to be mindful of our clients Burst & QPS configuration,
 // which is overrideable by the user.
-const informerResyncTime = 0
+const informerResyncTime = time.Hour * 1
 
 // Setting a large channel buffer mostly for first boot and the  resync timer,
 // this really should be sized according to the size of your k8s deployment.

--- a/backend/service/k8s/lightweightinformer.go
+++ b/backend/service/k8s/lightweightinformer.go
@@ -71,6 +71,9 @@ func NewLightweightInformer(
 				switch d.Type {
 				case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
 					if _, exists, err := cacheStore.Get(lightweightObj); err == nil && exists {
+						// Not all use-cases of this informer require updates to Kubernetes objects
+						// For this reason you can disable updates completely by setting `recieveUpdates` to false
+						// This both disables the cache update and the OnUpdate handler
 						if recieveUpdates {
 							if err := cacheStore.Update(lightweightObj); err != nil {
 								return err

--- a/backend/service/k8s/lightweightinformer.go
+++ b/backend/service/k8s/lightweightinformer.go
@@ -42,6 +42,7 @@ func NewLightweightInformer(
 	objType runtime.Object,
 	resync time.Duration,
 	h cache.ResourceEventHandler,
+	recieveUpdates bool,
 ) cache.Controller {
 	cacheStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
 	fifo := cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
@@ -70,10 +71,12 @@ func NewLightweightInformer(
 				switch d.Type {
 				case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
 					if _, exists, err := cacheStore.Get(lightweightObj); err == nil && exists {
-						if err := cacheStore.Update(lightweightObj); err != nil {
-							return err
+						if recieveUpdates {
+							if err := cacheStore.Update(lightweightObj); err != nil {
+								return err
+							}
+							h.OnUpdate(nil, d.Object)
 						}
-						h.OnUpdate(nil, d.Object)
 					} else {
 						if err := cacheStore.Add(lightweightObj); err != nil {
 							return err

--- a/backend/service/k8s/lightweightinformer_test.go
+++ b/backend/service/k8s/lightweightinformer_test.go
@@ -38,6 +38,7 @@ func TestLightweightInformer(t *testing.T) {
 		&v1.Pod{},
 		time.Minute,
 		informerHandlers,
+		true,
 	)
 
 	go podInformer.Run(stop)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
For large Kubernetes deployments reacting to all informer events can put a lot of load on the datastore, the motivation behind this change is to reduce load.

Currently we handle all updates to pods for the topology caching but we dont currently need that level of granularity, requirements can change in the future and we can think about making these configuration options if use cases arise.

### Testing Performed
<!-- Describe how you tested this change below. -->

This was tested locally.
