### PR TITLE
ui v2: button group

### DIFF
--- a/frontend/packages/core/src/Input/toggle.tsx
+++ b/frontend/packages/core/src/Input/toggle.tsx
@@ -26,7 +26,7 @@ const SwitchContainer = styled(MuiSwitch)({
   ".Mui-disabled": {
     ".MuiSwitch-thumb": {
       color: "rgba(248, 248, 249, 1)",
-    }
+    },
   },
   ".Mui-disabled + .MuiSwitch-track": {
     backgroundColor: "#E7E7EA",
@@ -61,10 +61,8 @@ const SwitchContainer = styled(MuiSwitch)({
   },
 });
 
-export interface SwitchProps extends Pick<MuiSwitchProps, "checked" | "disabled" | "onChange"> {};
+export interface SwitchProps extends Pick<MuiSwitchProps, "checked" | "disabled" | "onChange"> {}
 
-export const Switch = ({...props}: SwitchProps) => (
-  <SwitchContainer color="default" {...props} />
-);
+export const Switch = ({ ...props }: SwitchProps) => <SwitchContainer color="default" {...props} />;
 
 export default Switch;

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -100,15 +100,13 @@ const ButtonGroupContainer = styled(Grid)({
 });
 
 export interface ButtonGroupProps {
-  buttons: ButtonProps[];
+  children: React.ReactElement<ButtonProps> | React.ReactElement<ButtonProps>[];
   justify?: GridJustification;
 }
 
-const ButtonGroup: React.FC<ButtonGroupProps> = ({ buttons, justify = "center" }) => (
+const ButtonGroup = ({ children, justify = "center" }: ButtonGroupProps) => (
   <ButtonGroupContainer container justify={justify}>
-    {buttons.map(button => (
-      <Button key={button.text} {...button} />
-    ))}
+    {React.Children.map(children, child => child)}
   </ButtonGroupContainer>
 );
 

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -106,7 +106,7 @@ export interface ButtonGroupProps {
 
 const ButtonGroup = ({ children, justify = "center" }: ButtonGroupProps) => (
   <ButtonGroupContainer container justify={justify}>
-    {React.Children.map(children, child => child)}
+    {children}
   </ButtonGroupContainer>
 );
 

--- a/frontend/packages/core/src/stories/button-group.stories.tsx
+++ b/frontend/packages/core/src/stories/button-group.stories.tsx
@@ -2,40 +2,27 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
-import type { ButtonGroupProps } from "../button";
-import { ButtonGroup } from "../button";
+import type { ButtonGroupProps, ButtonProps } from "../button";
+import { Button, ButtonGroup } from "../button";
 
 export default {
   title: "Core/Buttons/Button Group",
   component: ButtonGroup,
 } as Meta;
 
-const Template = (props: ButtonGroupProps) => <ButtonGroup {...props} />;
-
-const sharedArgs = [
-  { text: "Back", variant: "neutral", onClick: action("onClick event") },
-  action("onClick event"),
-];
+const Template = ({ children, ...props }: ButtonGroupProps) => (
+  <ButtonGroup {...props}>
+    <Button text="Back" variant="neutral" onClick={action("onClick event")} />
+    {children as React.ReactElement<ButtonProps>}
+  </ButtonGroup>
+);
 
 export const Primary = Template.bind({});
 Primary.args = {
-  buttons: [
-    sharedArgs[0],
-    {
-      text: "Next",
-      onClick: sharedArgs[1],
-    },
-  ],
+  children: <Button text="Next" onClick={action("onClick event")} />,
 };
 
 export const Destructive = Template.bind({});
 Destructive.args = {
-  buttons: [
-    sharedArgs[0],
-    {
-      text: "Terminate",
-      variant: "destructive",
-      onClick: sharedArgs[1],
-    },
-  ],
+  children: <Button text="Terminate" variant="destructive" onClick={action("onClick event")} />,
 };

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ButtonGroup, Step, Stepper, Warning, WizardContext } from "@clutch-sh/core";
+import { Button, ButtonGroup, Step, Stepper, Warning, WizardContext } from "@clutch-sh/core";
 import type { ManagerLayout } from "@clutch-sh/data-layout";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
@@ -93,15 +93,9 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
         </DataLayoutContext.Provider>
         <Grid container justify="center">
           {state.activeStep === lastStepIndex && !isLoading && isMultistep && (
-            <ButtonGroup
-              justify="flex-end"
-              buttons={[
-                {
-                  text: "Start Over",
-                  onClick: () => dispatch(WizardAction.RESET),
-                },
-              ]}
-            />
+            <ButtonGroup justify="flex-end">
+              <Button text="Start Over" onClick={() => dispatch(WizardAction.RESET)} />
+            </ButtonGroup>
           )}
         </Grid>
       </>

--- a/frontend/workflows/ec2/src/reboot-instance.tsx
+++ b/frontend/workflows/ec2/src/reboot-instance.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  Button,
   ButtonGroup,
   client,
   Confirmation,
@@ -51,19 +52,10 @@ const InstanceDetails: React.FC<WizardChild> = () => {
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
       <MetadataTable data={data} />
-      <ButtonGroup
-        buttons={[
-          {
-            text: "Back",
-            onClick: onBack,
-          },
-          {
-            text: "Reboot",
-            onClick: onSubmit,
-            variant: "destructive",
-          },
-        ]}
-      />
+      <ButtonGroup>
+        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Reboot" variant="destructive" onClick={onSubmit} />
+      </ButtonGroup>
     </WizardStep>
   );
 };

--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  Button,
   ButtonGroup,
   client,
   Confirmation,
@@ -67,19 +68,10 @@ const GroupDetails: React.FC<WizardChild> = () => {
           { name: "Availability Zone", value: group.zones },
         ]}
       />
