### PR TITLE
ui v2: restrict tab panel width to 100%

### DIFF
--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "@emotion/styled";
 import type { TabProps as MuiTabProps, TabsProps as MuiTabsProps } from "@material-ui/core";
 import { Tab as MuiTab } from "@material-ui/core";
-import { TabContext, TabList, TabPanel } from "@material-ui/lab";
+import { TabContext, TabList, TabPanel as MuiTabPanel } from "@material-ui/lab";
 
 const StyledTab = styled(MuiTab)({
   minWidth: "111px",
@@ -60,6 +60,10 @@ export const Tab = ({ onClick, ...props }: TabProps) => {
   };
   return <StyledTab color="primary" onClick={onClickMiddleware} {...tabProps} />;
 };
+
+const TabPanel = styled(MuiTabPanel)({
+  maxWidth: "100%",
+});
 
 export interface TabsProps extends Pick<MuiTabsProps, "value"> {
   children: React.ReactElement<TabProps> | React.ReactElement<TabProps>[];


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Restrict TabPanel width to 100% of its parent. This prevents tab panel content from growing beyond the parent and overflowing.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
