### PR TITLE
frontend: fix dialog closing behavior

### DIFF
--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -1,17 +1,8 @@
 import React from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Grid,
-  IconButton,
-  Paper as MuiPaper,
-} from "@material-ui/core";
-import CloseIcon from "@material-ui/icons/Close";
+import { Dialog, DialogContent } from "@clutch-sh/core";
+import { Grid, IconButton } from "@material-ui/core";
 import LaunchIcon from "@material-ui/icons/Launch";
 import { Alert } from "@material-ui/lab";
-import styled from "styled-components";
 
 export interface BaseWorkflowProps {
   heading: string;
@@ -55,16 +46,6 @@ export interface ConfiguredRoute extends Route {
   componentProps?: object;
   trending?: boolean;
 }
-
-const RightAlignedButton = styled(IconButton)`
-  float: right;
-`;
-
-const Paper = styled(MuiPaper)`
-  ${({ theme }) => `
-  background-color: ${theme.palette.background.default};
-  `}
-`;
 
 interface ErrorBoundaryProps {
   workflow: Workflow;
@@ -125,25 +106,12 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 
       return (
         <Grid container direction="column" justify="center" alignItems="center">
-          <Dialog
-            open={showDetails}
-            scroll="paper"
-            onClose={this.onDetailsClose}
-            PaperComponent={Paper}
-          >
-            <DialogTitle>
-              <strong>Stack Trace</strong>
-              <RightAlignedButton onClick={this.onDetailsClose}>
-                <CloseIcon />
-              </RightAlignedButton>
-            </DialogTitle>
-            <DialogContent dividers>
-              <DialogContentText color="textPrimary" tabIndex={-1} component="div">
-                {errorInfo.componentStack.split("\n").map((i, key) => {
-                  /* eslint-disable-next-line react/no-array-index-key */
-                  return <div key={key}>{i}</div>;
-                })}
-              </DialogContentText>
+          <Dialog onClose={this.onDetailsClose} open={showDetails} title="Stack Trace">
+            <DialogContent>
+              {errorInfo?.componentStack?.split("\n").map((i, key) => {
+                /* eslint-disable-next-line react/no-array-index-key */
+                return <div key={key}>{i}</div>;
+              })}
             </DialogContent>
           </Dialog>
           <Alert

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { Grid, IconButton } from "@material-ui/core";
 import LaunchIcon from "@material-ui/icons/Launch";
 import { Alert } from "@material-ui/lab";
+
 import { Dialog, DialogContent } from "../dialog";
+
 export interface BaseWorkflowProps {
   heading: string;
 }

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { Dialog, DialogContent } from "@clutch-sh/core";
 import { Grid, IconButton } from "@material-ui/core";
 import LaunchIcon from "@material-ui/icons/Launch";
 import { Alert } from "@material-ui/lab";
-
+import { Dialog, DialogContent } from "../dialog";
 export interface BaseWorkflowProps {
   heading: string;
 }

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -69,7 +69,7 @@ export interface DialogProps extends Pick<MuiDialogProps, "open"> {
 
 const Dialog = ({ title, children, open: isOpenFromProps, onClose }: DialogProps) => {
   const [isOpenFromState, setIsOpen] = React.useState(isOpenFromProps);
-  const onCloseHandlerExists = typeof onClose === "function";
+  const onCloseHandlerExists = !!onClose;
   const closeCallback = () => {
     if (onCloseHandlerExists) {
       onClose();

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -57,7 +57,7 @@ const DialogActions = styled(MuiDialogActions)({
 
 export interface DialogContentProps {}
 export interface DialogActionsProps {}
-export type DialogCloseReasons = "closeButtonClick" | "escapeKeyDown" | "backdropClick"
+export type DialogCloseReasons = "closeButtonClick" | "escapeKeyDown" | "backdropClick";
 export interface DialogProps extends Pick<MuiDialogProps, "open"> {
   title: string;
   children:
@@ -69,11 +69,7 @@ export interface DialogProps extends Pick<MuiDialogProps, "open"> {
 }
 
 const Dialog = ({ title, children, open, onClose }: DialogProps) => (
-  <MuiDialog
-    PaperComponent={DialogPaper}
-    open={open}
-    onClose={onClose}
-  >
+  <MuiDialog PaperComponent={DialogPaper} open={open} onClose={onClose}>
     <DialogTitle disableTypography>
       <DialogTitleText>{title}</DialogTitleText>
       <IconButton onClick={e => onClose(e, "closeButtonClick")}>

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -57,6 +57,7 @@ const DialogActions = styled(MuiDialogActions)({
 
 export interface DialogContentProps {}
 export interface DialogActionsProps {}
+export type DialogCloseReasons = "closeButtonClick" | "escapeKeyDown" | "backdropClick"
 export interface DialogProps extends Pick<MuiDialogProps, "open"> {
   title: string;
   children:
@@ -64,35 +65,23 @@ export interface DialogProps extends Pick<MuiDialogProps, "open"> {
     | React.ReactElement<DialogContentProps>[]
     | React.ReactElement<DialogActionsProps>
     | React.ReactElement<DialogActionsProps>[];
-  onClose?: () => void;
+  onClose: (event?: object, reason?: DialogCloseReasons) => void;
 }
 
-const Dialog = ({ title, children, open: isOpenFromProps, onClose }: DialogProps) => {
-  const [isOpenFromState, setIsOpen] = React.useState(isOpenFromProps);
-  const onCloseHandlerExists = !!onClose;
-  const closeCallback = () => {
-    if (onCloseHandlerExists) {
-      onClose();
-    } else {
-      setIsOpen(prevOpenState => !prevOpenState);
-    }
-  };
-  React.useEffect(() => setIsOpen(isOpenFromProps), [isOpenFromProps]);
-  return (
-    <MuiDialog
-      PaperComponent={DialogPaper}
-      open={onCloseHandlerExists ? isOpenFromProps : isOpenFromState}
-      onClose={closeCallback}
-    >
-      <DialogTitle disableTypography>
-        <DialogTitleText>{title}</DialogTitleText>
-        <IconButton onClick={closeCallback}>
-          <CloseIcon />
-        </IconButton>
-      </DialogTitle>
-      {children}
-    </MuiDialog>
-  );
-};
+const Dialog = ({ title, children, open, onClose }: DialogProps) => (
+  <MuiDialog
+    PaperComponent={DialogPaper}
+    open={open}
+    onClose={onClose}
+  >
+    <DialogTitle disableTypography>
+      <DialogTitleText>{title}</DialogTitleText>
+      <IconButton onClick={e => onClose(e, "closeButtonClick")}>
+        <CloseIcon />
+      </IconButton>
+    </DialogTitle>
+    {children}
+  </MuiDialog>
+);
 
 export { Dialog, DialogActions, DialogContent };

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -69,7 +69,7 @@ export interface DialogProps extends Pick<MuiDialogProps, "open"> {
 
 const Dialog = ({ title, children, open: isOpenFromProps, onClose }: DialogProps) => {
   const [isOpenFromState, setIsOpen] = React.useState(isOpenFromProps);
-  const onCloseHandlerExists = typeof onClose === 'function';
+  const onCloseHandlerExists = typeof onClose === "function";
   const closeCallback = () => {
     if (onCloseHandlerExists) {
       onClose();
@@ -79,7 +79,11 @@ const Dialog = ({ title, children, open: isOpenFromProps, onClose }: DialogProps
   };
   React.useEffect(() => setIsOpen(isOpenFromProps), [isOpenFromProps]);
   return (
-    <MuiDialog PaperComponent={DialogPaper} open={onCloseHandlerExists ? isOpenFromProps : isOpenFromState} onClose={closeCallback}>
+    <MuiDialog
+      PaperComponent={DialogPaper}
+      open={onCloseHandlerExists ? isOpenFromProps : isOpenFromState}
+      onClose={closeCallback}
+    >
       <DialogTitle disableTypography>
         <DialogTitleText>{title}</DialogTitleText>
         <IconButton onClick={closeCallback}>

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -64,19 +64,25 @@ export interface DialogProps extends Pick<MuiDialogProps, "open"> {
     | React.ReactElement<DialogContentProps>[]
     | React.ReactElement<DialogActionsProps>
     | React.ReactElement<DialogActionsProps>[];
+  onClose?: () => void;
 }
 
-const Dialog = ({ title, children, open }: DialogProps) => {
-  const [isOpen, setIsOpen] = React.useState(open);
-  const onClose = () => {
-    setIsOpen(prevOpenState => !prevOpenState);
+const Dialog = ({ title, children, open: isOpenFromProps, onClose }: DialogProps) => {
+  const [isOpenFromState, setIsOpen] = React.useState(isOpenFromProps);
+  const onCloseHandlerExists = typeof onClose === 'function';
+  const closeCallback = () => {
+    if (onCloseHandlerExists) {
+      onClose();
+    } else {
+      setIsOpen(prevOpenState => !prevOpenState);
+    }
   };
-  React.useEffect(() => setIsOpen(open), [open]);
+  React.useEffect(() => setIsOpen(isOpenFromProps), [isOpenFromProps]);
   return (
-    <MuiDialog PaperComponent={DialogPaper} open={isOpen} onClose={onClose}>
+    <MuiDialog PaperComponent={DialogPaper} open={onCloseHandlerExists ? isOpenFromProps : isOpenFromState} onClose={closeCallback}>
       <DialogTitle disableTypography>
         <DialogTitleText>{title}</DialogTitleText>
-        <IconButton onClick={onClose}>
+        <IconButton onClick={closeCallback}>
           <CloseIcon />
         </IconButton>
       </DialogTitle>

--- a/frontend/packages/core/src/stories/dialog.stories.tsx
+++ b/frontend/packages/core/src/stories/dialog.stories.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
@@ -14,7 +14,7 @@ export default {
 
 const Template = ({ content, open, ...props }: DialogProps & { content: React.ReactNode }) => {
   const [isOpen, setIsOpen] = useState(open);
-  
+
   return (
     <>
       <Button disabled={!open} text="Show Dialog" onClick={() => setIsOpen(true)} />

--- a/frontend/packages/core/src/stories/dialog.stories.tsx
+++ b/frontend/packages/core/src/stories/dialog.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
@@ -12,15 +12,22 @@ export default {
   component: Dialog,
 } as Meta;
 
-const Template = ({ content, open, ...props }: DialogProps & { content: React.ReactNode }) => (
-  <Dialog open={open} {...props}>
-    <DialogContent>{content}</DialogContent>
-    <DialogActions>
-      <Button text="Back" variant="neutral" onClick={action("back button click")} />
-      <Button text="Continue" onClick={action("continue button click")} />
-    </DialogActions>
-  </Dialog>
-);
+const Template = ({ content, open, ...props }: DialogProps & { content: React.ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(open);
+  
+  return (
+    <>
+      <Button disabled={!open} text="Show Dialog" onClick={() => setIsOpen(true)} />
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)} {...props}>
+        <DialogContent>{content}</DialogContent>
+        <DialogActions>
+          <Button text="Close" variant="neutral" onClick={() => setIsOpen(false)} />
+          <Button text="Continue" onClick={action("continue button click")} />
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
 
 export const Primary = Template.bind({});
 Primary.args = {

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -332,7 +332,11 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
         hostsPercentageBasedTargetingEnabled={hostsPercentageBasedTargetingEnabled}
         onStart={experimentDetails => setExperimentData(experimentDetails)}
       />
-      <Dialog title="Experiment Start Confirmation" open={experimentData !== undefined}>
+      <Dialog
+        title="Experiment Start Confirmation"
+        open={experimentData !== undefined}
+        onClose={() => setExperimentData(undefined)}
+      >
         <DialogContent>
           Are you sure you want to start an experiment? The experiment will start immediately and
           you will be moved to experiment details view page.

--- a/frontend/workflows/serverexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
+++ b/frontend/workflows/serverexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Start Experiment workflow renders correctly 1`] = `
 "<PageLayout heading=\\"Start Experiment\\" error={[undefined]}>
   <ExperimentDetails upstreamClusterTypeSelectionEnabled={false} hostsPercentageBasedTargetingEnabled={false} onStart={[Function: onStart]} />
-  <Dialog title=\\"Experiment Start Confirmation\\" open={false}>
+  <Dialog title=\\"Experiment Start Confirmation\\" open={false} onClose={[Function: onClose]}>
     <Styled(WithStyles(ForwardRef(DialogContent)))>
       Are you sure you want to start an experiment? The experiment will start immediately and you will be moved to experiment details view page.
     </Styled(WithStyles(ForwardRef(DialogContent)))>
@@ -18,7 +18,7 @@ exports[`Start Experiment workflow renders correctly 1`] = `
 exports[`Start Experiment workflow renders correctly with host percentage based faults and upstream cluster type selecion enabled 1`] = `
 "<PageLayout heading=\\"Start Experiment\\" error={[undefined]}>
   <ExperimentDetails upstreamClusterTypeSelectionEnabled={true} hostsPercentageBasedTargetingEnabled={true} onStart={[Function: onStart]} />
-  <Dialog title=\\"Experiment Start Confirmation\\" open={false}>
+  <Dialog title=\\"Experiment Start Confirmation\\" open={false} onClose={[Function: onClose]}>
     <Styled(WithStyles(ForwardRef(DialogContent)))>
       Are you sure you want to start an experiment? The experiment will start immediately and you will be moved to experiment details view page.
     </Styled(WithStyles(ForwardRef(DialogContent)))>
@@ -33,7 +33,7 @@ exports[`Start Experiment workflow renders correctly with host percentage based 
 exports[`Start Experiment workflow renders correctly with host percentage based faults enabled 1`] = `
 "<PageLayout heading=\\"Start Experiment\\" error={[undefined]}>
   <ExperimentDetails upstreamClusterTypeSelectionEnabled={false} hostsPercentageBasedTargetingEnabled={true} onStart={[Function: onStart]} />
-  <Dialog title=\\"Experiment Start Confirmation\\" open={false}>
+  <Dialog title=\\"Experiment Start Confirmation\\" open={false} onClose={[Function: onClose]}>
     <Styled(WithStyles(ForwardRef(DialogContent)))>
       Are you sure you want to start an experiment? The experiment will start immediately and you will be moved to experiment details view page.
     </Styled(WithStyles(ForwardRef(DialogContent)))>
@@ -48,7 +48,7 @@ exports[`Start Experiment workflow renders correctly with host percentage based 
 exports[`Start Experiment workflow renders correctly with upstream cluster type selection enabled 1`] = `
 "<PageLayout heading=\\"Start Experiment\\" error={[undefined]}>
   <ExperimentDetails upstreamClusterTypeSelectionEnabled={true} hostsPercentageBasedTargetingEnabled={false} onStart={[Function: onStart]} />
-  <Dialog title=\\"Experiment Start Confirmation\\" open={false}>
+  <Dialog title=\\"Experiment Start Confirmation\\" open={false} onClose={[Function: onClose]}>
     <Styled(WithStyles(ForwardRef(DialogContent)))>
       Are you sure you want to start an experiment? The experiment will start immediately and you will be moved to experiment details view page.
     </Styled(WithStyles(ForwardRef(DialogContent)))>


### PR DESCRIPTION
### Description
<!-- Describe your change below. -->
Fix a bug with the  closing behavior of the Dialog frontend component: Closing the modal via ESC, the X button, or clicking the backdrop got the the modal stuck in an OFF state and unable to appear again.

The component now accepts an optional `onClose` callback. This callback can be used to set the `open` prop passed into `Dialog`. If this callback exists, the component will rely on the `open` prop alone to show/hide. Otherwise, the old functionality is preserved where the component will use its own internal `isOpen` state.  Warning: With the latter use case, closing the dialog with the Escape key, clicking on the backdrop, or using the "X" button will cause the modal to be stuck in the off state.

<!-- Reference previous related pull requests below. -->
https://github.com/lyft/clutch/pull/674
https://github.com/lyft/clutch/pull/823


### Testing Performed
Storybook
