### PR TITLE
docs: fix authn config example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ See comments in [any.proto](https://github.com/protocolbuffers/protobuf/blob/d4c
 {{ simpleProtoYAML "clutch.config.gateway.v1.Service" }}
 ```
 
-Example with `clutch.service.authn` and environment variables. As an example, see [`api/config/service/authn/v1/authn.proto`](https://github.com/lyft/clutch/blob/main/api/config/service/authn/v1/authn.proto) for the configuration definition for this particular service.
+Example with `clutch.service.authn` and environment variables. As an example, see [`api/config/service/authn/v1/authn.proto`](https://github.com/lyft/clutch/blob/826a1319f2c83bcce55492d0a472db010b6e38a9/api/config/service/authn/v1/authn.proto) for the configuration definition for this particular service.
 ```yaml title="clutch-config.yaml"
 ...
 services:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ See comments in [any.proto](https://github.com/protocolbuffers/protobuf/blob/d4c
 {{ simpleProtoYAML "clutch.config.gateway.v1.Service" }}
 ```
 
-Example with `clutch.service.authn` and environment variables.
+Example with `clutch.service.authn` and environment variables. As an example, see [`api/config/service/authn/v1/authn.proto`](https://github.com/lyft/clutch/blob/main/api/config/service/authn/v1/authn.proto) for the configuration definition for this particular service.
 ```yaml title="clutch-config.yaml"
 ...
 services:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ services:
         client_id: ${OIDC_CLIENT_ID}
         client_secret: ${OIDC_CLIENT_SECRET}
         redirect_url: "http://localhost:8080/v1/authn/callback"
-        session_secret: ${AUTHN_SESSION_SECRET}
+      session_secret: ${AUTHN_SESSION_SECRET}
 ...
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ See comments in [any.proto](https://github.com/protocolbuffers/protobuf/blob/d4c
 {{ simpleProtoYAML "clutch.config.gateway.v1.Service" }}
 ```
 
-Example with `clutch.service.authn` and environment variables. As an example, see [`api/config/service/authn/v1/authn.proto`](https://github.com/lyft/clutch/blob/826a1319f2c83bcce55492d0a472db010b6e38a9/api/config/service/authn/v1/authn.proto) for the configuration definition for this particular service.
+Example with `clutch.service.authn` and environment variables.
 ```yaml title="clutch-config.yaml"
 ...
 services:


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Reported in Slack: https://lyftoss.slack.com/archives/C015UJ6LED9/p1607788759067900.

> (1) session_secret appears at the same level as oidc, but the code has it one level above (and c&p fails because of that), is that an oversight or am I missing something?

### Testing Performed
Docs render.