### PR TITLE
frontend: allow override of resolver api package

### DIFF
--- a/frontend/packages/core/src/Resolver/fetch.tsx
+++ b/frontend/packages/core/src/Resolver/fetch.tsx
@@ -4,21 +4,13 @@ import _ from "lodash";
 
 import { client, parseErrorMessage } from "../network";
 
-const fetchResourceSchemas = async (
-  type: string,
-  apiProto?: any
-): Promise<IClutch.resolver.v1.Schema[]> => {
+const fetchResourceSchemas = async (type: string): Promise<IClutch.resolver.v1.Schema[]> => {
   const response = await client.post("/v1/resolver/getObjectSchemas", {
     type_url: `type.googleapis.com/${type}`,
   });
-  return response.data.schemas.map((schema: object) => {
-    if (apiProto) {
-      try {
-        return apiProto.clutch.resolver.v1.Schema.fromObject(schema);
-      } catch {}
-    }
-    return $pbclutch.clutch.resolver.v1.Schema.fromObject(schema);
-  });
+  return response.data.schemas.map((schema: object) =>
+    $pbclutch.clutch.resolver.v1.Schema.fromObject(schema)
+  );
 };
 
 export interface ResolutionResults {

--- a/frontend/packages/core/src/Resolver/fetch.tsx
+++ b/frontend/packages/core/src/Resolver/fetch.tsx
@@ -61,6 +61,8 @@ const resolveResource = async (
   const resolver = fields?.query !== undefined ? resolveQuery : resolveFields;
   return resolver(type, limit, fields)
     .then(({ results, failures }) => {
+      // n.b. default to using the open source @clutch-sh/api package to resolve the
+      // resource against unless a custom package has been specified by the workflow.
       let pbClutch = _.get($pbclutch, type);
       if (apiPackage) {
         pbClutch = _.get(apiPackage, type);

--- a/frontend/packages/core/src/Resolver/fetch.tsx
+++ b/frontend/packages/core/src/Resolver/fetch.tsx
@@ -4,7 +4,10 @@ import _ from "lodash";
 
 import { client, parseErrorMessage } from "../network";
 
-const fetchResourceSchemas = async (type: string, apiProto?: any): Promise<IClutch.resolver.v1.Schema[]> => {
+const fetchResourceSchemas = async (
+  type: string,
+  apiProto?: any
+): Promise<IClutch.resolver.v1.Schema[]> => {
   const response = await client.post("/v1/resolver/getObjectSchemas", {
     type_url: `type.googleapis.com/${type}`,
   });
@@ -61,7 +64,7 @@ const resolveResource = async (
   },
   onResolve: (resultObjects: any[], failureMessages: string[]) => void,
   onError: (message: string) => void,
-  apiProto?: any,
+  apiProto?: any
 ) => {
   const resolver = fields?.query !== undefined ? resolveQuery : resolveFields;
   return resolver(type, limit, fields)

--- a/frontend/packages/core/src/Resolver/fetch.tsx
+++ b/frontend/packages/core/src/Resolver/fetch.tsx
@@ -56,14 +56,14 @@ const resolveResource = async (
   },
   onResolve: (resultObjects: any[], failureMessages: string[]) => void,
   onError: (message: string) => void,
-  apiProto?: any
+  apiPackage?: any
 ) => {
   const resolver = fields?.query !== undefined ? resolveQuery : resolveFields;
   return resolver(type, limit, fields)
     .then(({ results, failures }) => {
       let pbClutch = _.get($pbclutch, type);
-      if (apiProto) {
-        pbClutch = _.get(apiProto, type);
+      if (apiPackage) {
+        pbClutch = _.get(apiPackage, type);
       }
       const resultObjects = results.map(result => pbClutch.fromObject(result));
       const failureMessages = failures.map(failure => parseErrorMessage(failure.message).summary);

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -48,7 +48,10 @@ interface ResolverProps {
   searchLimit: number;
   onResolve: (data: { results: object[]; input: object }) => void;
   variant?: "dual" | "query" | "schema";
-  apiPackage?: any;
+  /**
+   *  API module to resolve lookups against.
+   * */
+  apiPackage?: object;
 }
 
 const Resolver: React.FC<ResolverProps> = ({

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -48,7 +48,7 @@ interface ResolverProps {
   searchLimit: number;
   onResolve: (data: { results: object[]; input: object }) => void;
   variant?: "dual" | "query" | "schema";
-  apiProto?: any;
+  apiPackage?: any;
 }
 
 const Resolver: React.FC<ResolverProps> = ({
@@ -56,7 +56,7 @@ const Resolver: React.FC<ResolverProps> = ({
   searchLimit,
   onResolve,
   variant = "dual",
-  apiProto,
+  apiPackage,
 }) => {
   const [state, dispatch] = useResolverState();
   const { displayWarnings } = useWizardContext();
@@ -98,7 +98,7 @@ const Resolver: React.FC<ResolverProps> = ({
         dispatch({ type: ResolverAction.RESOLVE_SUCCESS });
       },
       err => dispatch({ type: ResolverAction.RESOLVE_ERROR, error: err }),
-      apiProto
+      apiPackage
     );
   };
 

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -125,7 +125,7 @@ const Resolver: React.FC<ResolverProps> = ({
   return (
     <Loadable isLoading={state.schemasLoading}>
       {state.schemaFetchError !== "" ? (
-        <Error message={state.schemaFetchError} onRetry={() => loadSchemas(type, dispatch)} />
+        <Error message={state.schemaFetchError} onRetry={() => loadSchemas(type, dispatch,  apiProto)} />
       ) : (
         <Loadable variant="overlay" isLoading={state.resolverLoading}>
           {process.env.REACT_APP_DEBUG_FORMS === "true" && <DevTool control={validation.control} />}

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -51,7 +51,13 @@ interface ResolverProps {
   apiProto?: any;
 }
 
-const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, variant = "dual", apiProto }) => {
+const Resolver: React.FC<ResolverProps> = ({
+  type,
+  searchLimit,
+  onResolve,
+  variant = "dual",
+  apiProto,
+}) => {
   const [state, dispatch] = useResolverState();
   const { displayWarnings } = useWizardContext();
 
@@ -92,7 +98,7 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
         dispatch({ type: ResolverAction.RESOLVE_SUCCESS });
       },
       err => dispatch({ type: ResolverAction.RESOLVE_ERROR, error: err }),
-      apiProto,
+      apiProto
     );
   };
 

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -26,8 +26,8 @@ const Form = styled.form`
   width: 100%;
 `;
 
-const loadSchemas = (type: string, dispatch: React.Dispatch<DispatchAction>, apiProto: any) => {
-  fetchResourceSchemas(type, apiProto)
+const loadSchemas = (type: string, dispatch: React.Dispatch<DispatchAction>) => {
+  fetchResourceSchemas(type)
     .then(schemas => {
       if (schemas.length === 0) {
         dispatch({
@@ -73,7 +73,7 @@ const Resolver: React.FC<ResolverProps> = ({
   });
   const [validation, setValidation] = React.useState(() => queryValidation);
 
-  React.useEffect(() => loadSchemas(type, dispatch, apiProto), []);
+  React.useEffect(() => loadSchemas(type, dispatch), []);
 
   const submitHandler = () => {
     // Move to loading state.
@@ -125,7 +125,7 @@ const Resolver: React.FC<ResolverProps> = ({
   return (
     <Loadable isLoading={state.schemasLoading}>
       {state.schemaFetchError !== "" ? (
-        <Error message={state.schemaFetchError} onRetry={() => loadSchemas(type, dispatch,  apiProto)} />
+        <Error message={state.schemaFetchError} onRetry={() => loadSchemas(type, dispatch)} />
       ) : (
         <Loadable variant="overlay" isLoading={state.resolverLoading}>
           {process.env.REACT_APP_DEBUG_FORMS === "true" && <DevTool control={validation.control} />}

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -26,8 +26,8 @@ const Form = styled.form`
   width: 100%;
 `;
 
-const loadSchemas = (type: string, dispatch: React.Dispatch<DispatchAction>) => {
-  fetchResourceSchemas(type)
+const loadSchemas = (type: string, dispatch: React.Dispatch<DispatchAction>, apiProto: any) => {
+  fetchResourceSchemas(type, apiProto)
     .then(schemas => {
       if (schemas.length === 0) {
         dispatch({
@@ -48,9 +48,10 @@ interface ResolverProps {
   searchLimit: number;
   onResolve: (data: { results: object[]; input: object }) => void;
   variant?: "dual" | "query" | "schema";
+  apiProto?: any;
 }
 
-const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, variant = "dual" }) => {
+const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, variant = "dual", apiProto }) => {
   const [state, dispatch] = useResolverState();
   const { displayWarnings } = useWizardContext();
 
@@ -66,7 +67,7 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
   });
   const [validation, setValidation] = React.useState(() => queryValidation);
 
-  React.useEffect(() => loadSchemas(type, dispatch), []);
+  React.useEffect(() => loadSchemas(type, dispatch, apiProto), []);
 
   const submitHandler = () => {
     // Move to loading state.
@@ -90,7 +91,8 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
         }
         dispatch({ type: ResolverAction.RESOLVE_SUCCESS });
       },
-      err => dispatch({ type: ResolverAction.RESOLVE_ERROR, error: err })
+      err => dispatch({ type: ResolverAction.RESOLVE_ERROR, error: err }),
+      apiProto,
     );
   };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Allow workflows to specify optional Resolver prop to override the API proto used to resolve schema type lookups and response objects against.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
- [ ] Test against mock server
