### PR TITLE
ui v2: add key to Resolver hydrator select element

### DIFF
--- a/frontend/packages/core/src/Resolver/hydrator.tsx
+++ b/frontend/packages/core/src/Resolver/hydrator.tsx
@@ -86,6 +86,7 @@ const OptionField = (
 
   return (
     <Select
+      key={field.metadata.displayName}
       label={field.metadata.displayName}
       onChange={updateSelectedOption}
       name={field.name}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes warning in console where the resolver hydrator maps elements and select is missing a key

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
locally
