### PR TITLE
ui v2: warning invoke onClose before exiting

### DIFF
--- a/frontend/packages/core/src/Feedback/warning.tsx
+++ b/frontend/packages/core/src/Feedback/warning.tsx
@@ -26,6 +26,7 @@ const Warning: React.FC<WarningProps> = ({ message, onClose }) => {
     <Snackbar
       open={open}
       autoHideDuration={6000}
+      onExiting={onDismiss}
       onClose={() => setOpen(false)}
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
     >


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
invoke onClose before the snackbar exits. This allows for the wizard to reset warnings after they have been dismissed.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manaul