### PR TITLE
ui v2: allow button group border movement

### DIFF
--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -98,12 +98,12 @@ const ButtonGroupContainer = styled(Grid)(
     },
   },
   props => (
-    props["data-border"] === "top" ? {
-    marginTop: "24px",
-    borderTop: "1px solid #E7E7EA",
-  } : {
-    marginBottom: "24px",
-    borderBottom: "1px solid #E7E7EA",
+    props["data-border"] === "bottom" ? {
+      marginBottom: "24px",
+      borderBottom: "1px solid #E7E7EA",
+    } : {
+      marginTop: "24px",
+      borderTop: "1px solid #E7E7EA",
   })
 );
 

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -97,20 +97,22 @@ const ButtonGroupContainer = styled(Grid)(
       margin: "8px",
     },
   },
-  props => (
-    props["data-border"] === "bottom" ? {
-      marginBottom: "24px",
-      borderBottom: "1px solid #E7E7EA",
-    } : {
-      marginTop: "24px",
-      borderTop: "1px solid #E7E7EA",
-  })
+  props =>
+    props["data-border"] === "bottom"
+      ? {
+          marginBottom: "24px",
+          borderBottom: "1px solid #E7E7EA",
+        }
+      : {
+          marginTop: "24px",
+          borderTop: "1px solid #E7E7EA",
+        }
 );
 
 export interface ButtonGroupProps {
   children: React.ReactElement<ButtonProps> | React.ReactElement<ButtonProps>[];
   justify?: GridJustification;
-  border?: "top" | "bottom"
+  border?: "top" | "bottom";
 }
 
 const ButtonGroup = ({ children, justify = "flex-end", border = "top" }: ButtonGroupProps) => (

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -91,21 +91,30 @@ const Button: React.FC<ButtonProps> = ({ text, variant = "primary", ...props }) 
   );
 };
 
-const ButtonGroupContainer = styled(Grid)({
-  borderTop: "1px solid #E7E7EA",
-  marginTop: "24px",
-  "> *": {
-    margin: "8px",
+const ButtonGroupContainer = styled(Grid)(
+  {
+    "> *": {
+      margin: "8px",
+    },
   },
-});
+  props => (
+    props["data-border"] === "top" ? {
+    marginTop: "24px",
+    borderTop: "1px solid #E7E7EA",
+  } : {
+    marginBottom: "24px",
+    borderBottom: "1px solid #E7E7EA",
+  })
+);
 
 export interface ButtonGroupProps {
   children: React.ReactElement<ButtonProps> | React.ReactElement<ButtonProps>[];
   justify?: GridJustification;
+  border?: "top" | "bottom"
 }
 
-const ButtonGroup = ({ children, justify = "flex-end" }: ButtonGroupProps) => (
-  <ButtonGroupContainer container justify={justify}>
+const ButtonGroup = ({ children, justify = "flex-end", border = "top" }: ButtonGroupProps) => (
+  <ButtonGroupContainer container justify={justify} data-border={border}>
     {children}
   </ButtonGroupContainer>
 );

--- a/frontend/packages/core/src/stories/button-group.stories.tsx
+++ b/frontend/packages/core/src/stories/button-group.stories.tsx
@@ -22,6 +22,12 @@ Primary.args = {
   children: <Button text="Next" onClick={action("onClick event")} />,
 };
 
+export const BottomBorder = Template.bind({});
+BottomBorder.args = {
+  border: "bottom",
+  children: <Button text="Next" onClick={action("onClick event")} />,
+};
+
 export const Destructive = Template.bind({});
 Destructive.args = {
   children: <Button text="Terminate" variant="destructive" onClick={action("onClick event")} />,


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
There may be times when we want the button group border to be below the buttons (e.g. if the buttons are a heading to something as in the photo below)

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2020-12-29 at 3 36 52 PM](https://user-images.githubusercontent.com/1004789/103320858-e0a53e00-49eb-11eb-9f12-416726fc19b9.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual and story
