### PR TITLE
ui V2: add note panel, split metadata

### DIFF
--- a/frontend/workflows/ec2/src/reboot-instance.tsx
+++ b/frontend/workflows/ec2/src/reboot-instance.tsx
@@ -88,7 +88,7 @@ const RebootInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes 
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
-      <InstanceDetails name="Modify" />
+      <InstanceDetails name="Verify" />
       <Confirm name="Confirmation" notes={notes} />
     </Wizard>
   );

--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -5,6 +5,7 @@ import {
   client,
   Confirmation,
   MetadataTable,
+  NotePanel,
   Resolver,
   useWizardContext,
 } from "@clutch-sh/core";
@@ -78,11 +79,10 @@ const GroupDetails: React.FC<WizardChild> = () => {
 const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const group = useDataLayout("groupData").displayValue();
   const resizeData = useDataLayout("resizeData");
-  const formattedNotes = notes?.map(note => <div>{note.text}</div>);
 
   return (
     <WizardStep error={resizeData.error} isLoading={resizeData.isLoading}>
-      <Confirmation action="Resize">{notes && formattedNotes}</Confirmation>
+      <Confirmation action="Resize" />
       <MetadataTable
         data={[
           { name: "Name", value: group.name },
@@ -91,11 +91,12 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
           { name: "New Desired Size", value: group.size.desired },
         ]}
       />
+      <NotePanel notes={notes} />
     </WizardStep>
   );
 };
 
-const ResizeAutoscalingGroup: React.FC<WorkflowProps> = ({ heading, resolverType, notes }) => {
+const ResizeAutoscalingGroup: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     groupData: {},
     resizeData: {

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -7,6 +7,7 @@ import {
   client,
   Confirmation,
   MetadataTable,
+  NotePanel,
   Resolver,
   useWizardContext,
 } from "@clutch-sh/core";
@@ -72,7 +73,6 @@ const InstanceDetails: React.FC<WizardChild> = () => {
 const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const terminationData = useDataLayout("terminationData");
   const instance = useDataLayout("resourceData").displayValue();
-  const formattedNotes = notes?.map(note => <div>{note.text}</div>);
 
   const data = [
     { name: "Instance ID", value: instance.instanceId },
@@ -81,13 +81,14 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
 
   return (
     <WizardStep error={terminationData.error} isLoading={terminationData.isLoading}>
-      <Confirmation action="Termination">{notes && formattedNotes}</Confirmation>
+      <Confirmation action="Termination" />
       <MetadataTable data={data} />
+      <NotePanel notes={notes} />
     </WizardStep>
   );
 };
 
-const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes }) => {
+const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     resourceData: {},
     terminationData: {
@@ -104,7 +105,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, not
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
-      <InstanceDetails name="Modify" />
+      <InstanceDetails name="Verify" />
       <Confirm name="Confirmation" notes={notes} />
     </Wizard>
   );

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -101,7 +101,7 @@ const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <PodIdentifier name="Lookup" resolverType={resolverType} />
-      <PodDetails name="Modify" />
+      <PodDetails name="Verify" />
       <Confirm name="Confirmation" />
     </Wizard>
   );

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -8,6 +8,7 @@ import {
   client,
   Confirmation,
   MetadataTable,
+  NotePanel,
   Resolver,
   useWizardContext,
 } from "@clutch-sh/core";
@@ -42,17 +43,18 @@ const HPADetails: React.FC<WizardChild> = () => {
     hpaData.updateData(key, value);
   };
 
-  const metadata = [];
+  const metadataAnnotations = [];
+  const metadataLabels = [];
 
   if (hpa.annotations) {
     _.forEach(hpa.annotations, (annotation, key) => {
-      metadata.push({ name: key, value: annotation });
+      metadataAnnotations.push({ name: key, value: annotation });
     });
   }
 
   if (hpa.labels) {
     _.forEach(hpa.labels, (label, key) => {
-      metadata.push({ name: key, value: label });
+      metadataLabels.push({ name: key, value: label });
     });
   }
 
@@ -82,10 +84,17 @@ const HPADetails: React.FC<WizardChild> = () => {
           { name: "Cluster", value: hpa.cluster },
         ]}
       />
-      {metadata.length > 0 && (
-        <Accordion title="Metadata">
+      {metadataAnnotations.length > 0 && (
+        <Accordion title="Annotations">
           <AccordionDetails>
-            <MetadataTable data={metadata} />
+            <MetadataTable data={metadataAnnotations} />
+          </AccordionDetails>
+        </Accordion>
+      )}
+      {metadataLabels.length > 0 && (
+        <Accordion title="Labels">
+          <AccordionDetails>
+            <MetadataTable data={metadataLabels} />
           </AccordionDetails>
         </Accordion>
       )}
@@ -101,11 +110,10 @@ const HPADetails: React.FC<WizardChild> = () => {
 const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const hpa = useDataLayout("hpaData").displayValue() as IClutch.k8s.v1.HPA;
   const resizeData = useDataLayout("resizeData");
-  const formattedNotes = notes?.map(note => <div>{note.text}</div>);
 
   return (
     <WizardStep error={resizeData.error} isLoading={resizeData.isLoading}>
-      <Confirmation action="Resize">{notes && formattedNotes}</Confirmation>
+      <Confirmation action="Resize" />
       <MetadataTable
         data={[
           { name: "Name", value: hpa.name },
@@ -115,11 +123,12 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
           { name: "New Max Size", value: hpa.sizing.maxReplicas },
         ]}
       />
+      <NotePanel notes={notes} />
     </WizardStep>
   );
 };
 
-const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes }) => {
+const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     hpaData: {},
     inputData: {},


### PR DESCRIPTION
### Description

Addresses bug bash action items:
* adds note panels to workflows that had the notes as plain text
* splits up the annotations and labels into their own accordions
* updates stepper titles

<img width="500" alt="Screen Shot 2021-01-05 at 11 10 00 PM" src="https://user-images.githubusercontent.com/39421794/103728145-2b562580-4fab-11eb-80e4-6de290015138.png">

<img width="500" alt="Screen Shot 2021-01-05 at 11 08 11 PM" src="https://user-images.githubusercontent.com/39421794/103728072-ef22c500-4faa-11eb-999f-811fa37110d1.png">

### Testing Performed
Locally