### PR TITLE
ui v2: use margin for wizard steps

### DIFF
--- a/frontend/packages/wizard/src/step.tsx
+++ b/frontend/packages/wizard/src/step.tsx
@@ -6,7 +6,7 @@ import { Grid as MuiGrid } from "@material-ui/core";
 const Grid = styled(MuiGrid)({
   width: "100%",
   "> *": {
-    padding: "8px 0",
+    margin: "8px 0",
   },
 });
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Use margin over padding for wizard steps to prevent misaligning children

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
