### PR TITLE
resize workflows: fix max number & k8s submission validation

### DIFF
--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -61,7 +61,7 @@ const GroupDetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "size.max",
-              validation: number().integer().moreThan(ref("Min Size")),
+              validation: number().integer().min(ref("Min Size")),
             },
           },
           {
@@ -70,7 +70,7 @@ const GroupDetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "size.desired",
-              validation: number().integer().moreThan(ref("Min Size")),
+              validation: number().integer().min(ref("Min Size")),
             },
           },
           { name: "Availability Zone", value: group.zones },

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -52,7 +52,7 @@ const HPADetails: React.FC<WizardChild> = () => {
         metadataAnnotations.push({ name: key, value: annotation });
       });
     }
-  
+
     if (hpa.labels) {
       _.forEach(hpa.labels, (label, key) => {
         metadataLabels.push({ name: key, value: label });

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -46,17 +46,19 @@ const HPADetails: React.FC<WizardChild> = () => {
   const metadataAnnotations = [];
   const metadataLabels = [];
 
-  if (hpa.annotations) {
-    _.forEach(hpa.annotations, (annotation, key) => {
-      metadataAnnotations.push({ name: key, value: annotation });
-    });
-  }
-
-  if (hpa.labels) {
-    _.forEach(hpa.labels, (label, key) => {
-      metadataLabels.push({ name: key, value: label });
-    });
-  }
+  React.useEffect(() => {
+    if (hpa.annotations) {
+      _.forEach(hpa.annotations, (annotation, key) => {
+        metadataAnnotations.push({ name: key, value: annotation });
+      });
+    }
+  
+    if (hpa.labels) {
+      _.forEach(hpa.labels, (label, key) => {
+        metadataLabels.push({ name: key, value: label });
+      });
+    }
+  }, []);
 
   return (
     <WizardStep error={hpaData.error} isLoading={hpaData.isLoading}>
@@ -83,7 +85,7 @@ const HPADetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "sizing.maxReplicas",
-              validation: number().integer().moreThan(ref("Min Size")),
+              validation: number().integer().min(ref("Min Size")),
             },
           },
           { name: "Cluster", value: hpa.cluster },


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR contains two changes:
- Modify both resize hpa and asg workflows to allow max sizes to equal min
- Fix k8s validation to properly block on errors

### Testing Performed
<!-- Describe how you tested this change below. -->
manual