### PR TITLE
ui v2: text field white background

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -42,7 +42,8 @@ const StyledTextField = styled(BaseTextField)({
     border: "1px solid rgba(13, 16, 48, 0.38)",
     borderRadius: "4px",
     fontSize: "16px",
-    color: "#0D1030"
+    color: "#0D1030",
+    backgroundColor: "#FFFFFF",
   },
 
   "label + .MuiInput-formControl": {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Change background color of text fields to be white instead of transparent.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Local
