### PR TITLE
ui v2: fix accordion bug

### DIFF
--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -125,11 +125,7 @@ export const Accordion = ({
   };
 
   return (
-    <StyledAccordion
-      defaultExpanded={defaultExpanded}
-      expanded={expanded}
-      {...props}
-    >
+    <StyledAccordion defaultExpanded={defaultExpanded} expanded={expanded} {...props}>
       <StyledAccordionSummary expanded={expanded} collapsible={collapsible} onClick={handleClick}>
         {title}
       </StyledAccordionSummary>

--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -127,7 +127,7 @@ export const Accordion = ({
   return (
     <StyledAccordion
       defaultExpanded={defaultExpanded}
-      expanded={expanded || defaultExpanded || false}
+      expanded={expanded}
       {...props}
     >
       <StyledAccordionSummary expanded={expanded} collapsible={collapsible} onClick={handleClick}>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
if `defaultExpanded` was true, the value would always be true so the accordion would never collapse. `useControlled` properly manages the state without the need for the OR to set the initial val.

### Testing Performed
Storybook.