### PR TITLE
K8s: add a k8s service resource to kind script

### DIFF
--- a/tools/kind.sh
+++ b/tools/kind.sh
@@ -61,6 +61,7 @@ seed() {
     # Creating resources in `envoy-*` namespace
     KUBECONFIG=$KUBECONFIG kubectl create deployment envoy --image envoyproxy/envoy:v1.14-latest -n "envoy-${env}" || true
     KUBECONFIG=$KUBECONFIG kubectl autoscale deployment envoy --cpu-percent=50 --min=1 --max=2 -n "envoy-${env}" || true
+    KUBECONFIG=$KUBECONFIG kubectl expose deployment envoy --port=8080 -n "envoy-${env}" || true
   done
 }
 


### PR DESCRIPTION

### Description
This PR adds a service resource in the kind script to enable local dev testing with service objects



### Testing Performed
Local Testing:

```
Creating fake resources in clutch-local k8s cluster

Error from server (AlreadyExists): namespaces "envoy-staging" already exists
Error from server (AlreadyExists): deployments.apps "envoy" already exists
Error from server (AlreadyExists): horizontalpodautoscalers.autoscaling "envoy" already exists
service/envoy exposed
Error from server (AlreadyExists): namespaces "envoy-production" already exists
Error from server (AlreadyExists): deployments.apps "envoy" already exists
Error from server (AlreadyExists): horizontalpodautoscalers.autoscaling "envoy" already exists
service/envoy exposed
```