### PR TITLE
ui v2: restyle terminate instance

### DIFF
--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -4,7 +4,12 @@ module.exports = {
       trending: true,
       componentProps: {
         resolverType: "clutch.aws.ec2.v1.Instance",
-        note: "The instance may take several minutes to shut down.",
+        notes: [
+          {
+            severity: "info",
+            text: "The instance may take several minutes to shut down.",
+          },
+        ],
       },
     },
     rebootInstance: {

--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -4,6 +4,7 @@ module.exports = {
       trending: true,
       componentProps: {
         resolverType: "clutch.aws.ec2.v1.Instance",
+        note: "The instance may take several minutes to shut down.",
       },
     },
     rebootInstance: {

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -99,7 +99,7 @@ const StyledSelect = styled(BaseSelect)({
     height: "48px",
   },
 
-  ".MuiListItem-root:first-child": {
+  ".MuiListItem-root:first-of-type": {
     borderRadius: "4px 4px 0 0",
   },
 

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -4,7 +4,6 @@ import styled from "@emotion/styled";
 import _ from "lodash";
 
 import { AccordionGroup } from "../accordion";
-import { Button } from "../button";
 import { useWizardContext } from "../Contexts";
 import { CompressedError, Error } from "../error";
 import { HorizontalRule } from "../horizontal-rule";

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -110,7 +110,6 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
                 onChange={queryOnChange}
                 validation={queryValidation}
               />
-              <Button text="Search" type="submit" />
             </Form>
           )}
           {variant === "dual" && <HorizontalRule>OR</HorizontalRule>}

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { UseFormMethods } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import type { clutch } from "@clutch-sh/api";
+import SearchIcon from "@material-ui/icons/Search";
 
 import {
   Accordion,
@@ -43,6 +44,7 @@ const QueryResolver: React.FC<QueryResolverProps> = ({ schemas, onChange, valida
       inputRef={validation.register({ required: true })}
       error={!!error}
       helperText={error?.message || error?.type || ""}
+      endAdornment={<SearchIcon />}
     />
   );
 };

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -34,7 +34,6 @@ interface IdentifiableRowData extends RowData {
 const TableContainer = styled(MuiTableContainer)({
   borderWidth: "0",
   border: "0",
-  padding: "16px 32px",
 });
 
 const Table = styled(MuiTable)({

--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -36,10 +36,6 @@ const StyledAccordion = styled(MuiAccordion)({
     padding: "8px",
     fontSize: "16px",
   },
-
-  ".MuiAccordionActions-root": {
-    padding: "0",
-  },
 });
 
 const AccordionSummaryBase = ({ children, collapsible, expanded, ...props }) => {
@@ -89,7 +85,7 @@ const StyledAccordionGroup = styled.div({
     marginBottom: "16px",
   },
 
-  ".MuiAccordion-root:before": {
+  "&.MuiAccordion-root:before": {
     display: "none",
   },
 });
@@ -171,6 +167,13 @@ const StyledAccordionDetails = styled(MuiAccordionDetails)({
   },
 });
 
-export const AccordionActions = MuiAccordionActions;
+const StyledAccordionActions = styled(MuiAccordionActions)({
+  padding: "8px",
+  "> *": {
+    margin: "8px 8px",
+  },
+});
+
+export const AccordionActions = StyledAccordionActions;
 export const AccordionDetails = StyledAccordionDetails;
 export const AccordionDivider = MuiDivider;

--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -85,7 +85,7 @@ const StyledAccordionGroup = styled.div({
     marginBottom: "16px",
   },
 
-  "&.MuiAccordion-root:before": {
+  ".MuiAccordion-root:before": {
     display: "none",
   },
 });

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -91,17 +91,25 @@ const Button: React.FC<ButtonProps> = ({ text, variant = "primary", ...props }) 
   );
 };
 
+const ButtonGroupContainer = styled(Grid)({
+  borderTop: "1px solid #E7E7EA",
+  marginTop: "24px",
+  "> *": {
+    margin: "8px",
+  },
+});
+
 export interface ButtonGroupProps {
   buttons: ButtonProps[];
   justify?: GridJustification;
 }
 
 const ButtonGroup: React.FC<ButtonGroupProps> = ({ buttons, justify = "center" }) => (
-  <Grid container justify={justify}>
+  <ButtonGroupContainer container justify={justify}>
     {buttons.map(button => (
       <Button key={button.text} {...button} />
     ))}
-  </Grid>
+  </ButtonGroupContainer>
 );
 
 export interface ClipboardButtonProps {

--- a/frontend/packages/core/src/confirmation.tsx
+++ b/frontend/packages/core/src/confirmation.tsx
@@ -1,35 +1,51 @@
 import React from "react";
 import { Grid, Typography } from "@material-ui/core";
 import ThumbUpIcon from "@material-ui/icons/ThumbUp";
-import styled from "styled-components";
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import styled from "@emotion/styled";
 
-const GridIcon = styled(Grid)`
-  ${({ theme }) => `
-  padding-top: 20px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  color: ${theme.palette.accent.main};
-  font-size: 7rem;
-  `}
-`;
 
-const Icon = styled(ThumbUpIcon)`
-  font-size: 0.5em;
-  margin-bottom: 10px;
-`;
+const IconContainer = styled(Grid)({
+  paddingTop: "20px",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  color: "#2F67F6",
+  fontSize: "7rem",
+});
+
+const Icon = styled(ThumbUpIcon)({
+  fontSize: "0.5em",
+  marginBottom: "10px",
+});
+
+const TitleContainer = styled(Grid)({
+  color: "#1E942E",
+  display: "flex",
+  alignItems: "center",
+  fontSize: "20px",
+  fontWeight: 500,
+  textTransform: "capitalize",
+});
+
+const CheckmarkIcon = styled(CheckCircleIcon)({
+  marginRight: "8px",
+});
+
+const SubtitleContainer = styled.div({
+  color: "rgba(13, 16, 48, 0.6)",
+  fontSize: "12px",
+});
 
 const Confirmation: React.FC<{ action: string }> = ({ action, children }) => (
   <Grid container direction="column" justify="center" alignItems="center">
-    <GridIcon item>
-      <Icon />
-    </GridIcon>
-    <Grid item>
-      <Typography align="center" color="textPrimary" variant="h5">
-        <Grid item>{action} requested!</Grid>
-      </Typography>
+    <IconContainer item><Icon /></IconContainer>
+    <TitleContainer item>
+      <CheckmarkIcon/> {action} Requested!
+    </TitleContainer>
+    <SubtitleContainer>
       {children}
-    </Grid>
+    </SubtitleContainer>
   </Grid>
 );
 

--- a/frontend/packages/core/src/confirmation.tsx
+++ b/frontend/packages/core/src/confirmation.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { Grid, Typography } from "@material-ui/core";
-import ThumbUpIcon from "@material-ui/icons/ThumbUp";
-import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import styled from "@emotion/styled";
-
+import { Grid } from "@material-ui/core";
+import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+import ThumbUpIcon from "@material-ui/icons/ThumbUp";
 
 const IconContainer = styled(Grid)({
   paddingTop: "20px",
@@ -39,13 +38,13 @@ const SubtitleContainer = styled.div({
 
 const Confirmation: React.FC<{ action: string }> = ({ action, children }) => (
   <Grid container direction="column" justify="center" alignItems="center">
-    <IconContainer item><Icon /></IconContainer>
+    <IconContainer item>
+      <Icon />
+    </IconContainer>
     <TitleContainer item>
-      <CheckmarkIcon/> {action} Requested!
+      <CheckmarkIcon /> {action} Requested!
     </TitleContainer>
-    <SubtitleContainer>
-      {children}
-    </SubtitleContainer>
+    <SubtitleContainer>{children}</SubtitleContainer>
   </Grid>
 );
 

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -1,3 +1,4 @@
+import { Accordion, AccordionDetails } from "./accordion";
 // @ts-ignore
 import { BaseWorkflowProps, WorkflowConfiguration } from "./AppProvider/workflow";
 import { CheckboxPanel } from "./Input/checkbox";
@@ -16,6 +17,7 @@ import Loadable from "./loading";
 import { client, ClientError } from "./network";
 import ExpansionPanel from "./panel";
 import Resolver from "./Resolver";
+import { Step, Stepper } from "./stepper";
 import {
   ExpandableRow,
   ExpandableTable,
@@ -27,6 +29,8 @@ import {
 } from "./Table";
 
 export {
+  Accordion,
+  AccordionDetails,
   ClutchApp,
   BaseWorkflowProps,
   Button,
@@ -56,6 +60,8 @@ export {
   Select,
   Status,
   StatusRow,
+  Step,
+  Stepper,
   Table,
   TextField,
   TreeTable,

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -1,10 +1,10 @@
-import { Accordion, AccordionDetails } from "./accordion";
 // @ts-ignore
 import { BaseWorkflowProps, WorkflowConfiguration } from "./AppProvider/workflow";
 import { CheckboxPanel } from "./Input/checkbox";
 import { RadioGroup } from "./Input/radio-group";
 import { Select } from "./Input/select";
 import { TextField } from "./Input/text-field";
+import { Accordion, AccordionDetails } from "./accordion";
 import ClutchApp from "./AppProvider";
 import { Button, ButtonGroup, ButtonProps, ClipboardButton } from "./button";
 import Confirmation from "./confirmation";

--- a/frontend/packages/wizard/package.json
+++ b/frontend/packages/wizard/package.json
@@ -27,13 +27,14 @@
   "dependencies": {
     "@clutch-sh/core": "^1.0.0-beta",
     "@clutch-sh/data-layout": "^1.0.0-beta",
+    "@emotion/react": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "clsx": "^1.1.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-is": "^16.8.0",
-    "styled-components": "^5.1.1"
+    "react-is": "^16.8.0"
   },
   "devDependencies": {
     "@clutch-sh/tools": "^1.0.0-beta"

--- a/frontend/packages/wizard/src/step.tsx
+++ b/frontend/packages/wizard/src/step.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Error, Loadable, useWizardContext } from "@clutch-sh/core";
-import { Grid } from "@material-ui/core";
-import styled from "styled-components";
+import { Grid as MuiGrid} from "@material-ui/core";
+import styled from "@emotion/styled";
 
-const SizedGrid = styled(Grid)`
-  width: 100%;
-  padding: 0 5%;
-`;
+const Grid = styled(MuiGrid)({
+  width: "100%",
+  "> *": {
+    padding: "8px"
+  },
+});
 
 export interface WizardStepProps {
   isLoading: boolean;
@@ -26,9 +28,9 @@ const WizardStep: React.FC<WizardStepProps> = ({ isLoading, error, children }) =
   return hasError ? (
     <Error message={error} />
   ) : (
-    <SizedGrid container justify="center" direction="column" alignItems="center">
+    <Grid container justify="center" direction="column" alignItems="stretch">
       {children}
-    </SizedGrid>
+    </Grid>
   );
 };
 

--- a/frontend/packages/wizard/src/step.tsx
+++ b/frontend/packages/wizard/src/step.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Error, Loadable, useWizardContext } from "@clutch-sh/core";
-import { Grid as MuiGrid} from "@material-ui/core";
 import styled from "@emotion/styled";
+import { Grid as MuiGrid } from "@material-ui/core";
 
 const Grid = styled(MuiGrid)({
   width: "100%",
   "> *": {
-    padding: "8px"
+    padding: "8px",
   },
 });
 

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -1,13 +1,9 @@
 import React from "react";
-import { Warning, Step, Stepper, WizardContext, ButtonGroup } from "@clutch-sh/core";
+import { ButtonGroup, Step, Stepper, Warning, WizardContext } from "@clutch-sh/core";
 import type { ManagerLayout } from "@clutch-sh/data-layout";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
-import {
-  Container as MuiContainer,
-  Grid,
-  Typography,
-} from "@material-ui/core";
 import styled from "@emotion/styled";
+import { Container as MuiContainer, Grid, Typography } from "@material-ui/core";
 
 import { useWizardState, WizardAction } from "./state";
 import type { WizardStepProps } from "./step";
@@ -84,7 +80,7 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
   const lastStepIndex = React.Children.count(children) - 1;
   // If our wizard only has 1 step, it doesn't make sense to put a restart button
   const isMultistep = lastStepIndex > 0;
-  const steps = React.Children.map(children, (child: WizardChildren, idx: number) => {
+  const steps = React.Children.map(children, (child: WizardChildren) => {
     const isLoading = wizardStepData[child.type.name]?.isLoading || false;
     return (
       <>
@@ -97,15 +93,15 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
         </DataLayoutContext.Provider>
         <Grid container justify="center">
           {state.activeStep === lastStepIndex && !isLoading && isMultistep && (
-          <ButtonGroup
-            justify="flex-end"
-            buttons={[
-              {
-                text: "Start Over",
-                onClick: () => dispatch(WizardAction.RESET),
-              },
-            ]}
-          />
+            <ButtonGroup
+              justify="flex-end"
+              buttons={[
+                {
+                  text: "Start Over",
+                  onClick: () => dispatch(WizardAction.RESET),
+                },
+              ]}
+            />
           )}
         </Grid>
       </>
@@ -125,7 +121,7 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
         alignItems="stretch"
         style={{ display: "inline" }}
       >
-      {heading && <Heading>{heading}</Heading>}
+        {heading && <Heading>{heading}</Heading>}
         <Grid item>
           <Stepper activeStep={state.activeStep}>
             {React.Children.map(children, (child: WizardChildren) => {

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -10,7 +10,7 @@ interface ResolverConfigProps {
 }
 
 interface ConfirmConfigProps {
-  notes?: NoteConfig[];
+  note?: string;
 }
 
 export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps {}

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -1,4 +1,4 @@
-import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
+import type { BaseWorkflowProps, NoteConfig, WorkflowConfiguration } from "@clutch-sh/core";
 import type { WizardChild } from "@clutch-sh/wizard";
 
 import RebootInstance from "./reboot-instance";
@@ -10,7 +10,7 @@ interface ResolverConfigProps {
 }
 
 interface ConfirmConfigProps {
-  note?: string;
+  notes?: NoteConfig[];
 }
 
 export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps {}

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -1,4 +1,4 @@
-import type { BaseWorkflowProps, NoteConfig, WorkflowConfiguration } from "@clutch-sh/core";
+import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 import type { WizardChild } from "@clutch-sh/wizard";
 
 import RebootInstance from "./reboot-instance";

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -6,7 +6,6 @@ import {
   client,
   Confirmation,
   MetadataTable,
-  NotePanel,
   Resolver,
   useWizardContext,
 } from "@clutch-sh/core";
@@ -82,13 +81,11 @@ const Confirm: React.FC<ConfirmChild> = ({ note }) => {
   const terminationData = useDataLayout("terminationData");
   const configData = JSON.parse(terminationData.displayValue()?.config?.data || "{}");
   const confirmationData = Object.keys(configData).map(key => {
-    return {name: key, value: configData[key]};
+    return { name: key, value: configData[key] };
   });
   return (
     <WizardStep error={terminationData.error} isLoading={terminationData.isLoading}>
-      <Confirmation action="Termination">
-        {note && note}
-      </Confirmation>
+      <Confirmation action="Termination">{note && note}</Confirmation>
       <MetadataTable data={confirmationData} />
     </WizardStep>
   );

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import {
+  Accordion,
+  AccordionDetails,
   ButtonGroup,
   client,
   Confirmation,
@@ -42,20 +44,28 @@ const InstanceDetails: React.FC<WizardChild> = () => {
     { name: "Availability Zone", value: instance.availabilityZone },
   ];
 
+  const metadata = [];
   if (instance.tags) {
     Object.keys(instance.tags).forEach(key => {
-      data.push({ name: key, value: instance.tags[key] });
+      metadata.push({ name: key, value: instance.tags[key] });
     });
   }
 
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
       <MetadataTable data={data} />
+      <Accordion title="Metadata">
+        <AccordionDetails>
+          <MetadataTable data={metadata} />
+        </AccordionDetails>
+      </Accordion>
       <ButtonGroup
+        justify="flex-end"
         buttons={[
           {
             text: "Back",
             onClick: onBack,
+            variant: "neutral",
           },
           {
             text: "Terminate",
@@ -68,18 +78,23 @@ const InstanceDetails: React.FC<WizardChild> = () => {
   );
 };
 
-const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
+const Confirm: React.FC<ConfirmChild> = ({ note }) => {
   const terminationData = useDataLayout("terminationData");
-
+  const configData = JSON.parse(terminationData.displayValue()?.config?.data || "{}");
+  const confirmationData = Object.keys(configData).map(key => {
+    return {name: key, value: configData[key]};
+  });
   return (
     <WizardStep error={terminationData.error} isLoading={terminationData.isLoading}>
-      <Confirmation action="Termination" />
-      <NotePanel notes={notes} />
+      <Confirmation action="Termination">
+        {note && note}
+      </Confirmation>
+      <MetadataTable data={confirmationData} />
     </WizardStep>
   );
 };
 
-const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
+const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, note }) => {
   const dataLayout = {
     resourceData: {},
     terminationData: {
@@ -97,7 +112,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, not
     <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Modify" />
-      <Confirm name="Confirmation" notes={notes} />
+      <Confirm name="Confirmation" note={note} />
     </Wizard>
   );
 };

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -77,21 +77,22 @@ const InstanceDetails: React.FC<WizardChild> = () => {
   );
 };
 
-const Confirm: React.FC<ConfirmChild> = ({ note }) => {
+const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const terminationData = useDataLayout("terminationData");
   const configData = JSON.parse(terminationData.displayValue()?.config?.data || "{}");
   const confirmationData = Object.keys(configData).map(key => {
     return { name: key, value: configData[key] };
   });
+  const formattedNotes = notes.map(note => <div>{note.text}</div>)
   return (
     <WizardStep error={terminationData.error} isLoading={terminationData.isLoading}>
-      <Confirmation action="Termination">{note && note}</Confirmation>
+      <Confirmation action="Termination">{notes && formattedNotes}</Confirmation>
       <MetadataTable data={confirmationData} />
     </WizardStep>
   );
 };
 
-const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, note }) => {
+const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes }) => {
   const dataLayout = {
     resourceData: {},
     terminationData: {
@@ -109,7 +110,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, not
     <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Modify" />
-      <Confirm name="Confirmation" note={note} />
+      <Confirm name="Confirmation" notes={notes} />
     </Wizard>
   );
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Restyle the terminate instance workflow.

This doesn't include all the final touches. This is just the major style changes. There are still a few minor things to fix along the way include:

- The accordion group has a top border that is rendering when it's a child
- The metadata keys on the confirmation page need to converted to either hard coded strings or normalized
- Fix breakpoints for responsive devices

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![terminstancev2](https://user-images.githubusercontent.com/1004789/101963604-f4673c80-3bc3-11eb-86f6-a5125318d5fa.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manually
