### PR TITLE
ci: add go-sqlmock license

### DIFF
--- a/.github/workflows/license_review.yml
+++ b/.github/workflows/license_review.yml
@@ -8,6 +8,7 @@ on:
       - backend/go.mod
       - backend/go.sum
       - .github/workflows/license_review.yml
+      - tools/license-finder/config/*.yml
 jobs:
   license-check:
     runs-on: ubuntu-latest

--- a/tools/license-finder/config/license_dependency_decisions.yml
+++ b/tools/license-finder/config/license_dependency_decisions.yml
@@ -386,3 +386,10 @@
     :why: 
     :versions: []
     :when: 2021-01-22 00:04:57.253574509 Z
+- - :license
+  - github.com/DATA-DOG/go-sqlmock
+  - BSD-3-Clause
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2021-02-01 00:00:01.412574509 Z


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
License check is failing in PRs.

```
Dependencies that need approval:
github.com/DATA-DOG/go-sqlmock, v1.5.0, unknown
Error: Process completed with exit code 1.
```

### Testing Performed
CI.
