### PR TITLE
frontend: clean assets before running dev server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "lint:packages:fix": "sort-package-json package.json packages/**/package.json",
     "package": "func() { yarn workspace @clutch-sh/\"$@\"; }; func",
     "publishBeta": "lerna run compile && lerna run publishBeta --no-bail",
-    "start": "yarn compile:watch & FORCE_COLOR=true yarn workspace @clutch-sh/app start | cat",
+    "start": "yarn clean && yarn compile:watch & FORCE_COLOR=true yarn workspace @clutch-sh/app start | cat",
     "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook --no-dll -o netlify/storybook-static",
     "test": "lerna run test --stream --no-bail --",

--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --ext .js,.jsx .",
     "lint:fix": "yarn run lint --fix",
     "register-workflows": "npm explore @clutch-sh/tools -- yarn registerWorkflows $PWD/src",
-    "start": "yarn compile:watch & yarn register-workflows && react-scripts start",
+    "start": "yarn clean && yarn compile:watch & yarn register-workflows && react-scripts start",
     "test": "lerna run test --stream --no-bail",
     "test:coverage": "lerna run test:coverage --stream --no-bail",
     "test:watch": "lerna run test:watch --parallel",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This prevents previously compiled assets from taking precedence when running the frontend dev server.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual