### PR TITLE
experimentation: tune rtds removing faults log level

### DIFF
--- a/backend/module/chaos/serverexperimentation/rtds/rtds_cache.go
+++ b/backend/module/chaos/serverexperimentation/rtds/rtds_cache.go
@@ -157,7 +157,7 @@ func refreshCache(ctx context.Context, storer experimentstore.Storer, snapshotCa
 	// Settings snapshot with empty faults to remove the faults
 	for _, cluster := range snapshotCache.GetStatusKeys() {
 		if _, exist := clusterFaultMap[cluster]; !exist {
-			logger.Infow("Removing faults for cluster", "cluster", cluster)
+			logger.Debugw("Removing faults for cluster", "cluster", cluster)
 			err = setSnapshot(snapshotCache, rtdsLayerName, cluster, ingressPrefix, egressPrefix, []*experimentation.Experiment{}, logger)
 			if err != nil {
 				logger.Errorw("Unable to unset the fault for cluster", "cluster", cluster,


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Small change to alter the log level as it can produce a lot of logs in a large deployment as we have seen internally.

### Testing Performed
<!-- Describe how you tested this change below. -->
Unit.
