### PR TITLE
CI: update go version to 1.15.6

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14.4
+          go-version: 1.15.6
       - name: Set up Node
         uses: actions/setup-node@v2-beta
         with:
@@ -36,6 +36,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14.4
+          go-version: 1.15.6
       - name: lint
         run: make api-lint

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.5
+          go-version: 1.15.6
       - run: make backend
   test:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.5
+          go-version: 1.15.6
       - run: make backend-test
       - run: make backend-config-validation
   lint:
@@ -34,6 +34,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.5
+          go-version: 1.15.6
       - run: make backend-lint
       - run: make backend-verify

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14.4
+          go-version: 1.15.5
       - run: make backend
   test:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14.4
+          go-version: 1.15.5
       - run: make backend-test
       - run: make backend-config-validation
   lint:
@@ -34,6 +34,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14.4
+          go-version: 1.15.5
       - run: make backend-lint
       - run: make backend-verify

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -18,7 +18,7 @@ jobs:
           path: ${{ env.PACKAGEPATH }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14.4
+          go-version: 1.15.6
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '14.x'


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Updating CI to use the latest version of go (1.15.6)