### PR TITLE
tools: increase FD limit on OSX for air

### DIFF
--- a/tools/air.sh
+++ b/tools/air.sh
@@ -36,7 +36,14 @@ ensure_binary() {
   fi
 }
 
+ensure_fd() {
+  if [[ "${OSTYPE}" == *"darwin"* ]]; then
+    ulimit -n 1024
+  fi
+}
+
 cd "${REPO_ROOT}/backend"
 ensure_binary
+ensure_fd
 
 "${RELEASE_BINARY}" 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
```bash
> make backend-dev
tools/air.sh

  __    _   ___  
 / /\  | | | |_) 
/_/--\ |_| |_| \_ 1.15.1 // live reload for Go apps, with Go 1.15.5
.
.
.
.
.
failed to watching lyft/clutch/backend/service/chaos/experimentation/experimentstore, error: too many open files
```

Relates to https://github.com/cosmtrek/air/issues/32 which is due to the underlying issue https://github.com/fsnotify/fsnotify/issues/129

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
locally 
