### PR TITLE
frontend: Fix metadata-table grid props

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -77,6 +77,7 @@ const TableCell = styled(MuiTableCell)({
 
 const Grid = styled(MuiGrid)({
   display: "flex",
+  alignItems: "center",
   ".MuiFormControl-root": {
     flexDirection: "row",
   },
@@ -143,7 +144,7 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
     <TableRow key={data.id}>
       <KeyCell data={data} />
       <TableCell>
-        <Grid spacing={2} alignItems="center">
+        <Grid>
           <div className="textfield-disabled">
             <TextField disabled id={data.id} name={data.name} defaultValue={data.value} />
           </div>


### PR DESCRIPTION
### Description
Resolving these warnings raised. The MutableRow Grid had props that can only be set if the `container` prop was set.
<img width="695" alt="Screen Shot 2021-01-13 at 6 06 51 PM" src="https://user-images.githubusercontent.com/39421794/104521829-aa5ee580-55cb-11eb-9959-f789d55aa278.png">

<img width="695" alt="Screen Shot 2021-01-13 at 6 07 09 PM" src="https://user-images.githubusercontent.com/39421794/104521837-adf26c80-55cb-11eb-9079-cef949eb5e3c.png">


### Testing Performed
Locally