### PR TITLE
ui v2: remove input styling from webkit autofill

### DIFF
--- a/frontend/packages/app/src/index.css
+++ b/frontend/packages/app/src/index.css
@@ -7,3 +7,14 @@ html, body, #root, #App {
 #App {
   background-color: #f9fafe;
 }
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  font-size: 16px;
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+  transition: background-color 5000s ease-in-out 0s;
+  -webkit-text-fill-color: #0D1030 !important;
+}

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -42,6 +42,7 @@ const StyledTextField = styled(BaseTextField)({
     border: "1px solid rgba(13, 16, 48, 0.38)",
     borderRadius: "4px",
     fontSize: "16px",
+    color: "#0D1030"
   },
 
   "label + .MuiInput-formControl": {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Define css applied to inputs when autofill occurs.

This also updates the TextField input color to match the figma designs

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![autofill](https://user-images.githubusercontent.com/1004789/103445772-51876880-4c2d-11eb-8c0a-0d7af794d801.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
