### PR TITLE
docs: remove duplicate highlight in code snippet

### DIFF
--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -77,7 +77,6 @@ package clutch.amiibo.v1;
 
 option go_package = "amiibov1";
 
-// highlight-next-line
 import "google/api/annotations.proto";
 
 service AmiiboAPI {


### PR DESCRIPTION
### Description
Removing duplicated highlight in docs as outlined in #449 

### Testing Performed
N/A

### GitHub Issue

Fixes #449 
