### PR TITLE
ui v2: change textfield icon button color

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -51,12 +51,6 @@ const StyledTextField = styled(BaseTextField)({
 
   ".MuiInputBase-root.Mui-focused": {
     borderColor: "#3548d4",
-    ".MuiButtonBase-root": {
-      backgroundColor: "#3548D4",
-      "*": {
-        color: "#FFFFFF",
-      },
-    },
   },
 
   ".MuiInputBase-root.Mui-disabled": {
@@ -99,20 +93,15 @@ const StyledTextField = styled(BaseTextField)({
 
 const IconButton = styled(MuiIconButton)({
   borderRadius: "0",
-  backgroundColor: "#E7E7EA",
+  backgroundColor: "#3548D4",
+  color: "#FFFFFF",
   borderBottomRightRadius: "3px",
   borderTopRightRadius: "3px",
   "&:hover": {
     backgroundColor: "#2D3DB4",
-    "*": {
-      color: "#FFFFFF",
-    },
   },
   "&:active": {
     backgroundColor: "#2938A5",
-    "*": {
-      color: "#FFFFFF",
-    },
   },
 });
 


### PR DESCRIPTION
### Description
Address bug bash action item
* updates the text field icon button to be blue

<img width="500" alt="Screen Shot 2021-01-05 at 11 51 35 PM" src="https://user-images.githubusercontent.com/39421794/103730492-ffd63980-4fb0-11eb-8590-fb15371f121b.png">

### Testing Performed
Locally