### PR TITLE
k8s: add cronjob to kind script

### DIFF
--- a/tools/kind.sh
+++ b/tools/kind.sh
@@ -57,11 +57,13 @@ seed() {
   for env in staging production; do
     # Creating namespaces
     KUBECONFIG=$KUBECONFIG kubectl create ns "envoy-${env}" || true
+    KUBECONFIG=$KUBECONFIG kubectl create ns "cron-${env}" || true
 
     # Creating resources in `envoy-*` namespace
     KUBECONFIG=$KUBECONFIG kubectl create deployment envoy --image envoyproxy/envoy:v1.14-latest -n "envoy-${env}" || true
     KUBECONFIG=$KUBECONFIG kubectl autoscale deployment envoy --cpu-percent=50 --min=1 --max=2 -n "envoy-${env}" || true
     KUBECONFIG=$KUBECONFIG kubectl expose deployment envoy --port=8080 -n "envoy-${env}" || true
+    KUBECONFIG=$KUBECONFIG kubectl create cronjob cron-test --schedule "*/1 * * * *" --image busybox -n "cron-${env}" || true
   done
 }
 


### PR DESCRIPTION
### Description
Add a cronjob resource to the kind script to test newly added cronjob APIs

https://github.com/lyft/clutch/pull/793


### Testing Performed
Local spin up of k8s cluster
```
Creating fake resources in clutch-local k8s cluster

Error from server (AlreadyExists): namespaces "envoy-staging" already exists
namespace/cron-staging created
...
cronjob.batch/cron-test created
namespace/cron-production created
...
cronjob.batch/cron-test created

$ kubectl get all -n cron-staging
NAME                             READY   STATUS      RESTARTS   AGE
pod/cron-test-1610557380-czc2n   0/1     Completed   0          24s

NAME                             COMPLETIONS   DURATION   AGE
job.batch/cron-test-1610557380   1/1           6s         24s

NAME                      SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cronjob.batch/cron-test   */1 * * * *   False     0        33s             73s

$ kubectl get all -n cron-production
NAME                             READY   STATUS      RESTARTS   AGE
pod/cron-test-1610557380-9gwkk   0/1     Completed   0          59s

NAME                             COMPLETIONS   DURATION   AGE
job.batch/cron-test-1610557380   1/1           7s         59s

NAME                      SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cronjob.batch/cron-test   */1 * * * *   False     0        68s             107s
```
