### PR TITLE
frontend: remove parallel flag from compilations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "build": "yarn compile && yarn workspace @clutch-sh/app build",
     "build:dev": "yarn compile:dev && yarn workspace @clutch-sh/app register-workflows",
     "clean": "lerna run clean --parallel",
-    "compile": "lerna run compile --parallel",
+    "compile": "lerna run compile",
     "compile:dev": "lerna run compile:dev",
     "compile:watch": "lerna run compile:watch --parallel",
     "lint": "lerna run lint --no-bail",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Testing out build times without parallel lerna commands. In theory TSC dependencies need to be built in order anyways so this appears to be a micro-optimization but consumes a large amount of resources. 

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
CI