### PR TITLE
ui v2: use new alert for note panel and fix layout max width

### DIFF
--- a/frontend/packages/core/src/Feedback/alert.tsx
+++ b/frontend/packages/core/src/Feedback/alert.tsx
@@ -22,11 +22,13 @@ const StyledAlert = styled(MuiAlert)(
     paddingBottom: "20px",
     color: "rgba(13, 16, 48, 0.6)",
     fontSize: "14px",
+    overflow: "auto",
     ".MuiAlert-icon": {
       marginRight: "16px",
       padding: "0",
     },
     ".MuiAlert-message": {
+      maxWidth: "calc(100% - 40px)",
       width: "100%",
       padding: "0",
       ".MuiAlertTitle-root": {

--- a/frontend/packages/core/src/Feedback/note.tsx
+++ b/frontend/packages/core/src/Feedback/note.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import styled from "@emotion/styled";
 import { Grid, Paper } from "@material-ui/core";
 import type { Color } from "@material-ui/lab/Alert";
-import MuiAlert from "@material-ui/lab/Alert";
 
-const Alert = styled(MuiAlert)({
-  alignItems: "center",
+import { Alert } from "./alert"
+
+const NotePanelContainer = styled(Grid)({
+  "> *": {
+    padding: "4px 0",
+  }
 });
 
 export interface NoteProps {
@@ -34,14 +37,14 @@ const Note: React.FC<NoteProps> = ({ severity = "info", children }) => {
 };
 
 const NotePanel: React.FC<NotePanelProps> = ({ direction = "column", notes, children }) => (
-  <Grid container direction={direction} justify="center" alignContent="space-between" wrap="nowrap">
+  <NotePanelContainer container direction={direction} justify="center" alignContent="space-between" wrap="nowrap">
     {notes?.map((note: NoteConfig) => (
       <Note key={note.text} severity={note.severity}>
         {note.text}
       </Note>
     ))}
     {children}
-  </Grid>
+  </NotePanelContainer>
 );
 
 export { Note, NotePanel };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Update Note and NotePanel to use new alert component. Fix max width of alerts and overflow.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-01-07 at 12 03 35 PM](https://user-images.githubusercontent.com/1004789/103939437-9e14ed00-50e0-11eb-9014-eddf8a5f7cef.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
