### PR TITLE
ui v2: fix header searchfield bug

### DIFF
--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -132,7 +132,7 @@ const CustomCloseIcon: React.FC = () => {
 const Input = (params: AutocompleteRenderInputParams): React.ReactNode => {
   const searchRef = React.useRef();
   const handleKeyPress = (event: KeyboardEvent) => {
-    if (searchRef.current !== undefined) {
+      if (searchRef.current && searchRef.current !== undefined) {
       if (event.key === hotKey && (event.target as Node).nodeName !== "INPUT") {
         // @ts-ignore
         searchRef.current.focus();

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -132,7 +132,7 @@ const CustomCloseIcon: React.FC = () => {
 const Input = (params: AutocompleteRenderInputParams): React.ReactNode => {
   const searchRef = React.useRef();
   const handleKeyPress = (event: KeyboardEvent) => {
-      if (searchRef.current && searchRef.current !== undefined) {
+    if (searchRef.current && searchRef.current !== undefined) {
       if (event.key === hotKey && (event.target as Node).nodeName !== "INPUT") {
         // @ts-ignore
         searchRef.current.focus();

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -132,7 +132,7 @@ const CustomCloseIcon: React.FC = () => {
 const Input = (params: AutocompleteRenderInputParams): React.ReactNode => {
   const searchRef = React.useRef();
   const handleKeyPress = (event: KeyboardEvent) => {
-    if (searchRef.current && searchRef.current !== undefined) {
+    if (searchRef.current) {
       if (event.key === hotKey && (event.target as Node).nodeName !== "INPUT") {
         // @ts-ignore
         searchRef.current.focus();


### PR DESCRIPTION
### Description

The error was coming from here:
https://github.com/lyft/clutch/blob/UIV2/frontend/packages/core/src/AppLayout/search.tsx#L136

Since we toggle between rendering the search icon or search bar, we need to add a null check for `searchRef.current`. Otherwise, once the search bar is collapsed, the `handleKeyPress` will still allow the `\` to focus the input field which isn't rendered.

Open to other suggestions for fixing the bug! 

Steps to reproduce bug on ui v2 master:
* open searchbar
* click into it
* close out of the searchbar
* press `/` key

![Screen Shot 2020-12-18 at 5 11 57 PM](https://user-images.githubusercontent.com/39421794/102666108-280e0d80-4154-11eb-9a1c-71350c719d44.png)

