### PR TITLE
frontend: fix accordion detail children layout

### DIFF
--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -164,7 +164,7 @@ const StyledAccordionDetails = styled(MuiAccordionDetails)({
   flexWrap: "wrap",
   boxSizing: "border-box",
   "> *": {
-    padding: "8px 8px",
+    margin: "8px 8px",
   },
   ".MuiFormLabel-root": {
     padding: "inherit",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Use margin to offset accordion detail children instead of padding as this is less intrusive on the children's layout. With padding set you could have an element with a border that is now offset by 8px. This fixes that use case.
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-02-07 at 9 12 07 PM](https://user-images.githubusercontent.com/1004789/107179050-6375cd00-698a-11eb-8c58-0b22eebf07e9.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual