### PR TITLE
frontend: allow eslintrc extra import wildcard

### DIFF
--- a/frontend/packages/tools/.eslintrc.js
+++ b/frontend/packages/tools/.eslintrc.js
@@ -96,7 +96,7 @@ module.exports = {
     "import/no-extraneous-dependencies": [
       "error",
       {
-        "devDependencies": ["**/*.config.js", ".eslintrc.js"],
+        "devDependencies": ["**/*.config.js", "**/.eslintrc.js"],
       }
     ],
     "no-console": ["error"],


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Allow nested "extraneous imports" for tools' eslintrc

### Testing Performed
Local, CI.