### PR TITLE
ui v2: fix searchfield bugs

### DIFF
--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -60,6 +60,7 @@ const InputField = styled(TextField)({
   },
 });
 
+// search's result options container
 const ResultGrid = styled(Grid)({
   height: "inherit",
 })
@@ -171,7 +172,7 @@ interface ResultProps {
 }
 
 const Result: React.FC<ResultProps> = ({ option, handleSelection }) => (
-  <ResultGrid container alignItems="center" onClick={handleSelection} style={{height: "inherit"}}>
+  <ResultGrid container alignItems="center" onClick={handleSelection}>
     <Grid item xs>
       <ResultLabel>{option.label}</ResultLabel>
     </Grid>

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -266,7 +266,6 @@ const SearchField: React.FC = () => {
             PopperComponent={renderPopper}
             popupIcon={<CustomCloseIcon />}
             forcePopupIcon={!!showOptions}
-            closeIcon={<CustomCloseIcon />}
             noOptionsText="No results found"
             onKeyDown={handleListKeyDown}
           />

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -54,8 +54,7 @@ const InputField = styled(TextField)({
         background: "#e7e7ea",
       },
       "&:active": {
-        background:
-          "linear-gradient(0deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.85)), #0D1030;",
+        background: "#DBDBE0",
       },
     },
   },
@@ -239,6 +238,13 @@ const SearchField: React.FC = () => {
     setOpen(false);
   };
 
+  function handleListKeyDown(event) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      setOpen(false);
+    }
+  }
+
   return (
     <Grid container alignItems="center">
       {open ? (
@@ -260,7 +266,9 @@ const SearchField: React.FC = () => {
             PopperComponent={renderPopper}
             popupIcon={<CustomCloseIcon />}
             forcePopupIcon={!!showOptions}
+            closeIcon={<CustomCloseIcon />}
             noOptionsText="No results found"
+            onKeyDown={handleListKeyDown}
           />
         </ClickAwayListener>
       ) : (

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -60,6 +60,10 @@ const InputField = styled(TextField)({
   },
 });
 
+const ResultGrid = styled(Grid)({
+  height: "inherit",
+})
+
 // search's result options
 const ResultLabel = styled(Typography)({
   color: "#0d1030",
@@ -167,11 +171,11 @@ interface ResultProps {
 }
 
 const Result: React.FC<ResultProps> = ({ option, handleSelection }) => (
-  <Grid container alignItems="center" onClick={handleSelection}>
+  <ResultGrid container alignItems="center" onClick={handleSelection} style={{height: "inherit"}}>
     <Grid item xs>
       <ResultLabel>{option.label}</ResultLabel>
     </Grid>
-  </Grid>
+  </ResultGrid>
 );
 
 const filterResults = (searchOptions: SearchIndex[], state: FilterOptionsState<SearchIndex>) => {

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -63,6 +63,7 @@ const InputField = styled(TextField)({
 // search's result options container
 const ResultGrid = styled(Grid)({
   height: "inherit",
+  padding: "12px 16px 12px 16px",
 })
 
 // search's result options
@@ -104,6 +105,7 @@ const Popper = styled(MuiPopper)({
   },
   ".MuiAutocomplete-option": {
     height: "48px",
+    padding: "0px",
   },
   ".MuiAutocomplete-option[data-focus='true']": {
     background: "#ebedfb",

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -64,7 +64,7 @@ const InputField = styled(TextField)({
 const ResultGrid = styled(Grid)({
   height: "inherit",
   padding: "12px 16px 12px 16px",
-})
+});
 
 // search's result options
 const ResultLabel = styled(Typography)({
@@ -245,6 +245,8 @@ const SearchField: React.FC = () => {
     setOpen(false);
   };
 
+  // If workflow selected by pressing enter/return,
+  // update the open state to collapse search bar to search icon
   function handleListKeyDown(event) {
     if (event.key === "Enter") {
       event.preventDefault();


### PR DESCRIPTION
## Description

PR fixes 2 bugs for the header searchfield component:

<img src="https://user-images.githubusercontent.com/39421794/102097913-8190d800-3df4-11eb-9b06-d8c08b854693.gif" width="400"/>

(1) The [result component](https://github.com/lyft/clutch/blob/main/frontend/packages/core/src/AppLayout/search.tsx#L90) has the onClick event to navigate to a workflow. The issue was that its Grid did not match the parent height (see gif). So if you did not click exactly within the result Grid, you were not navigated to a workflow.

Solution: Have the result Grid inherit the height of its parent (autocomplete option container)

(2) If you chose a workflow by pressing the enter/return key, the header search bar would remain open. The expected behavior is for the searchbar to collapse back to the search icon when a result option is selected, like the mouse click behavior.

Solution: Add a `onKeyDown` event to update the `open` state

## Testing Performed
Local app, Storybook