-      <ButtonGroup
-        buttons={[
-          {
-            text: "Back",
-            onClick: onBack,
-          },
-          {
-            text: "Resize",
-            onClick: onSubmit,
-            variant: "destructive",
-          },
-        ]}
-      />
+      <ButtonGroup>
+        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Resize" variant="destructive" onClick={onSubmit} />
+      </ButtonGroup>
     </WizardStep>
   );
 };

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Accordion,
   AccordionDetails,
+  Button,
   ButtonGroup,
   client,
   Confirmation,
@@ -58,21 +59,10 @@ const InstanceDetails: React.FC<WizardChild> = () => {
           <MetadataTable data={metadata} />
         </AccordionDetails>
       </Accordion>
-      <ButtonGroup
-        justify="flex-end"
-        buttons={[
-          {
-            text: "Back",
-            onClick: onBack,
-            variant: "neutral",
-          },
-          {
-            text: "Terminate",
-            onClick: onSubmit,
-            variant: "destructive",
-          },
-        ]}
-      />
+      <ButtonGroup justify="flex-end">
+        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Terminate" variant="destructive" onClick={onSubmit} />
+      </ButtonGroup>
     </WizardStep>
   );
 };
@@ -83,7 +73,7 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const confirmationData = Object.keys(configData).map(key => {
     return { name: key, value: configData[key] };
   });
-  const formattedNotes = notes.map(note => <div>{note.text}</div>)
+  const formattedNotes = notes.map(note => <div>{note.text}</div>);
   return (
     <WizardStep error={terminationData.error} isLoading={terminationData.isLoading}>
       <Confirmation action="Termination">{notes && formattedNotes}</Confirmation>

--- a/frontend/workflows/envoy/src/remote-triage.tsx
+++ b/frontend/workflows/envoy/src/remote-triage.tsx
@@ -90,7 +90,7 @@ const RemoteTriage: React.FC<BaseWorkflowProps> = ({ heading }) => {
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} maxWidth={false}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <TriageIdentifier name="Lookup" />
       <TriageDetails name="Details" />
     </Wizard>

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { BaseWorkflowProps, ButtonGroup, client } from "@clutch-sh/core";
+import { BaseWorkflowProps, Button, ButtonGroup, client } from "@clutch-sh/core";
 
 import PageLayout from "./core/page-layout";
 import { Column, ListView } from "./list-view";
@@ -39,16 +39,13 @@ const ListExperiments: React.FC<ListExperimentsProps> = ({ heading, columns, lin
       });
   }, []);
 
