### PR TITLE
ui v2: validate max sizes are greater than min in resize workflows

### DIFF
--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -12,7 +12,7 @@ import {
 import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
-import { number } from "yup";
+import { number, ref } from "yup";
 
 import type { ConfirmChild, ResolverChild, WorkflowProps } from ".";
 
@@ -57,12 +57,20 @@ const GroupDetails: React.FC<WizardChild> = () => {
           {
             name: "Max Size",
             value: group.size.max,
-            input: { type: "number", key: "size.max" },
+            input: {
+              type: "number",
+              key: "size.max",
+              validation: number().integer().moreThan(ref("Min Size"))
+            },
           },
           {
             name: "Desired Size",
             value: group.size.desired,
-            input: { type: "number", key: "size.desired" },
+            input: {
+              type: "number",
+              key: "size.desired",
+              validation: number().integer().moreThan(ref("Min Size")),
+            },
           },
           { name: "Availability Zone", value: group.zones },
         ]}

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -16,7 +16,7 @@ import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
 import _ from "lodash";
-import * as yup from "yup";
+import { number, ref } from "yup";
 
 import type { ConfirmChild, ResolverChild, WorkflowProps } from ".";
 
@@ -73,13 +73,17 @@ const HPADetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "sizing.minReplicas",
-              validation: yup.number().integer().moreThan(0),
+              validation: number().integer().moreThan(0),
             },
           },
           {
             name: "Max Size",
             value: hpa.sizing.maxReplicas,
-            input: { type: "number", key: "sizing.maxReplicas" },
+            input: {
+              type: "number",
+              key: "sizing.maxReplicas",
+              validation: number().integer().moreThan(ref("Min Size")),
+            },
           },
           { name: "Cluster", value: hpa.cluster },
         ]}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
add validation to resize workflows such that the max value does not go below the min value

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
