### PR TITLE
frontend: fix resolver schema data race condition

### DIFF
--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -82,7 +82,9 @@ const SchemaResolver = ({ schema, expanded, onClick, submitHandler }: SchemaReso
   });
 
   const onChange = e => {
-    setData(existing => { return { ...existing, [e.target.name]: e.target.value } });
+    setData(existing => {
+      return { ...existing, [e.target.name]: e.target.value };
+    });
   };
 
   return (

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -82,7 +82,7 @@ const SchemaResolver = ({ schema, expanded, onClick, submitHandler }: SchemaReso
   });
 
   const onChange = e => {
-    setData({ ...data, [e.target.name]: e.target.value });
+    setData(existing => { return { ...existing, [e.target.name]: e.target.value } });
   };
 
   return (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix an issue in `SchemaResolver` where initial field values would be overwritten by default data.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual