### PR TITLE
ui v2: add end adornment support to text fields

### DIFF
--- a/frontend/packages/core/src/Input/stories/text-field.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/text-field.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
+import SearchIcon from "@material-ui/icons/Search"
 
 import type { TextFieldProps } from "../text-field";
 import { TextField } from "../text-field";
@@ -41,4 +42,11 @@ MultipleLines.args = {
   ...Primary.args,
   multiline: true,
   defaultValue: "This is\nan example\nof multiline content",
+};
+
+export const WithEndAdornment = Template.bind({});
+WithEndAdornment.args = {
+  ...Primary.args,
+  defaultValue: "Search",
+  endAdornment: <SearchIcon />,
 };

--- a/frontend/packages/core/src/Input/stories/text-field.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/text-field.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
+import SearchIcon from "@material-ui/icons/Search";
 import type { Meta } from "@storybook/react";
-import SearchIcon from "@material-ui/icons/Search"
 
 import type { TextFieldProps } from "../text-field";
 import { TextField } from "../text-field";

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -50,6 +50,12 @@ const StyledTextField = styled(BaseTextField)({
 
   ".MuiInputBase-root.Mui-focused": {
     borderColor: "#3548d4",
+    ".MuiButtonBase-root": {
+      backgroundColor: "#3548D4",
+      "*": {
+        color: "#FFFFFF"
+      },
+    },
   },
 
   ".MuiInputBase-root.Mui-disabled": {
@@ -95,6 +101,18 @@ const IconButton = styled(MuiIconButton)({
   backgroundColor: "#E7E7EA",
   borderBottomRightRadius: "3px",
   borderTopRightRadius: "3px",
+  "&:hover": {
+    backgroundColor: "#2D3DB4",
+    "*": {
+      color: "#FFFFFF"
+    },
+  },
+  "&:active": {
+    backgroundColor: "#2938A5",
+    "*": {
+      color: "#FFFFFF",
+    },
+  },
 });
 
 export interface TextFieldProps
@@ -117,9 +135,8 @@ export interface TextFieldProps
       | "type"
       | "value"
     >,
-    Pick<MuiInputProps, "readOnly"> {
+    Pick<MuiInputProps, "readOnly" | "endAdornment"> {
   onReturn?: () => void;
-  endAdornment?: React.ReactElement | React.ReactElement[];
 }
 
 export const TextField = ({

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -53,7 +53,7 @@ const StyledTextField = styled(BaseTextField)({
     ".MuiButtonBase-root": {
       backgroundColor: "#3548D4",
       "*": {
-        color: "#FFFFFF"
+        color: "#FFFFFF",
       },
     },
   },
@@ -104,7 +104,7 @@ const IconButton = styled(MuiIconButton)({
   "&:hover": {
     backgroundColor: "#2D3DB4",
     "*": {
-      color: "#FFFFFF"
+      color: "#FFFFFF",
     },
   },
   "&:active": {

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -4,7 +4,7 @@ import type {
   InputProps as MuiInputProps,
   StandardTextFieldProps as MuiStandardTextFieldProps,
 } from "@material-ui/core";
-import { TextField as MuiTextField } from "@material-ui/core";
+import { IconButton as MuiIconButton, TextField as MuiTextField } from "@material-ui/core";
 import ErrorIcon from "@material-ui/icons/Error";
 
 const KEY_ENTER = 13;
@@ -42,7 +42,6 @@ const StyledTextField = styled(BaseTextField)({
     border: "1px solid rgba(13, 16, 48, 0.38)",
     borderRadius: "4px",
     fontSize: "16px",
-    padding: "14px 16px",
   },
 
   "label + .MuiInput-formControl": {
@@ -58,7 +57,7 @@ const StyledTextField = styled(BaseTextField)({
   },
 
   ".MuiInput-input": {
-    padding: "0",
+    padding: "14px 16px",
     height: "20px",
   },
 
@@ -91,6 +90,13 @@ const StyledTextField = styled(BaseTextField)({
   },
 });
 
+const IconButton = styled(MuiIconButton)({
+  borderRadius: "0",
+  backgroundColor: "#E7E7EA",
+  borderBottomRightRadius: "3px",
+  borderTopRightRadius: "3px",
+});
+
 export interface TextFieldProps
   extends Pick<
       MuiStandardTextFieldProps,
@@ -113,6 +119,7 @@ export interface TextFieldProps
     >,
     Pick<MuiInputProps, "readOnly"> {
   onReturn?: () => void;
+  endAdornment?: React.ReactElement | React.ReactElement[];
 }
 
 export const TextField = ({
@@ -121,6 +128,7 @@ export const TextField = ({
   error,
   helperText,
   readOnly,
+  endAdornment,
   ...props
 }: TextFieldProps) => {
   const onKeyDown = (
@@ -153,7 +161,10 @@ export const TextField = ({
       onBlur={onChange}
       error={error}
       helperText={helpText}
-      InputProps={{ readOnly }}
+      InputProps={{
+        readOnly,
+        endAdornment: endAdornment && <IconButton type="submit">{endAdornment}</IconButton>,
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add support to text fields for end adornment

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2020-12-10 at 2 44 43 PM](https://user-images.githubusercontent.com/1004789/101838952-59ecf780-3af6-11eb-924a-bf928a4ab5a2.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
In dev app and storybook
