### PR TITLE
ui v2: resolver refactor and other polish

### DIFF
--- a/frontend/packages/app/src/index.css
+++ b/frontend/packages/app/src/index.css
@@ -5,4 +5,5 @@ html, body, #root, #App {
 #App {
   display: flex;
   flex-direction: column;
+  background-color: #f9fafe;
 }

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -24,7 +24,6 @@ const SchemaLabel = styled.div({
   alignSelf: "flex-start",
   fontSize: "20px",
   fontWeight: 700,
-  paddingBottom: "8px",
 });
 
 const loadSchemas = (type: string, dispatch: React.Dispatch<DispatchAction>) => {

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useForm } from "react-hook-form";
 import styled from "@emotion/styled";
 import _ from "lodash";
 
@@ -13,7 +12,6 @@ import { fetchResourceSchemas, resolveResource } from "./fetch";
 import { QueryResolver, SchemaResolver } from "./input";
 import type { DispatchAction } from "./state";
 import { ResolverAction, useResolverState } from "./state";
-
 
 const SchemaLabel = styled.div({
   alignSelf: "flex-start",
@@ -52,7 +50,6 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
 
   React.useEffect(() => loadSchemas(type, dispatch), []);
 
-
   const submitHandler = data => {
     // Move to loading state.
     dispatch({ type: ResolverAction.RESOLVING });
@@ -76,7 +73,6 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
     );
   };
 
-
   return (
     <Loadable isLoading={state.schemasLoading}>
       {state.schemaFetchError !== "" ? (
@@ -87,10 +83,7 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
           {(variant === "dual" || variant === "query") && (
             <>
               <SchemaLabel>Search</SchemaLabel>
-              <QueryResolver
-                schemas={state.searchableSchemas}
-                submitHandler={submitHandler}
-              />
+              <QueryResolver schemas={state.searchableSchemas} submitHandler={submitHandler} />
             </>
           )}
           {variant === "dual" && <HorizontalRule>OR</HorizontalRule>}

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -14,11 +14,6 @@ import { QueryResolver, SchemaResolver } from "./input";
 import type { DispatchAction } from "./state";
 import { ResolverAction, useResolverState } from "./state";
 
-const Form = styled.form({
-  alignItems: "center",
-  display: "flex",
-  flexDirection: "column",
-});
 
 const SchemaLabel = styled.div({
   alignSelf: "flex-start",
@@ -56,7 +51,6 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
 
   React.useEffect(() => loadSchemas(type, dispatch), []);
 
-  const [queryData, setQueryData] = React.useState({ query: "" });
 
   const submitHandler = data => {
     // Move to loading state.
@@ -81,15 +75,6 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
     );
   };
 
-  const queryValidation = useForm({
-    mode: "onSubmit",
-    reValidateMode: "onSubmit",
-    shouldFocusError: false,
-  });
-
-  const queryOnChange = e => {
-    setQueryData({ query: e.target.value });
-  };
 
   return (
     <Loadable isLoading={state.schemasLoading}>
@@ -99,17 +84,13 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
         <Loadable variant="overlay" isLoading={state.resolverLoading}>
           <CompressedError title="Error" message={state.resolverFetchError} />
           {(variant === "dual" || variant === "query") && (
-            <Form
-              onSubmit={queryValidation.handleSubmit(() => submitHandler(queryData))}
-              noValidate
-            >
+            <>
               <SchemaLabel>Search</SchemaLabel>
               <QueryResolver
                 schemas={state.searchableSchemas}
-                onChange={queryOnChange}
-                validation={queryValidation}
+                submitHandler={submitHandler}
               />
-            </Form>
+            </>
           )}
           {variant === "dual" && <HorizontalRule>OR</HorizontalRule>}
           <SchemaLabel>Advanced Search</SchemaLabel>

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -104,6 +104,7 @@ const Resolver: React.FC<ResolverProps> = ({ type, searchLimit, onResolve, varia
               onSubmit={queryValidation.handleSubmit(() => submitHandler(queryData))}
               noValidate
             >
+              <SchemaLabel>Search</SchemaLabel>
               <QueryResolver
                 schemas={state.searchableSchemas}
                 onChange={queryOnChange}

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -19,6 +19,7 @@ const SchemaLabel = styled.div({
   alignSelf: "flex-start",
   fontSize: "20px",
   fontWeight: 700,
+  marginBottom: "8px",
 });
 
 const loadSchemas = (type: string, dispatch: React.Dispatch<DispatchAction>) => {

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { useForm } from "react-hook-form";
-import styled from "@emotion/styled";
-
 import type { clutch } from "@clutch-sh/api";
+import styled from "@emotion/styled";
 import SearchIcon from "@material-ui/icons/Search";
 
 import {
@@ -19,10 +18,7 @@ import { TextField } from "../Input/text-field";
 import type { ChangeEventTarget } from "./hydrator";
 import { convertChangeEvent, hydrateField } from "./hydrator";
 
-const Form = styled.form({
-
-});
-
+const Form = styled.form({});
 
 interface QueryResolverProps {
   schemas: clutch.resolver.v1.Schema[];
@@ -47,22 +43,19 @@ const QueryResolver: React.FC<QueryResolverProps> = ({ schemas, submitHandler })
 
   const error = validation.errors?.query;
   return (
-    <Form
-    onSubmit={validation.handleSubmit(() => submitHandler({query: queryData}))}
-    noValidate
-  >
-    <TextField
-      label={typeLabel}
-      name="query"
-      required
-      onChange={handleChanges}
-      onKeyDown={handleChanges}
-      onFocus={handleChanges}
-      inputRef={validation.register({ required: true })}
-      error={!!error}
-      helperText={error?.message || error?.type || ""}
-      endAdornment={<SearchIcon />}
-    />
+    <Form onSubmit={validation.handleSubmit(() => submitHandler({ query: queryData }))} noValidate>
+      <TextField
+        label={typeLabel}
+        name="query"
+        required
+        onChange={handleChanges}
+        onKeyDown={handleChanges}
+        onFocus={handleChanges}
+        inputRef={validation.register({ required: true })}
+        error={!!error}
+        helperText={error?.message || error?.type || ""}
+        endAdornment={<SearchIcon />}
+      />
     </Form>
   );
 };

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import type { UseFormMethods } from "react-hook-form";
 import { useForm } from "react-hook-form";
+import styled from "@emotion/styled";
+
 import type { clutch } from "@clutch-sh/api";
 import SearchIcon from "@material-ui/icons/Search";
 
@@ -18,24 +19,40 @@ import { TextField } from "../Input/text-field";
 import type { ChangeEventTarget, ResolverChangeEvent } from "./hydrator";
 import { convertChangeEvent, hydrateField } from "./hydrator";
 
+const Form = styled.form({
+
+});
+
+
 interface QueryResolverProps {
   schemas: clutch.resolver.v1.Schema[];
-  onChange: (e: ResolverChangeEvent) => void;
-  validation: UseFormMethods;
+  submitHandler: any;
 }
 
-const QueryResolver: React.FC<QueryResolverProps> = ({ schemas, onChange, validation }) => {
+const QueryResolver: React.FC<QueryResolverProps> = ({ schemas, submitHandler }) => {
+  const validation = useForm({
+    mode: "onSubmit",
+    reValidateMode: "onSubmit",
+    shouldFocusError: false,
+  });
+
+  const [queryData, setQueryData] = React.useState("");
+
   let typeLabel = schemas.map(schema => schema?.metadata.displayName).join();
   typeLabel = `Search by ${typeLabel}`;
 
   const handleChanges = (event: React.ChangeEvent<ChangeEventTarget> | React.KeyboardEvent) => {
-    onChange(convertChangeEvent(event));
+    setQueryData(convertChangeEvent(event).target.value);
   };
 
   const error = validation.errors?.query;
   return (
+    <Form
+    onSubmit={validation.handleSubmit(() => submitHandler({query: queryData}))}
+    noValidate
+  >
     <TextField
-      label={typeLabel || "Please select a resolver"}
+      label={typeLabel}
       name="query"
       required
       onChange={handleChanges}
@@ -46,6 +63,7 @@ const QueryResolver: React.FC<QueryResolverProps> = ({ schemas, onChange, valida
       helperText={error?.message || error?.type || ""}
       endAdornment={<SearchIcon />}
     />
+    </Form>
   );
 };
 
@@ -69,7 +87,7 @@ const SchemaResolver = ({ schema, expanded, onClick, submitHandler }: SchemaReso
   };
 
   return (
-    <form noValidate onSubmit={schemaValidation.handleSubmit(() => submitHandler(data))}>
+    <Form noValidate onSubmit={schemaValidation.handleSubmit(() => submitHandler(data))}>
       <Accordion
         title={`Search by ${schema.metadata.displayName}`}
         expanded={expanded}
@@ -87,7 +105,7 @@ const SchemaResolver = ({ schema, expanded, onClick, submitHandler }: SchemaReso
           <Button text="Submit" type="submit" />
         </AccordionActions>
       </Accordion>
-    </form>
+    </Form>
   );
 };
 

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form";
 import styled from "@emotion/styled";
 
 import type { clutch } from "@clutch-sh/api";
-import styled from "@emotion/styled";
 import SearchIcon from "@material-ui/icons/Search";
 
 import {
@@ -17,7 +16,7 @@ import { Button } from "../button";
 import { Error } from "../error";
 import { TextField } from "../Input/text-field";
 
-import type { ChangeEventTarget, ResolverChangeEvent } from "./hydrator";
+import type { ChangeEventTarget } from "./hydrator";
 import { convertChangeEvent, hydrateField } from "./hydrator";
 
 const Form = styled.form({

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -20,7 +20,7 @@ const DialogPaper = styled(Paper)({
 
 const DialogTitle = styled(MuiDialogTitle)({
   display: "flex",
-  justifyContent: "space-between",
+  justifyContent: "space-evenly",
   fontSize: "20px",
   padding: "12px 12px 0 32px",
   fontWeight: 400,

--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -41,8 +41,7 @@ const Error: React.FC<ErrorProps> = ({ message, onRetry }) => {
 };
 
 const Collapse = styled(MuiCollapse)`
-  margin-top: 10px;
-  width: 45%;
+  display: none;
 `;
 
 const ErrorText = styled(Typography)`

--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -41,7 +41,6 @@ const Error: React.FC<ErrorProps> = ({ message, onRetry }) => {
 };
 
 const Collapse = styled(MuiCollapse)`
-  display: none;
 `;
 
 const ErrorText = styled(Typography)`

--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -40,8 +40,6 @@ const Error: React.FC<ErrorProps> = ({ message, onRetry }) => {
   );
 };
 
-const Collapse = styled(MuiCollapse)``;
-
 const ErrorText = styled(Typography)`
   color: rgb(97, 26, 21);
   font-size: 0.875rem;
@@ -89,7 +87,7 @@ const CompressedError: React.FC<CompressedErrorProps> = ({ title, message }) => 
 
   const breakpoint = findBreakpoint(errorMsg);
   return (
-    <Collapse in={open}>
+    <MuiCollapse in={open}>
       <Alert severity="error">
         <AlertTitle>{title || "Error"}</AlertTitle>
         {(errorMsg?.length || 0) > BREAKPOINT_LENGTH ? (
@@ -109,7 +107,7 @@ const CompressedError: React.FC<CompressedErrorProps> = ({ title, message }) => 
           errorMsg
         )}
       </Alert>
-    </Collapse>
+    </MuiCollapse>
   );
 };
 

--- a/frontend/packages/core/src/error.tsx
+++ b/frontend/packages/core/src/error.tsx
@@ -40,8 +40,7 @@ const Error: React.FC<ErrorProps> = ({ message, onRetry }) => {
   );
 };
 
-const Collapse = styled(MuiCollapse)`
-`;
+const Collapse = styled(MuiCollapse)``;
 
 const ErrorText = styled(Typography)`
   color: rgb(97, 26, 21);

--- a/frontend/packages/core/src/horizontal-rule.tsx
+++ b/frontend/packages/core/src/horizontal-rule.tsx
@@ -22,6 +22,7 @@ const StyledHorizontalRule = styled(HorizontalRuleBase)({
   display: "flex",
   flexDirection: "row",
   width: "100%",
+  margin: "16px 0px",
 
   ".line": {
     flex: "1 1 auto",
@@ -33,8 +34,9 @@ const StyledHorizontalRule = styled(HorizontalRuleBase)({
   },
 
   ".content": {
-    padding: "0 30px",
+    padding: "0 16px",
     fontWeight: "bold",
+    fontSize: "14px",
     color: "rgba(13, 16, 48, 0.38)",
     textTransform: "uppercase",
     display: "inline-flex",

--- a/frontend/packages/core/src/loading.tsx
+++ b/frontend/packages/core/src/loading.tsx
@@ -13,10 +13,6 @@ const ContentContainer = styled(Grid)`
 
 const ChildrenContainer = styled.div({
   width: "100%",
-  "> *": {
-    paddingTop: "8px",
-    paddingBottom: "8px",
-  },
 });
 
 const Overlay = styled(Paper)`

--- a/frontend/packages/core/src/stepper.tsx
+++ b/frontend/packages/core/src/stepper.tsx
@@ -11,12 +11,48 @@ import MuiCheckIcon from "@material-ui/icons/Check";
 import PriorityHighIcon from "@material-ui/icons/PriorityHigh";
 
 const StepContainer = styled.div({
+  margin: "0px 10px 30px 10px",
+
   ".MuiStepper-root": {
     padding: "0",
   },
   ".MuiGrid-container": {
     padding: "16px 0",
   },
+  ".MuiStepLabel-labelContainer": {
+    width: "unset",
+  },
+  ".MuiStepConnector-alternativeLabel": {
+    top: "10px",
+    right: "calc(50%)",
+    left: "calc(-50%)",
+    zIndex: 10,
+  },
+  ".MuiStepLabel-iconContainer": {
+    zIndex: 20,
+  },
+  ".MuiStep-root": {
+    padding: "0",
+  },
+  ".MuiStep-root:first-of-type": {
+    ".MuiStepLabel-root": {
+      alignItems: "flex-start",
+    },
+  },
+  ".MuiStep-root:nth-of-type(2)": {
+    ".MuiStepConnector-alternativeLabel": {
+      left: "calc(-100%)",
+    },
+  },
+  ".MuiStep-root:last-of-type": {
+    ".MuiStepLabel-root": {
+      alignItems: "flex-end",
+    },
+
+    ".MuiStepConnector-alternativeLabel": {
+      right: "0px",
+    }
+  }
 });
 
 const Circle = styled.div((props: { background: string; border: string }) => ({
@@ -55,12 +91,6 @@ const StepConnector = styled(MuiStepConnector)((props: { completed?: boolean }) 
     border: "0",
   },
 }));
-
-const StepLabelIcon = styled(MuiStepLabel)({
-  ".MuiStepLabel-iconContainer": {
-    padding: "0",
-  },
-});
 
 type StepIconVariant = "active" | "pending" | "success" | "failed";
 export interface StepIconProps {
@@ -130,7 +160,7 @@ export interface StepperProps {
 
 const Stepper = ({ activeStep, children }: StepperProps) => (
   <StepContainer>
-    <MuiStepper activeStep={activeStep + 1} connector={<StepConnector />}>
+    <MuiStepper activeStep={activeStep + 1} connector={<StepConnector />} alternativeLabel>
       {React.Children.map(children, (step: any, idx: number) => {
         const stepProps = {
           index: idx + 1,
@@ -143,19 +173,14 @@ const Stepper = ({ activeStep, children }: StepperProps) => (
         }
 
         return (
-          <MuiStep key={step.label} style={{ padding: "0" }}>
-            <StepLabelIcon icon={<StepIcon {...stepProps} />} />
+          <MuiStep key={step.props.label}>
+            <MuiStepLabel StepIconComponent={() => <StepIcon {...stepProps} />}>
+              {step.props.label ?? `Step ${idx + 1}`}
+            </MuiStepLabel>
           </MuiStep>
         );
       })}
     </MuiStepper>
-    <Grid container justify="space-between">
-      {React.Children.map(children, (step: any, idx: number) => (
-        <StepLabel item data-active={idx === activeStep}>
-          {step.props.label}
-        </StepLabel>
-      ))}
-    </Grid>
   </StepContainer>
 );
 

--- a/frontend/packages/core/src/stepper.tsx
+++ b/frontend/packages/core/src/stepper.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import styled from "@emotion/styled";
 import {
-  Grid,
   Step as MuiStep,
   StepConnector as MuiStepConnector,
   StepLabel as MuiStepLabel,
@@ -11,8 +10,16 @@ import MuiCheckIcon from "@material-ui/icons/Check";
 import PriorityHighIcon from "@material-ui/icons/PriorityHigh";
 
 const StepContainer = styled.div({
-  margin: "0px 10px 30px 10px",
+  margin: "0px 2px 30px 2px",
 
+  ".MuiStepLabel-label": {
+    fontWeight: 500,
+    fontSize: "14px",
+    color: "rgba(13, 16, 48, 0.38)",
+  },
+  ".MuiStepLabel-label.MuiStepLabel-active": {
+    color: "#0d1030",
+  },
   ".MuiStepper-root": {
     padding: "0",
   },
@@ -24,8 +31,8 @@ const StepContainer = styled.div({
   },
   ".MuiStepConnector-alternativeLabel": {
     top: "10px",
-    right: "calc(50%)",
-    left: "calc(-50%)",
+    right: "calc(50% + 8px)",
+    left: "calc(-50% + 8px)",
     zIndex: 10,
   },
   ".MuiStepLabel-iconContainer": {
@@ -38,6 +45,7 @@ const StepContainer = styled.div({
     ".MuiStepLabel-root": {
       alignItems: "flex-start",
     },
+    width: "50%",
   },
   ".MuiStep-root:nth-of-type(2)": {
     ".MuiStepConnector-alternativeLabel": {
@@ -51,8 +59,23 @@ const StepContainer = styled.div({
 
     ".MuiStepConnector-alternativeLabel": {
       right: "0px",
-    }
-  }
+    },
+  },
+
+  ".MuiStepConnector-line": {
+    height: "5px",
+    border: 0,
+    backgroundColor: "#E7E7EA",
+    borderRadius: "4px",
+  },
+
+  ".MuiStepConnector-active .MuiStepConnector-line": {
+    backgroundColor: "#3548D4",
+  },
+
+  ".MuiStepConnector-completed .MuiStepConnector-line": {
+    backgroundColor: "#3548D4",
+  },
 });
 
 const Circle = styled.div((props: { background: string; border: string }) => ({
@@ -83,14 +106,6 @@ const CheckIcon = styled(MuiCheckIcon)((props: { font: string }) => ({
 }));
 
 const ClearIcon = CheckIcon.withComponent(PriorityHighIcon);
-
-const StepConnector = styled(MuiStepConnector)((props: { completed?: boolean }) => ({
-  ".MuiStepConnector-line": {
-    height: "5px",
-    background: props.completed ? "#3548D4" : "#E7E7EA",
-    border: "0",
-  },
-}));
 
 type StepIconVariant = "active" | "pending" | "success" | "failed";
 export interface StepIconProps {
@@ -136,16 +151,6 @@ const StepIcon: React.FC<StepIconProps> = ({ index, variant }) => {
   );
 };
 
-const StepLabel = styled(Grid)(
-  {
-    fontWeight: 500,
-    fontSize: "14px",
-  },
-  props => ({
-    color: props["data-active"] ? "#0D1030" : "rgba(13, 16, 48, 0.38)",
-  })
-);
-
 export interface StepProps {
   label: string;
   error?: boolean;
@@ -160,7 +165,7 @@ export interface StepperProps {
 
 const Stepper = ({ activeStep, children }: StepperProps) => (
   <StepContainer>
-    <MuiStepper activeStep={activeStep + 1} connector={<StepConnector />} alternativeLabel>
+    <MuiStepper activeStep={activeStep} connector={<MuiStepConnector />} alternativeLabel>
       {React.Children.map(children, (step: any, idx: number) => {
         const stepProps = {
           index: idx + 1,

--- a/frontend/packages/core/src/stepper.tsx
+++ b/frontend/packages/core/src/stepper.tsx
@@ -45,7 +45,6 @@ const StepContainer = styled.div({
     ".MuiStepLabel-root": {
       alignItems: "flex-start",
     },
-    width: "50%",
   },
   ".MuiStep-root:nth-of-type(2)": {
     ".MuiStepConnector-alternativeLabel": {

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -128,9 +128,7 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
               return <Step key={child.props.name} label={child.props.name} error={hasError} />;
             })}
           </Stepper>
-          <Paper elevation={0}>
-          {steps[state.activeStep]}
-          </Paper>
+          <Paper elevation={0}>{steps[state.activeStep]}</Paper>
         </Grid>
       </Grid>
       {globalWarnings.map(error => (

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -3,7 +3,7 @@ import { ButtonGroup, Step, Stepper, Warning, WizardContext } from "@clutch-sh/c
 import type { ManagerLayout } from "@clutch-sh/data-layout";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
-import { Container as MuiContainer, Grid, Typography } from "@material-ui/core";
+import { Container as MuiContainer, Grid, Paper as MuiPaper, Typography } from "@material-ui/core";
 
 import { useWizardState, WizardAction } from "./state";
 import type { WizardStepProps } from "./step";
@@ -35,6 +35,11 @@ interface WizardStepData {
 const Container = styled(MuiContainer)({
   padding: "32px",
   maxWidth: "800px",
+});
+
+const Paper = styled(MuiPaper)({
+  boxShadow: "0px 5px 15px rgba(53, 72, 212, 0.2)",
+  padding: "32px",
 });
 
 const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
@@ -129,7 +134,9 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
               return <Step key={child.props.name} label={child.props.name} error={hasError} />;
             })}
           </Stepper>
+          <Paper elevation={0}>
           {steps[state.activeStep]}
+          </Paper>
         </Grid>
       </Grid>
       {globalWarnings.map(error => (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Moving the QueryResolver < form > element into the child similar to the SchemaResolver.

Had to change some margin rules around. Need to add it back.

Also significant changes to stepper to fix alignment by recombining labels and icons.

![Screenshot from 2020-12-17 15-40-16](https://user-images.githubusercontent.com/4712430/102547046-32f66e80-407e-11eb-8826-b5d4b9106a3f.png)

### Testing Performed
dev

### TODO
- [ ] loadable paper
- [ ] fix extra width on first and last stepper element
- [ ] refactor error display