### PR TITLE
frontend: fix drawer title overflow

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -38,8 +38,9 @@ const GroupList = styled(List)({
 
 const GroupListItem = styled(ListItem)({
   flexDirection: "column",
-  height: "82px",
+  minHeight: "82px",
   padding: "16px 8px 16px 8px",
+  height: "fit-content",
   "&:hover": {
     backgroundColor: "#F5F6FD",
   },
@@ -73,6 +74,9 @@ const GroupHeading = styled(Typography)({
   lineHeight: "18px",
   flexGrow: 1,
   paddingTop: "11px",
+  width: "100%",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
 });
 
 const Avatar = styled(MuiAvatar)({
@@ -153,11 +157,6 @@ const Group: React.FC<GroupProps> = ({
   }
   // TODO (dschaller): revisit how we handle long groups once we have designs.
   // n.b. this is a stop-gap solution to prevent long groups from looking unreadable.
-  let formattedHeading = heading;
-  if (heading.length > 11) {
-    formattedHeading = `${heading.substring(0, 10)}...`;
-  }
-
   return (
     <GroupList data-qa="workflowGroup">
       <GroupListItem
@@ -170,8 +169,8 @@ const Group: React.FC<GroupProps> = ({
           updateOpenGroup(heading);
         }}
       >
-        <Avatar>{formattedHeading.charAt(0)}</Avatar>
-        <GroupHeading align="center">{formattedHeading}</GroupHeading>
+        <Avatar>{heading.charAt(0)}</Avatar>
+        <GroupHeading align="center">{heading}</GroupHeading>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <Popper open={open} anchorEl={anchorRef.current} transition placement="right-start">
             <Paper>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Use css to handle overflow of drawer titles and set height to fit the content given we allow wrapping spaces

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-02-03 at 7 26 45 PM](https://user-images.githubusercontent.com/1004789/106840920-f266aa80-6655-11eb-9eca-6eaedf4c0b94.png)
![Screen Shot 2021-02-03 at 7 27 10 PM](https://user-images.githubusercontent.com/1004789/106840925-f4c90480-6655-11eb-844a-14f1659e5487.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
