### PR TITLE
ui V2: fix accordion overflow

### DIFF
--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -17,6 +17,7 @@ const StyledAccordion = styled(MuiAccordion)({
   boxShadow: "none",
   border: "1px solid transparent",
   boxSizing: "content-box",
+  maxWidth: "100%",
 
   "&.Mui-expanded": {
     boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
@@ -38,7 +39,7 @@ const StyledAccordion = styled(MuiAccordion)({
 
   "&:before": {
     display: "none",
-  }
+  },
 });
 
 const AccordionSummaryBase = ({ children, collapsible, expanded, ...props }) => {

--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -18,6 +18,7 @@ const StyledAccordion = styled(MuiAccordion)({
   border: "1px solid transparent",
   boxSizing: "content-box",
   maxWidth: "100%",
+  overflowWrap: "anywhere",
 
   "&.Mui-expanded": {
     boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",


### PR DESCRIPTION
### Description
Fixes issue when accordion overflows its parent container, which happens when there are long strings of text that do not have an acceptable break (ie space, hyphen).

before
<img width="500" alt="Screen Shot 2021-01-07 at 4 58 06 PM" src="https://user-images.githubusercontent.com/39421794/103950095-48edd100-510a-11eb-8bb9-ca29f3b4ad82.png">

<img width="500" alt="Screen Shot 2021-01-07 at 4 58 30 PM" src="https://user-images.githubusercontent.com/39421794/103950123-5905b080-510a-11eb-891c-598c6e03d6e7.png">

now
<img width="600" alt="Screen Shot 2021-01-07 at 4 59 08 PM" src="https://user-images.githubusercontent.com/39421794/103950167-6c188080-510a-11eb-9ebf-2f74ffbd9fe4.png">




<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
Locally and checked stories to make sure it didn't break other functionality/designs