### PR TITLE
ui v2: trim long group headings

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -151,6 +151,12 @@ const Group: React.FC<GroupProps> = ({
   if (React.Children.count(children) === 0) {
     return null;
   }
+  // TODO (dschaller): revisit how we handle long groups once we have designs.
+  // n.b. this is a stop-gap solution to prevent long groups from looking unreadable.
+  let formattedHeading = heading;
+  if (heading.length > 11) {
+    formattedHeading = `${heading.substring(0, 10)}...`;
+  }
 
   return (
     <GroupList data-qa="workflowGroup">
@@ -161,11 +167,11 @@ const Group: React.FC<GroupProps> = ({
         aria-controls={open ? "workflow-options" : undefined}
         aria-haspopup="true"
         onClick={() => {
-          updateOpenGroup(heading);
+          updateOpenGroup(formattedHeading);
         }}
       >
-        <Avatar>{heading.charAt(0)}</Avatar>
-        <GroupHeading align="center">{heading}</GroupHeading>
+        <Avatar>{formattedHeading.charAt(0)}</Avatar>
+        <GroupHeading align="center">{formattedHeading}</GroupHeading>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <Popper open={open} anchorEl={anchorRef.current} transition placement="right-start">
             <Paper>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Implement stop gap solution to prevent text overflow on drawer. Following up on longer term solution with design [here](https://lyftoss.slack.com/archives/C015UJ6LED9/p1608581951140400)

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
**Before**
![Screen Shot 2020-12-21 at 12 29 04 PM](https://user-images.githubusercontent.com/1004789/102819341-23319f80-4388-11eb-9545-991e48817474.png)

**After**
![Screen Shot 2020-12-21 at 12 28 52 PM](https://user-images.githubusercontent.com/1004789/102819357-2c227100-4388-11eb-9f27-ffc3bfa01453.png)


### Testing Performed
<!-- Describe how you tested this change below. -->
manual
### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
