### PR TITLE
resolver: use common response object

### DIFF
--- a/backend/module/resolver/resolver.go
+++ b/backend/module/resolver/resolver.go
@@ -50,6 +50,7 @@ type resolverAPI struct{}
 func newResponse() *response {
 	return &response{
 		Results: []*any.Any{},
+		PartialFailures: []*statuspb.Status{},
 	}
 }
 

--- a/backend/module/resolver/resolver.go
+++ b/backend/module/resolver/resolver.go
@@ -7,14 +7,12 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
-	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -46,68 +44,6 @@ func newAPI() resolverv1.ResolverAPIServer {
 }
 
 type resolverAPI struct{}
-
-func newResponse() *response {
-	return &response{
-		Results:         []*any.Any{},
-		PartialFailures: []*statuspb.Status{},
-	}
-}
-
-// Generic object to handle common operations for SearchResponse and ResolveResponse.
-type response struct {
-	Results         []*any.Any
-	PartialFailures []*statuspb.Status
-}
-
-// Get rid of any extraneous results or partial failures based on the limit provided in the request.
-func (r *response) truncate(limit uint32) {
-	if limit == 0 {
-		return
-	}
-
-	if len(r.Results) > int(limit) {
-		// Truncate in case it wasn't done earlier.
-		r.Results = r.Results[:limit]
-	}
-
-	if len(r.Results) == int(limit) {
-		// If we fulfilled our limit then errors are not relevant.
-		r.PartialFailures = nil
-	}
-}
-
-func (r *response) marshalResults(results *resolver.Results) error {
-	for _, result := range results.Messages {
-		asAny, err := ptypes.MarshalAny(result)
-		if err != nil {
-			return err
-		}
-		r.Results = append(r.Results, asAny)
-	}
-
-	for _, failure := range results.PartialFailures {
-		r.PartialFailures = append(r.PartialFailures, failure.Proto())
-	}
-
-	return nil
-}
-
-func (r *response) isError(wanted string, searchedSchemas []string) error {
-	if len(r.Results) > 0 {
-		return nil
-	}
-
-	msg := fmt.Sprintf("Did not find a '%s', looked by: %s", wanted, strings.Join(searchedSchemas, ", "))
-
-	if len(r.PartialFailures) > 0 {
-		s := status.New(codes.FailedPrecondition, msg)
-		s, _ = s.WithDetails(resolver.MessageSlice(r.PartialFailures)...)
-		return s.Err()
-	}
-
-	return status.Error(codes.NotFound, msg)
-}
 
 func (r *resolverAPI) Resolve(ctx context.Context, req *resolverv1.ResolveRequest) (*resolverv1.ResolveResponse, error) {
 	resp := newResponse()

--- a/backend/module/resolver/resolver.go
+++ b/backend/module/resolver/resolver.go
@@ -49,7 +49,7 @@ type resolverAPI struct{}
 
 func newResponse() *response {
 	return &response{
-		Results: []*any.Any{},
+		Results:         []*any.Any{},
 		PartialFailures: []*statuspb.Status{},
 	}
 }

--- a/backend/module/resolver/response.go
+++ b/backend/module/resolver/response.go
@@ -1,0 +1,76 @@
+package resolver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/lyft/clutch/backend/resolver"
+)
+
+func newResponse() *response {
+	return &response{
+		Results:         []*any.Any{},
+		PartialFailures: []*statuspb.Status{},
+	}
+}
+
+// Generic object to handle common operations for SearchResponse and ResolveResponse.
+type response struct {
+	Results         []*any.Any
+	PartialFailures []*statuspb.Status
+}
+
+// Get rid of any extraneous results or partial failures based on the limit provided in the request.
+func (r *response) truncate(limit uint32) {
+	if limit == 0 {
+		return
+	}
+
+	if len(r.Results) > int(limit) {
+		// Truncate in case it wasn't done earlier.
+		r.Results = r.Results[:limit]
+	}
+
+	if len(r.Results) == int(limit) {
+		// If we fulfilled our limit then errors are not relevant.
+		r.PartialFailures = nil
+	}
+}
+
+func (r *response) marshalResults(results *resolver.Results) error {
+	for _, result := range results.Messages {
+		asAny, err := ptypes.MarshalAny(result)
+		if err != nil {
+			return err
+		}
+		r.Results = append(r.Results, asAny)
+	}
+
+	for _, failure := range results.PartialFailures {
+		r.PartialFailures = append(r.PartialFailures, failure.Proto())
+	}
+
+	return nil
+}
+
+func (r *response) isError(wanted string, searchedSchemas []string) error {
+	if len(r.Results) > 0 {
+		return nil
+	}
+
+	msg := fmt.Sprintf("Did not find a '%s', looked by: %s", wanted, strings.Join(searchedSchemas, ", "))
+
+	if len(r.PartialFailures) > 0 {
+		s := status.New(codes.FailedPrecondition, msg)
+		s, _ = s.WithDetails(resolver.MessageSlice(r.PartialFailures)...)
+		return s.Err()
+	}
+
+	return status.Error(codes.NotFound, msg)
+}

