### PR TITLE
db: enhance migrate tooling to allow federated migrations

### DIFF
--- a/backend/cmd/migrate/README.md
+++ b/backend/cmd/migrate/README.md
@@ -34,3 +34,15 @@ If you need to migrate down multiple versions, invoke the tool until you reach t
 cd backend/cmd/migrate
 go run migrate.go -template -down -c path/to/my/clutch-config.yaml
 ```
+
+## Federated Migrations
+
+:warning: **IT IS NOT SAFE TO MODIFY THE SAME TABLES FROM THE FEDERATED MIGRATIONS AND BUILT-IN MODULE MIGRATIONS. IT WILL CORRUPT THE DATABASE.**
+
+If you wish to run migrations for independent tables from federated code, provide the `-namespace` argument and `-migrationDir` argument.
+
+For example, if I had created a scaffolded application in `clutch-custom-gateway/`, I could create migrations for a new module's table in `clutch-custom-gateway/migrations`,
+e.g. `000001_create_my_new_table.up.sql` and `000001_create_my_new_table.down.sql`, and run the migrations using
+```bash
+$ go run migrate.go -c path/to/my/clutch-config.yaml -namespace custom_gateway -migrationDir path/to/clutch-custom-gateway/migrations
+```


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Allows federated migrations, in a different directory, on different schemas. See linked issue for more details.

```
$ go run migrate.go -namespace foo -migrationDir migrations -c ../../../examples/postgres-config/clutch-config.yaml 
2021-01-27T13:53:07.885-0600    INFO    migrate/migrate.go:129  using migration table   {"migrationTable": "schema_migrations_foo"}
2021-01-27T13:53:07.887-0600    INFO    migrate/migrate.go:147  using migration directory       {"migrationDir": "migrations"}
2021-01-27T13:53:07.887-0600    INFO    migrate/migrate.go:97   using database  {"hostInfo": "clutch@localhost:5432"}
2021-01-27T13:53:07.887-0600    WARN    migrate/migrate.go:99   migration has the potential to cause irrevocable data loss, verify information above

*** Continue with migration? [y/N]
```

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #947 