### PR TITLE
ui v2: alert message should be 100% width

### DIFF
--- a/frontend/packages/core/src/Feedback/alert.tsx
+++ b/frontend/packages/core/src/Feedback/alert.tsx
@@ -27,6 +27,7 @@ const StyledAlert = styled(MuiAlert)(
       padding: "0",
     },
     ".MuiAlert-message": {
+      width: "100%",
       padding: "0",
       ".MuiAlertTitle-root": {
         marginBottom: "0",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Ensure alert message uses 100% of the available width.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