--- a/backend/module/resolver/response_test.go
+++ b/backend/module/resolver/response_test.go
@@ -1,0 +1,7 @@
+package resolver
+
+func TestTruncate() {
+	resp := newResponse()
+
+	protojson.
+}

--- a/backend/module/resolver/response_test.go
+++ b/backend/module/resolver/response_test.go
@@ -1,7 +1,100 @@
 package resolver
 
-func TestTruncate() {
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	healthcheckv1 "github.com/lyft/clutch/backend/api/healthcheck/v1"
+	"github.com/lyft/clutch/backend/resolver"
+)
+
+// Simple truncate tests with 0 or 1 or 2 objects.
+func TestTruncateSimple(t *testing.T) {
+	resp := newResponse()
+	resp.truncate(0)
+	assert.Len(t, resp.Results, 0)
+	assert.Len(t, resp.PartialFailures, 0)
+
+	resp.truncate(1)
+	assert.Len(t, resp.Results, 0)
+	assert.Len(t, resp.PartialFailures, 0)
+
+	resp.Results = []*anypb.Any{{}}
+	resp.truncate(0)
+	assert.Len(t, resp.Results, 1)
+
+	resp.truncate(1)
+	assert.Len(t, resp.Results, 1)
+
+	resp.truncate(2)
+	assert.Len(t, resp.Results, 1)
+
+	resp.Results = []*anypb.Any{{}, {}}
+	resp.truncate(1)
+	assert.Len(t, resp.Results, 1)
+}
+
+func TestTruncateLimitMetRemovesFailures(t *testing.T) {
+	resp := newResponse()
+	resp.Results = []*anypb.Any{{}, {}}
+	resp.PartialFailures = []*statuspb.Status{{}, {}, {}}
+
+	resp.truncate(2)
+	assert.Len(t, resp.PartialFailures, 0)
+}
+
+func TestMarshalResults(t *testing.T) {
+	resp := newResponse()
+	err := resp.marshalResults(&resolver.Results{
+		Messages:        []proto.Message{&healthcheckv1.HealthcheckRequest{}, &healthcheckv1.HealthcheckResponse{}},
+		PartialFailures: []*status.Status{status.New(codes.Aborted, ""), status.New(codes.DataLoss, "")},
+	})
+
+	assert.NoError(t, err)
+
+	assert.Len(t, resp.Results, 2)
+	assert.Equal(t, resp.Results[0].TypeUrl, "type.googleapis.com/clutch.healthcheck.v1.HealthcheckRequest")
+	assert.Equal(t, resp.Results[1].TypeUrl, "type.googleapis.com/clutch.healthcheck.v1.HealthcheckResponse")
+
+	assert.Len(t, resp.PartialFailures, 2)
+	assert.EqualValues(t, resp.PartialFailures[0].Code, codes.Aborted)
+	assert.EqualValues(t, resp.PartialFailures[1].Code, codes.DataLoss)
+}
+
+func TestIsError(t *testing.T) {
+	wanted := "type.googleapis.com/clutch.foo"
+	schemas := []string{"foo", "bar"}
+
 	resp := newResponse()
 
-	protojson.
+	// No results, no failures = NotFound.
+	{
+		err := resp.isError(wanted, schemas)
+		assert.Error(t, err)
+		s, _ := status.FromError(err)
+		assert.Equal(t, codes.NotFound, s.Code())
+	}
+
+	// No results, some failures = FailedPrecondition.
+	{
+		resp.PartialFailures = append(resp.PartialFailures, status.New(codes.DataLoss, "").Proto())
+		err := resp.isError(wanted, schemas)
+		assert.Error(t, err)
+		s, _ := status.FromError(err)
+		assert.Equal(t, codes.FailedPrecondition, s.Code())
+	}
+
+	// Some results, no failures = OK.
+	{
+		resp.Results = append(resp.Results, &anypb.Any{})
+		resp.PartialFailures = nil
+		err := resp.isError(wanted, schemas)
+		assert.NoError(t, err)
+	}
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Create a common response object so we get common error handling, truncation of extra results, etc.

Before there was a bug where Search properly removed partial failures with a limit met but Resolve did not.

Moving the code to a common object will ensure both calls are handled the same way.

### Testing Performed
Unit, manual.

### TODOs
- [x] Unit tests