### PR TITLE
middleware: fix timeout race panic

### DIFF
--- a/backend/middleware/timeouts/timeouts.go
+++ b/backend/middleware/timeouts/timeouts.go
@@ -87,7 +87,7 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 		done := make(chan struct{})
 		if timeout != 0 {
 			// If timeout is not infinite, return after timeout plus boost
-			timer := time.AfterFunc(timeout + boost, func() {close(done)})
+			timer := time.AfterFunc(timeout+boost, func() { close(done) })
 			defer timer.Stop()
 		}
 

--- a/backend/middleware/timeouts/timeouts.go
+++ b/backend/middleware/timeouts/timeouts.go
@@ -88,7 +88,7 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 		if timeout != 0 {
 			// If timeout is not infinite, return after timeout plus boost. Boost give the goroutine a chance to return if it's respecting the deadline.
 			timer := time.AfterFunc(timeout+boost, func() { close(done) })
-			defer func() { timer.Stop(); close(done) }()
+			defer timer.Stop() // Channel will still be garbage collected if close never occurs.
 		} else {
 			defer close(done)
 		}

--- a/backend/middleware/timeouts/timeouts.go
+++ b/backend/middleware/timeouts/timeouts.go
@@ -89,6 +89,8 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 			// If timeout is not infinite, return after timeout plus boost
 			timer := time.AfterFunc(timeout+boost, func() { close(done) })
 			defer timer.Stop()
+		} else {
+			defer close(done)
 		}
 
 		// Spawn the handler in a goroutine so we can return early on timeout if it doesn't complete.

--- a/backend/middleware/timeouts/timeouts.go
+++ b/backend/middleware/timeouts/timeouts.go
@@ -75,16 +75,20 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 		resultChan := make(chan unaryHandlerReturn)
 		defer close(resultChan)
 
-		// Create a channel to track when the timeout error has already been returned and the return channel is closed.
-		done := make(chan struct{})
-		defer close(done)
-
 		// Compute timeout and set-up a context with timeout.
 		timeout := m.getDuration(service, method)
 		if timeout != 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, timeout)
 			defer cancel()
+		}
+
+		// Create a channel to track when the timeout error has already been returned and the return channel is closed.
+		done := make(chan struct{})
+		if timeout != 0 {
+			// If timeout is not infinite, return after timeout plus boost
+			timer := time.AfterFunc(timeout + boost, func() {close(done)})
+			defer timer.Stop()
 		}
 
 		// Spawn the handler in a goroutine so we can return early on timeout if it doesn't complete.
@@ -102,19 +106,10 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 			}
 		}()
 
-		// Wait for timeout or handler to send result. The waiting period for timeout is boosted by 50ms to give the
-		// goroutine a chance to return if it's respecting the deadline. If timeout is infinite it will never trigger.
-		var timeoutCh <-chan time.Time
-		if timeout != 0 {
-			timer := time.NewTimer(timeout + boost)
-			defer timer.Stop()
-			timeoutCh = timer.C
-		}
-
 		select {
 		case ret := <-resultChan:
 			return ret.resp, ret.err
-		case <-timeoutCh:
+		case <-done:
 			return nil, status.New(codes.DeadlineExceeded, "timeout exceeded").Err()
 		}
 	}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The race technically still exists and is unavoidable without some really unnecessary synchronization, so I had to boost the timeouts on the test. However **when the race occurs there will no longer be a panic**, instead it will just return the value.

If we make boost configurable we could create a brute force test to try and hit the race to ensure no panic ever occurs as a counter-test for that scenario. But with boost fixed at 50ms it would take too much unnecessary test time to do that.

### Testing Performed
CI + manual `-count 1000` several times