### PR TITLE
ui v2: reduce button group margin

### DIFF
--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -100,11 +100,11 @@ const ButtonGroupContainer = styled(Grid)(
   props =>
     props["data-border"] === "bottom"
       ? {
-          marginBottom: "24px",
+          marginBottom: "12px",
           borderBottom: "1px solid #E7E7EA",
         }
       : {
-          marginTop: "24px",
+          marginTop: "12px",
           borderTop: "1px solid #E7E7EA",
         }
 );

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -94,7 +94,7 @@ const Button: React.FC<ButtonProps> = ({ text, variant = "primary", ...props }) 
 const ButtonGroupContainer = styled(Grid)(
   {
     "> *": {
-      margin: "8px",
+      margin: "12px 8px",
     },
   },
   props =>
@@ -102,10 +102,12 @@ const ButtonGroupContainer = styled(Grid)(
       ? {
           marginBottom: "12px",
           borderBottom: "1px solid #E7E7EA",
+          marginTop: "0",
         }
       : {
           marginTop: "12px",
           borderTop: "1px solid #E7E7EA",
+          marginBottom: "0",
         }
 );
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Reduce button group margin

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-01-08 at 10 40 14 AM](https://user-images.githubusercontent.com/1004789/104052104-0c6bb500-519e-11eb-8804-2773d816b7a9.png)
![Screen Shot 2021-01-08 at 10 39 25 AM](https://user-images.githubusercontent.com/1004789/104052114-1097d280-519e-11eb-9d69-dc5c04499e21.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
