### PR TITLE
docs: support image directory

### DIFF
--- a/docs/_website/generator/generate.go
+++ b/docs/_website/generator/generate.go
@@ -148,12 +148,24 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Get all images files to be moved.
+	images, err := getFiles(docsRoot, ".png")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	files = append(files, images...)
+
 	for _, f := range files {
 		relpath, _ := filepath.Rel(docsRoot, f)
 		dest := filepath.Join(destRoot, relpath)
 
 		if strings.Contains(dest, "docs/blog") {
 			dest = strings.Replace(dest, "/docs/blog", "/blog", 1)
+		}
+
+		if strings.Contains(dest, "docs/images") {
+			dest = strings.Replace(dest, "/docs/images", "/images", 1)
 		}
 
 		// Make directory if it doesn't exist.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
While developing a recent blog #924, I wanted to add several images to the blog post. In this PR we simply create a new `images` directory that will be parse by the site generator and moved to the destination directory so these assets my be used by anything on the site.

### Testing Performed
<!-- Describe how you tested this change below. -->

local.