### PR TITLE
data layout: reset error state on load

### DIFF
--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -31,6 +31,8 @@ const useDataLayout = (key: string, opts?: object): DataLayout => {
     throw new Error(`Non-existant data layout key: ${key}`);
   }
 
+  // n.b. reset error and loading state on load.
+  // This prevents previous errors from rendering until hydration is finished.
   React.useEffect(() => {
     manager.update(key, { error: "", isLoading: false });
   }, []);

--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -32,6 +32,10 @@ const useDataLayout = (key: string, opts?: object): DataLayout => {
   }
 
   React.useEffect(() => {
+    manager.update(key, { error: "", isLoading: false });
+  }, []);
+
+  React.useEffect(() => {
     if (options.hydrate && (!manager.state[key].cache || _.isEmpty(manager.state[key].data))) {
       manager.hydrate(key);
     }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix bug where previous error state would be presented when a workflow was retried.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
