### PR TITLE
ui v2: support content within tabs

### DIFF
--- a/frontend/packages/core/src/stories/tabs.stories.tsx
+++ b/frontend/packages/core/src/stories/tabs.stories.tsx
@@ -12,17 +12,16 @@ export default {
   },
 } as Meta;
 
-const Template = ({ tabCount, value, ...props }: TabsProps & { tabCount: number }) => {
-  const [selectedValue, setSelectedValue] = React.useState(value - 1);
-  return (
-    <Tabs value={selectedValue} onChange={(_, v) => setSelectedValue(v)} {...props}>
-      {[...Array(tabCount)].map((_, index: number) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <Tab key={index} label={`Tab ${index + 1}`} value={index} />
-      ))}
-    </Tabs>
-  );
-};
+const Template = ({ tabCount, value }: TabsProps & { tabCount: number }) => (
+  <Tabs value={value - 1}>
+    {[...Array(tabCount)].map((_, index: number) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <Tab key={index} label={`Tab ${index + 1}`} value={index}>
+        <div>Tab {index + 1} Content</div>
+      </Tab>
+    ))}
+  </Tabs>
+);
 
 export const Primary = Template.bind({});
 Primary.args = {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Support tab content as children within a `Tab` component.

Additional changes include:
- css fixes for tab labels (figma uses roboto medium)
- remove text transform from tab
- move onto experimental TabContent, TabList, and TabPanel to make maintaining tabs state easier
- remove onChange prop from tabs since we maintain state internally now. Decided to move this state within the component because I cannot think or a reason that consumers of this component would need to know when these changes occur.

### Testing Performed
<!-- Describe how you tested this change below. -->
Storybook and manual

