### PR TITLE
ui v2: fix capitalization on cards

### DIFF
--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -42,7 +42,6 @@ const StyledLandingCard = styled(Card)({
   "& .header": {
     display: "inline-flex",
     marginBottom: "16px",
-    textTransform: "uppercase",
     fontWeight: "bold",
     fontSize: "12px",
     lineHeight: "36px",


### PR DESCRIPTION
### Description
Removes uppercasing of card headers to match the sidebar grouping titles
* addresses K8S -> K8s bug bash item

<img width="1808" alt="Screen Shot 2021-01-07 at 5 36 02 PM" src="https://user-images.githubusercontent.com/39421794/103952714-dc290580-510e-11eb-9ebf-1802a35a5879.png">

### Testing Performed
Locally