### PR TITLE
k8s: LightweightInformer disable resync

### DIFF
--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
@@ -22,7 +21,7 @@ import (
 // and the additional requests that we place on all configured kubernetes cluster.
 // We have to be mindful of our clients Burst & QPS configuration,
 // which is overrideable by the user.
-const informerResyncTime = time.Hour * 1
+const informerResyncTime = 0
 
 // Setting a large channel buffer mostly for first boot and the  resync timer,
 // this really should be sized according to the size of your k8s deployment.

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
@@ -16,13 +15,6 @@ import (
 
 	topologyv1 "github.com/lyft/clutch/backend/api/topology/v1"
 )
-
-// TODO (mcutalo): Make this configurable or keep this at a high value.
-// The implications of resync running often is both the pressure it puts on our datastore,
-// and the additional requests that we place on all configured kubernetes cluster.
-// We have to be mindful of our clients Burst & QPS configuration,
-// which is overrideable by the user.
-const informerResyncTime = time.Hour * 1
 
 // Setting a large channel buffer mostly for first boot and the  resync timer,
 // this really should be sized according to the size of your k8s deployment.
@@ -59,7 +51,6 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 	podInformer := NewLightweightInformer(
 		cache.NewListWatchFromClient(cs.CoreV1().RESTClient(), "pods", corev1.NamespaceAll, fields.Everything()),
 		&corev1.Pod{},
-		informerResyncTime,
 		informerHandlers,
 		false,
 	)
@@ -67,7 +58,6 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 	deploymentInformer := NewLightweightInformer(
 		cache.NewListWatchFromClient(cs.AppsV1().RESTClient(), "deployments", corev1.NamespaceAll, fields.Everything()),
 		&appsv1.Deployment{},
-		informerResyncTime,
 		informerHandlers,
 		true,
 	)
@@ -75,7 +65,6 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 	hpaInformer := NewLightweightInformer(
 		cache.NewListWatchFromClient(cs.AutoscalingV1().RESTClient(), "horizontalpodautoscalers", corev1.NamespaceAll, fields.Everything()),
 		&autoscalingv1.HorizontalPodAutoscaler{},
-		informerResyncTime,
 		informerHandlers,
 		true,
 	)

--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
@@ -21,7 +22,7 @@ import (
 // and the additional requests that we place on all configured kubernetes cluster.
 // We have to be mindful of our clients Burst & QPS configuration,
 // which is overrideable by the user.
-const informerResyncTime = 0
+const informerResyncTime = time.Hour * 1
 
 // Setting a large channel buffer mostly for first boot and the  resync timer,
 // this really should be sized according to the size of your k8s deployment.

--- a/backend/service/k8s/lightweightinformer.go
+++ b/backend/service/k8s/lightweightinformer.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,10 +36,12 @@ func (lw *lightweightCacheObject) GetNamespace() string { return lw.Namespace }
 // Drawbacks
 // - Update resource event handler does not function as expected, old objects will always return nil.
 //   This is because we dont cache the full k8s object to compute deltas as we are using lightweightCacheObjects instead.
+// - Resync does not work as expected becuase the cache is filled with lightweightCacheObjects,
+//   for this reason Resync is disabled.
+
 func NewLightweightInformer(
 	lw cache.ListerWatcher,
 	objType runtime.Object,
-	resync time.Duration,
 	h cache.ResourceEventHandler,
 	recieveUpdates bool,
 ) cache.Controller {
@@ -54,7 +55,7 @@ func NewLightweightInformer(
 		Queue:            fifo,
 		ListerWatcher:    lw,
 		ObjectType:       objType,
-		FullResyncPeriod: resync,
+		FullResyncPeriod: 0,
 		RetryOnError:     false,
 		Process: func(obj interface{}) error {
 			for _, d := range obj.(cache.Deltas) {

--- a/backend/service/k8s/lightweightinformer_test.go
+++ b/backend/service/k8s/lightweightinformer_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -36,7 +35,6 @@ func TestLightweightInformer(t *testing.T) {
 	podInformer := NewLightweightInformer(
 		fc,
 		&v1.Pod{},
-		time.Minute,
 		informerHandlers,
 		true,
 	)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

Disabling Resync for the LightweightInformer, as it does not provide any value. In additionally it was causing `lightweightCacheObject` objects to be passed through the topology pipeline throwing warnings like the one below.

Resyncing compares whats currently in the DeltaFIFO queue and what currently resides in cache, if the queue does not have an item that cache has, it will requeue it so the informer has a chance to reprocess that item. Resync is of no value here as `lightweightCacheObject` _never_ reside in the DeltaFIFO queue as that queue is only populated from the ListAndWatch Streams coming from the kube api. By resyncing we force items in cache to end up in the queue which ultimately produce the warning below.

> {"level":"warn","ts":1607102729.4194083,"caller":"k8s/cache.go:149","msg":"unable to determine topology object type","serviceName":"clutch.service.k8s","object_type":"*k8s.lightweightCacheObject"}

### Testing Performed
<!-- Describe how you tested this change below. -->
Localy.