### PR TITLE
ui v2: add wizard step error handling

### DIFF
--- a/frontend/packages/core/src/Contexts/wizard-context.tsx
+++ b/frontend/packages/core/src/Contexts/wizard-context.tsx
@@ -6,6 +6,7 @@ export interface ContextProps {
   onSubmit: () => void;
   setOnSubmit: (f: (...args: any[]) => void) => void;
   setIsLoading: (isLoading: boolean) => void;
+  setHasError: (hasError: boolean) => void;
 }
 
 const WizardContext = React.createContext<() => ContextProps>(undefined);

--- a/frontend/packages/wizard/src/step.tsx
+++ b/frontend/packages/wizard/src/step.tsx
@@ -22,6 +22,9 @@ const WizardStep: React.FC<WizardStepProps> = ({ isLoading, error, children }) =
   React.useEffect(() => {
     wizardContext.setIsLoading(showLoading);
   }, [showLoading]);
+  React.useEffect(() => {
+    wizardContext.setHasError(hasError);
+  }, [error]);
   if (showLoading) {
     return <Loadable isLoading={isLoading}>{children}</Loadable>;
   }

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -72,6 +72,9 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
       setIsLoading: (isLoading: boolean) => {
         updateStepData(child.type.name, { isLoading });
       },
+      setHasError: (hasError: boolean) => {
+        updateStepData(child.type.name, { hasError });
+      },
       displayWarnings: (warnings: string[]) => {
         setGlobalWarnings(warnings);
       },
@@ -87,6 +90,7 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
   const isMultistep = lastStepIndex > 0;
   const steps = React.Children.map(children, (child: WizardChildren) => {
     const isLoading = wizardStepData[child.type.name]?.isLoading || false;
+    const hasError = wizardStepData[child.type.name]?.hasError;
     return (
       <>
         <DataLayoutContext.Provider value={dataLayoutManager}>
@@ -97,7 +101,7 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
           </WizardContext.Provider>
         </DataLayoutContext.Provider>
         <Grid container justify="center">
-          {state.activeStep === lastStepIndex && !isLoading && isMultistep && (
+          {((state.activeStep === lastStepIndex && !isLoading && isMultistep) || hasError) && (
             <ButtonGroup>
               <Button text="Start Over" onClick={() => dispatch(WizardAction.RESET)} />
             </ButtonGroup>
@@ -124,8 +128,9 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
         <Grid item>
           <Stepper activeStep={state.activeStep}>
             {React.Children.map(children, (child: WizardChildren) => {
-              const hasError = (wizardStepData[child.type.name]?.errors?.length || 0) !== 0;
-              return <Step key={child.props.name} label={child.props.name} error={hasError} />;
+              const { name } = child.props;
+              const hasError = wizardStepData[child.type.name]?.hasError;
+              return <Step key={name} label={name} error={hasError} />;
             })}
           </Stepper>
           <Paper elevation={0}>{steps[state.activeStep]}</Paper>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Propagate errors from step to wizard in order to correctly display error icon on the stepper and to display a reset button.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![wizardsteperror](https://user-images.githubusercontent.com/1004789/103379425-79929280-4a9a-11eb-8f95-aba4668befd1.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual