### PR TITLE
frontend: fix data-layout data preservation after hydration

### DIFF
--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -46,7 +46,7 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
     case ManagerAction.HYDRATE_END: {
       const update = {
         isLoading: false,
-        data: { ...(action.payload?.result || {}), ...state[layoutKey].data },
+        data: { ...(action.payload?.result || {}), ...state[layoutKey]?.data },
         error: action.payload?.error,
       };
       return {
@@ -58,7 +58,7 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
       return {
         ...state,
         [layoutKey]: {
-          ...state[layoutKey],
+          ...state?.[layoutKey],
           data: action.payload?.value,
           isLoading: false,
         },
@@ -83,4 +83,4 @@ const useManagerState = (
   return useThunkReducer(reducer, initialState);
 };
 
-export { ManagerAction, useManagerState };
+export { ManagerAction, reducer, useManagerState };

--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -46,7 +46,7 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
     case ManagerAction.HYDRATE_END: {
       const update = {
         isLoading: false,
-        data: {...action.payload?.result || {}, ...state[layoutKey].data},
+        data: { ...(action.payload?.result || {}), ...state[layoutKey].data },
         error: action.payload?.error,
       };
       return {

--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -46,7 +46,7 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
     case ManagerAction.HYDRATE_END: {
       const update = {
         isLoading: false,
-        data: action.payload?.result || {},
+        data: {...action.payload?.result || {}, ...state[layoutKey].data},
         error: action.payload?.error,
       };
       return {

--- a/frontend/packages/data-layout/src/tests/state.test.tsx
+++ b/frontend/packages/data-layout/src/tests/state.test.tsx
@@ -6,13 +6,13 @@ describe("Manager State", () => {
       let state = {};
       state = reducer(state, {
         type: ManagerAction.SET,
-        payload: { key: "layout1", value: {update: "value"} },
+        payload: { key: "layout1", value: { update: "value" } },
       });
       state = reducer(state, {
         type: ManagerAction.HYDRATE_END,
-        payload: { key: "layout1", result: {hydrate: "value"} },
+        payload: { key: "layout1", result: { hydrate: "value" } },
       });
-      expect(state["layout1"].data).toStrictEqual({update: "value", hydrate: "value"});
+      expect(state.layout1.data).toStrictEqual({ update: "value", hydrate: "value" });
     });
   });
 });

--- a/frontend/packages/data-layout/src/tests/state.test.tsx
+++ b/frontend/packages/data-layout/src/tests/state.test.tsx
@@ -1,0 +1,18 @@
+import { ManagerAction, reducer } from "../state";
+
+describe("Manager State", () => {
+  describe("hydrate", () => {
+    it("preserves existing data", () => {
+      let state = {};
+      state = reducer(state, {
+        type: ManagerAction.SET,
+        payload: { key: "layout1", value: {update: "value"} },
+      });
+      state = reducer(state, {
+        type: ManagerAction.HYDRATE_END,
+        payload: { key: "layout1", result: {hydrate: "value"} },
+      });
+      expect(state["layout1"].data).toStrictEqual({update: "value", hydrate: "value"});
+    });
+  });
+});


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This fixes a bug where existing data set on a data layout will be overwritten when a hydrate response returns.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manually
### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #152
