### PR TITLE
resolver: remove k8s IP address resolver for Pod

### DIFF
--- a/backend/resolver/k8s/k8s.go
+++ b/backend/resolver/k8s/k8s.go
@@ -36,7 +36,6 @@ var typeURLHPA = meta.TypeURL((*k8sv1api.HPA)(nil))
 var typeSchemas = map[string][]descriptor.Message{
 	typeURLPod: {
 		(*k8sv1resolver.PodID)(nil),
-		(*k8sv1resolver.IPAddress)(nil),
 	},
 	typeURLHPA: {
 		(*k8sv1resolver.HPAName)(nil),


### PR DESCRIPTION

### Description
Remove the IP address resolver for the pod deletion URL

### Testing Performed
Tested locally to ensure the IP address resolver does not show up
