### PR TITLE
ui v2: fix radio group story location

### DIFF
--- a/frontend/packages/core/src/Input/stories/radio-group.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/radio-group.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
 
-import type { RadioGroupProps } from "../Input/radio-group";
-import { RadioGroup } from "../Input/radio-group";
+import type { RadioGroupProps } from "../radio-group";
+import { RadioGroup } from "../radio-group";
 
 export default {
   title: "Core/Input/RadioGroup",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Minor change to move the radio group story into the correct directory
