### PR TITLE
ui v2: fix layout spacing of dialog heading

### DIFF
--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -20,7 +20,7 @@ const DialogPaper = styled(Paper)({
 
 const DialogTitle = styled(MuiDialogTitle)({
   display: "flex",
-  justifyContent: "space-evenly",
+  justifyContent: "space-between",
   fontSize: "20px",
   padding: "12px 12px 0 32px",
   fontWeight: 400,


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix layout spacing of Dialog heading to left and right justify content.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
**current**
![Screen Shot 2020-12-29 at 10 57 42 AM](https://user-images.githubusercontent.com/1004789/103307404-c7d56200-49c4-11eb-802c-ef5e38086d7f.png)

**after PR**
![Screen Shot 2020-12-29 at 10 57 29 AM](https://user-images.githubusercontent.com/1004789/103307408-cb68e900-49c4-11eb-8a3d-0c56c8c95446.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual

