### PR TITLE
ui v2: select background should be white

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -79,6 +79,7 @@ const BaseSelect = ({ className, ...props }: MuiSelectProps) => (
 
 const StyledSelect = styled(BaseSelect)({
   padding: "0",
+  backgroundColor: "#FFFFFF",
 
   ".MuiSelect-root": {
     padding: "15px 60px 13px 16px",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Enforce Select background is white.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-01-08 at 1 54 33 PM](https://user-images.githubusercontent.com/1004789/104068041-16e77800-51b9-11eb-9858-32c1330c3a3f.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual 