### PR TITLE
ui v2: metadata input validation bug

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -76,12 +76,19 @@ const TableCell = styled(MuiTableCell)({
 });
 
 const Grid = styled(MuiGrid)({
+  display: "flex",
   ".MuiFormControl-root": {
-    height: "40px",
-    width: "100px",
     flexDirection: "row",
   },
-  ".textfield-disabled .MuiFormControl-root": {
+  ".MuiFormControl-root .MuiInputBase-root": {
+    height: "40px",
+    width: "100px",
+    alignSelf: "center",
+  },
+  ".MuiFormControl-root .MuiFormHelperText-root.Mui-error": {
+    flex: 1,
+  },
+  ".textfield-disabled .MuiFormControl-root .MuiInputBase-root": {
     width: "41px",
   },
   ".textfield-disabled .MuiInput-input": {
@@ -136,7 +143,7 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
     <TableRow key={data.id}>
       <KeyCell data={data} />
       <TableCell>
-        <Grid container alignItems="center" wrap="nowrap" spacing={2}>
+        <Grid spacing={2} alignItems="center">
           <div className="textfield-disabled">
             <TextField disabled id={data.id} name={data.name} defaultValue={data.value} />
           </div>


### PR DESCRIPTION
### Description
Address bug bash item:
* text field validations in the metadata table were not rendering correctly

before
<img width="500" alt="Screen Shot 2021-01-06 at 4 50 34 PM" src="https://user-images.githubusercontent.com/39421794/103823035-3f4b6700-503f-11eb-82b0-def1f27d930f.png">

now
<img width="500" alt="Screen Shot 2021-01-06 at 4 50 34 PM" src="https://user-images.githubusercontent.com/39421794/103823089-5c803580-503f-11eb-8432-914ab42e73e7.png">

longer errors
<img width="500" alt="Screen Shot 2021-01-06 at 4 50 43 PM" src="https://user-images.githubusercontent.com/39421794/103823098-61dd8000-503f-11eb-91a5-18a00670de5e.png">

default
<img width="500" alt="Screen Shot 2021-01-06 at 4 58 26 PM" src="https://user-images.githubusercontent.com/39421794/103823644-7a01cf00-5040-11eb-8644-51c7dc5b976f.png">

### Testing Performed
Locally
