### PR TITLE
frontend: autofocus input element in header search bar

### DIFF
--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -150,6 +150,7 @@ const Input = (params: AutocompleteRenderInputParams): React.ReactNode => {
   return (
     <InputField
       {...params}
+      autoFocus
       placeholder="Search..."
       fullWidth
       inputRef={searchRef}


### PR DESCRIPTION
### Description
A bug bash fix
* PR adds the `autofocus` prop to the textfield component so that it's already focused when the search bar is open.

https://material-ui.com/api/text-field/#textfield-api

### Testing Performed
Locally

![Untitled 10](https://user-images.githubusercontent.com/39421794/104659006-e492ba80-5691-11eb-8a07-71fbe980140b.gif)