### PR TITLE
ui v2: fix drawer panel opening

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -167,7 +167,7 @@ const Group: React.FC<GroupProps> = ({
         aria-controls={open ? "workflow-options" : undefined}
         aria-haspopup="true"
         onClick={() => {
-          updateOpenGroup(formattedHeading);
+          updateOpenGroup(heading);
         }}
       >
         <Avatar>{formattedHeading.charAt(0)}</Avatar>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Trimmed headings don't match when attempting to open their content. This fixes that.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![drawer](https://user-images.githubusercontent.com/1004789/103142498-e08a0300-46b8-11eb-953a-f5bc4fdaba30.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
