### PR TITLE
frontend: Add onClick handler to TableRow and Change max-width of Dialog

### DIFF
--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import type { TableProps as MuiTableProps } from "@material-ui/core";
+import type {
+  TableProps as MuiTableProps,
+  TableRowProps as MuiTableRowProps,
+} from "@material-ui/core";
 import {
   Paper,
   Table as MuiTable,
@@ -47,7 +50,7 @@ export const TableContainer = ({ children }: TableContainerProps) => (
   </MuiTableContainer>
 );
 
-export interface TableProps extends Pick<MuiTableProps, "stickyHeader"> {
+export interface TableProps extends Pick<MuiTableProps, "stickyHeader" | "className"> {
   headings?: string[];
 }
 
@@ -74,12 +77,12 @@ export const Table: React.FC<TableProps> = ({ headings, children, ...props }) =>
   );
 };
 
-export interface TableRowProps {
+export interface TableRowProps extends Pick<MuiTableRowProps, "onClick"> {
   children?: React.ReactNode;
 }
 
-export const TableRow = ({ children = [] }: TableRowProps) => (
-  <StyledTableRow>
+export const TableRow = ({ children = [], onClick}: TableRowProps) => (
+  <StyledTableRow onClick={onClick}>
     {React.Children.map(children, (value, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <TableCell key={index}>{value}</TableCell>

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -50,7 +50,7 @@ export const TableContainer = ({ children }: TableContainerProps) => (
   </MuiTableContainer>
 );
 
-export interface TableProps extends Pick<MuiTableProps, "stickyHeader" | "className"> {
+export interface TableProps extends Pick<MuiTableProps, "stickyHeader"> {
   headings?: string[];
 }
 

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -81,7 +81,7 @@ export interface TableRowProps extends Pick<MuiTableRowProps, "onClick"> {
   children?: React.ReactNode;
 }
 
-export const TableRow = ({ children = [], onClick}: TableRowProps) => (
+export const TableRow = ({ children = [], onClick }: TableRowProps) => (
   <StyledTableRow onClick={onClick}>
     {React.Children.map(children, (value, index) => (
       // eslint-disable-next-line react/no-array-index-key

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -58,7 +58,7 @@ const DialogActions = styled(MuiDialogActions)({
 export interface DialogContentProps {}
 export interface DialogActionsProps {}
 export type DialogCloseReasons = "closeButtonClick" | "escapeKeyDown" | "backdropClick";
-export interface DialogProps extends Pick<MuiDialogProps, "open"> {
+export interface DialogProps extends Pick<MuiDialogProps, "open" | "className"> {
   title: string;
   children:
     | React.ReactElement<DialogContentProps>
@@ -68,8 +68,8 @@ export interface DialogProps extends Pick<MuiDialogProps, "open"> {
   onClose: (event?: object, reason?: DialogCloseReasons) => void;
 }
 
-const Dialog = ({ title, children, open, onClose }: DialogProps) => (
-  <MuiDialog PaperComponent={DialogPaper} open={open} onClose={onClose}>
+const Dialog = ({ title, children, className, open, onClose }: DialogProps) => (
+  <MuiDialog className={className} PaperComponent={DialogPaper} open={open} onClose={onClose}>
     <DialogTitle disableTypography>
       <DialogTitleText>{title}</DialogTitleText>
       <IconButton onClick={e => onClose(e, "closeButtonClick")}>

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -60,7 +60,7 @@ const DialogActions = styled(MuiDialogActions)({
 export interface DialogContentProps {}
 export interface DialogActionsProps {}
 export type DialogCloseReasons = "closeButtonClick" | "escapeKeyDown" | "backdropClick";
-export interface DialogProps extends Pick<MuiDialogProps, "open" | "className"> {
+export interface DialogProps extends Pick<MuiDialogProps, "open"> {
   title: string;
   children:
     | React.ReactElement<DialogContentProps>
@@ -70,8 +70,8 @@ export interface DialogProps extends Pick<MuiDialogProps, "open" | "className"> 
   onClose: (event?: object, reason?: DialogCloseReasons) => void;
 }
 
-const Dialog = ({ title, children, className, open, onClose }: DialogProps) => (
-  <MuiDialog className={className} PaperComponent={DialogPaper} open={open} onClose={onClose}>
+const Dialog = ({ title, children, open, onClose }: DialogProps) => (
+  <MuiDialog PaperComponent={DialogPaper} open={open} onClose={onClose}>
     <DialogTitle disableTypography>
       <DialogTitleText>{title}</DialogTitleText>
       <IconButton onClick={e => onClose(e, "closeButtonClick")}>

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -16,6 +16,8 @@ const DialogPaper = styled(Paper)({
   boxShadow: "0px 10px 24px rgba(35, 48, 143, 0.3)",
   boxSizing: "border-box",
   backgroundColor: "#FFFFFF",
+  maxWidth: "fit-content",
+  minWidth: "600px",
 });
 
 const DialogTitle = styled(MuiDialogTitle)({


### PR DESCRIPTION
### Description

- Added onClick handler to TableRow
- Changed max-width of Dialog Paper to fit-content and added min-width: 600px

Needed for some extra flexibility in styling and functionality

<!-- Reference previous related pull requests below. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Locally
