### PR TITLE
docs: add component library links

### DIFF
--- a/docs/_website/docusaurus.config.js
+++ b/docs/_website/docusaurus.config.js
@@ -181,6 +181,10 @@ module.exports = {
               label: 'Backend',
               to: 'docs/components#backend',
             },
+            {
+              label: 'Storybook',
+              to: 'https://storybook.clutch.sh',
+            },
           ],
         },
         {

--- a/docs/_website/src/theme/Navbar/index.js
+++ b/docs/_website/src/theme/Navbar/index.js
@@ -38,11 +38,6 @@ var items = [
     label: 'Community',
   },
   {
-    to: 'https://storybook.clutch.sh',
-    icon: "fe fe-layers",
-    label: 'Storybook',
-  },
-  {
     href: 'https://github.com/lyft/clutch',
     icon: "fe fe-github",
     label: 'GitHub',

--- a/docs/_website/src/theme/Navbar/index.js
+++ b/docs/_website/src/theme/Navbar/index.js
@@ -38,7 +38,7 @@ var items = [
     label: 'Community',
   },
   {
-    to: 'storybook.clutch.sh',
+    to: 'https://storybook.clutch.sh',
     icon: "fe fe-layers",
     label: 'Storybook',
   },

--- a/docs/_website/src/theme/Navbar/index.js
+++ b/docs/_website/src/theme/Navbar/index.js
@@ -38,6 +38,11 @@ var items = [
     label: 'Community',
   },
   {
+    to: 'storybook.clutch.sh',
+    icon: "fe fe-layers",
+    label: 'Storybook',
+  },
+  {
     href: 'https://github.com/lyft/clutch',
     icon: "fe fe-github",
     label: 'GitHub',

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -25,6 +25,8 @@ frontend
 
 The packages within Clutch are separated by functionality, with the intent being that each package provides value to workflows while also not being required.
 
+An interactive playground of our component library is available at [storybook.clutch.sh](https://storybook.clutch.sh).
+
 ### @clutch-sh/core
 
 The Core package consists of various reusable components that are shared between workflows and/or other Clutch packages. This can span from things like the application provider, which renders the Clutch app, and resolver component ([see above](./###Resolver)) to something as simple as a centralized button component.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Adds links to component website in clutch.sh header and on frontend development page.