-  const buttons = links.map(link => {
-    return {
-      text: link.displayName,
-      onClick: () => navigate(link.path),
-    };
-  });
+  const buttons = links.map(link => (
+    <Button text={link.displayName} onClick={() => navigate(link.path)} />
+  ));
 
   return (
     <PageLayout heading={heading} error={error}>
-      <ButtonGroup buttons={buttons} />
+      <ButtonGroup>{buttons}</ButtonGroup>
       <ListView
         columns={columns}
         items={experiments}

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { clutch as IClutch } from "@clutch-sh/api";
-import { BaseWorkflowProps, ButtonGroup, client, TextField } from "@clutch-sh/core";
+import { BaseWorkflowProps, Button, ButtonGroup, client, TextField } from "@clutch-sh/core";
 import styled from "styled-components";
 
 import PageLayout from "./core/page-layout";
@@ -27,10 +27,7 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
     const goBack = () => {
       navigate("/experimentation/list");
     };
-    const goBackButton = {
-      text: "Return",
-      onClick: goBack,
-    };
+    const goBackButton = <Button text="Return" variant="neutral" onClick={goBack} />;
 
     const statusValue = IClutch.chaos.experimentation.v1.Experiment.Status[
       experiment.status
@@ -48,20 +45,22 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
       statusValue === IClutch.chaos.experimentation.v1.Experiment.Status.STATUS_RUNNING.toString()
         ? "Stop Experiment Run"
         : "Cancel Experiment Run";
-    const destructiveButton = {
-      text: title,
-      variant: "destructive",
-      onClick: () => {
-        client
-          .post("/v1/chaos/experimentation/cancelExperimentRun", { id: runID })
-          .then(() => {
-            setExperiment(undefined);
-          })
-          .catch(err => {
-            setError(err.response.statusText);
-          });
-      },
-    };
+    const destructiveButton = (
+      <Button
+        text={title}
+        variant="destructive"
+        onClick={() => {
+          client
+            .post("/v1/chaos/experimentation/cancelExperimentRun", { id: runID })
+            .then(() => {
+              setExperiment(undefined);
+            })
+            .catch(err => {
+              setError(err.response.statusText);
+            });
+        }}
+      />
+    );
 
     return [goBackButton, destructiveButton];
   }
@@ -96,7 +95,7 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
               label="Config"
               defaultValue={JSON.stringify(experiment.config, null, 4)}
             />
-            <ButtonGroup buttons={makeButtons()} />
+            <ButtonGroup>{makeButtons()}</ButtonGroup>
           </>
         )}
       </Form>

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import {
+  Button,
   ButtonGroup,
   client,
   Confirmation,
@@ -47,19 +48,10 @@ const PodDetails: React.FC<WizardChild> = () => {
           { name: "Pod IP Address", value: instance.podIp },
         ]}
       />
-      <ButtonGroup
-        buttons={[
-          {
-            text: "Back",
-            onClick: onBack,
-          },
-          {
-            text: "Delete",
-            onClick: onSubmit,
-            variant: "destructive",
-          },
-        ]}
-      />
+      <ButtonGroup>
+        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Delete" variant="destructive" onClick={onSubmit} />
+      </ButtonGroup>
     </WizardStep>
   );
 };

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import {
+  Button,
   ButtonGroup,
   client,
   Confirmation,
@@ -65,19 +66,10 @@ const HPADetails: React.FC<WizardChild> = () => {
           { name: "Cluster", value: hpa.cluster },
         ]}
       />
-      <ButtonGroup
-        buttons={[
-          {
-            text: "Back",
-            onClick: onBack,
-          },
-          {
-            text: "Resize",
-            onClick: onSubmit,
-            variant: "destructive",
-          },
-        ]}
-      />
+      <ButtonGroup>
+        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Resize" variant="destructive" onClick={onSubmit} />
+      </ButtonGroup>
     </WizardStep>
   );
 };

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useForm } from "react-hook-form";
 import {
   Button,
+  ButtonGroup,
   client,
   Confirmation,
   NotePanel,
@@ -12,7 +13,7 @@ import {
 import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
-import { Grid, Select } from "@material-ui/core";
+import { Select } from "@material-ui/core";
 
 import type { ResolverChild, WorkflowProps } from "./index";
 
@@ -80,10 +81,11 @@ const StreamDetails: React.FC<WizardChild> = () => {
           <option value={values[6]}>{values[6]}</option>
         </Select>
       </form>
-      <Grid container justify="center">
+
+      <ButtonGroup>
         <Button text="Back" onClick={onBack} />
         <Button text="Update" variant="destructive" onClick={onSubmit} />
-      </Grid>
+      </ButtonGroup>
       <NotePanel
         notes={[
           {

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -134,20 +134,10 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
   return (
     <form onSubmit={handleSubmit(handleOnSubmit)}>
       <FormFields state={experimentDataState} items={fields} register={register} errors={errors} />
-      <ButtonGroup
-        buttons={[
-          {
-            text: "Cancel",
-            onClick: () => {
-              handleOnCancel();
-            },
-          },
-          {
-            text: "Start",
-            type: "submit",
-          },
-        ]}
-      />
+      <ButtonGroup>
+        <Button text="Cancel" variant="neutral" onClick={handleOnCancel} />
+        <Button text="Start" type="submit" />
+      </ButtonGroup>
     </form>
   );
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Update button group to take `Button` as children instead of using a prop.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual and storybook