### PR TITLE
gateway: error log handler

### DIFF
--- a/backend/gateway/log/log.go
+++ b/backend/gateway/log/log.go
@@ -19,7 +19,7 @@ func ProtoField(key string, m proto.Message) zap.Field {
 }
 
 // NamedError returns a zap field that logs as the embedded JSON representation of the error.
-// If's a gRPC error, it converts it to a Status and returns
+// If it's a gRPC error, it converts it to a Status and returns
 // the unpacked information. Otherwise, it returns the original error.
 func NamedError(key string, err error) zap.Field {
 	s, ok := status.FromError(err)
@@ -27,4 +27,9 @@ func NamedError(key string, err error) zap.Field {
 		return zap.NamedError(key, err)
 	}
 	return ProtoField(key, s.Proto())
+}
+
+// Error calls NamedError with the key "error"
+func Error(err error) zap.Field {
+	return NamedError("error", err)
 }

--- a/backend/gateway/log/log.go
+++ b/backend/gateway/log/log.go
@@ -18,10 +18,10 @@ func ProtoField(key string, m proto.Message) zap.Field {
 	return zap.Any(key, json.RawMessage(b))
 }
 
-// NamedError returns a zap field that logs as the embedded JSON representation of the error.
+// NamedErrorField returns a zap field that logs as the embedded JSON representation of the error.
 // If it's a gRPC error, it converts it to a Status and returns
 // the unpacked information. Otherwise, it returns the original error.
-func NamedError(key string, err error) zap.Field {
+func NamedErrorField(key string, err error) zap.Field {
 	s, ok := status.FromError(err)
 	if !ok {
 		return zap.NamedError(key, err)
@@ -29,7 +29,7 @@ func NamedError(key string, err error) zap.Field {
 	return ProtoField(key, s.Proto())
 }
 
-// Error calls NamedError with the key "error"
-func Error(err error) zap.Field {
-	return NamedError("error", err)
+// ErrorField calls NamedErrorField with the key "error"
+func ErrorField(err error) zap.Field {
+	return NamedErrorField("error", err)
 }

--- a/backend/gateway/log/log.go
+++ b/backend/gateway/log/log.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 
 	"go.uber.org/zap"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -14,5 +16,25 @@ func ProtoField(key string, m proto.Message) zap.Field {
 	if err != nil {
 		return zap.Any(key, m)
 	}
+	return zap.Any(key, json.RawMessage(b))
+}
+
+// GrpcStatusField takes in an error and returns a zap field that logs as the embedded JSON
+// representation of a gRPC Status message.
+func GrpcStatusField(key string, err error) zap.Field {
+	var m *spb.Status
+	// the second return val is a bool reporting whether it was able to
+	// convert the input error to a Status. If false, FromError returns a new Status with
+	// codes.Unknown and the original input error message.
+	// https: //github.com/grpc/grpc-go/blob/master/status/status.go#L81
+	s, _ := status.FromError(err)
+
+	m = s.Proto()
+
+	b, err := protojson.Marshal(m)
+	if err != nil {
+		return zap.Any(key, m)
+	}
+
 	return zap.Any(key, json.RawMessage(b))
 }

--- a/backend/gateway/log/log_test.go
+++ b/backend/gateway/log/log_test.go
@@ -4,12 +4,17 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	healthcheckv1 "github.com/lyft/clutch/backend/api/healthcheck/v1"
 )
@@ -32,4 +37,66 @@ func TestProtoField(t *testing.T) {
 	o := make(map[string]interface{})
 	assert.NoError(t, json.Unmarshal(b.Bytes(), &o))
 	assert.Contains(t, b.String(), `{"@type":"type.googleapis.com/clutch.healthcheck.v1.HealthcheckRequest"}`)
+}
+
+func TestGrpcStatusField(t *testing.T) {
+	// a Status with no detailed appended
+	s1 := status.New(codes.PermissionDenied, "Permission denied")
+	err1 := s1.Err()
+
+	// a Status with details appended
+	s2 := status.New(codes.NotFound, "Resource not found")
+	s2, _ = s2.WithDetails(
+		&errdetails.ResourceInfo{ResourceType: "ConfigMap", Description: "configMap-test-1 not found"},
+		&errdetails.ResourceInfo{ResourceType: "ConfigMap", Description: "configMap-test-2 not found"},
+	)
+	err2 := s2.Err()
+
+	tests := []struct {
+		err             error
+		expectedCode    int
+		expectedMsg     string
+		expectedDetails []string
+	}{
+		{
+			err:          errors.New("I am a regular error message"),
+			expectedMsg:  "I am a regular error message",
+			expectedCode: 2,
+		},
+		{
+			err:          err1,
+			expectedMsg:  "Permission denied",
+			expectedCode: 7,
+		},
+		{
+			err:             err2,
+			expectedCode:    5,
+			expectedMsg:     "Resource not found",
+			expectedDetails: []string{"configMap-test-1 not found", "configMap-test-2 not found"},
+		},
+	}
+
+	for _, test := range tests {
+		var b bytes.Buffer
+		w := bufio.NewWriter(&b)
+
+		logger := zap.New(
+			zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(w), zap.DebugLevel),
+		)
+		logger.Info("test", GrpcStatusField("key", test.err))
+		assert.NoError(t, logger.Sync())
+		assert.NoError(t, w.Flush())
+
+		o := make(map[string]interface{})
+		assert.NoError(t, json.Unmarshal(b.Bytes(), &o))
+
+		assert.Contains(t, b.String(), strconv.Itoa(test.expectedCode))
+		assert.Contains(t, b.String(), test.expectedMsg)
+
+		if test.expectedDetails != nil {
+			for _, detail := range test.expectedDetails {
+				assert.Contains(t, b.String(), detail)
+			}
+		}
+	}
 }

--- a/backend/gateway/log/log_test.go
+++ b/backend/gateway/log/log_test.go
@@ -39,7 +39,7 @@ func TestProtoField(t *testing.T) {
 	assert.Contains(t, b.String(), `{"@type":"type.googleapis.com/clutch.healthcheck.v1.HealthcheckRequest"}`)
 }
 
-func TestNamedError(t *testing.T) {
+func TestNamedErrorField(t *testing.T) {
 	// a Status with no detailed appended
 	s1 := status.New(codes.PermissionDenied, "Permission denied")
 	err1 := s1.Err()
@@ -82,7 +82,7 @@ func TestNamedError(t *testing.T) {
 		logger := zap.New(
 			zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(w), zap.DebugLevel),
 		)
-		logger.Info("test", NamedError("key", test.err))
+		logger.Info("test", NamedErrorField("key", test.err))
 		assert.NoError(t, logger.Sync())
 		assert.NoError(t, w.Flush())
 
@@ -101,7 +101,7 @@ func TestNamedError(t *testing.T) {
 	}
 }
 
-func TestError(t *testing.T) {
+func TestErrorField(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 
@@ -109,7 +109,7 @@ func TestError(t *testing.T) {
 		zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(w), zap.DebugLevel),
 	)
 
-	logger.Info("test", Error(errors.New("yikes")))
+	logger.Info("test", ErrorField(errors.New("yikes")))
 	assert.NoError(t, logger.Sync())
 	assert.NoError(t, w.Flush())
 

--- a/backend/gateway/log/log_test.go
+++ b/backend/gateway/log/log_test.go
@@ -54,14 +54,13 @@ func TestGrpcStatusField(t *testing.T) {
 
 	tests := []struct {
 		err             error
-		expectedCode    int
 		expectedMsg     string
+		expectedCode    int
 		expectedDetails []string
 	}{
 		{
-			err:          errors.New("I am a regular error message"),
-			expectedMsg:  "I am a regular error message",
-			expectedCode: 2,
+			err:         errors.New("I am a conventional error message"),
+			expectedMsg: "I am a conventional error message",
 		},
 		{
 			err:          err1,
@@ -83,16 +82,17 @@ func TestGrpcStatusField(t *testing.T) {
 		logger := zap.New(
 			zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(w), zap.DebugLevel),
 		)
-		logger.Info("test", GrpcStatusField("key", test.err))
+		logger.Info("test", NamedError("key", test.err))
 		assert.NoError(t, logger.Sync())
 		assert.NoError(t, w.Flush())
 
 		o := make(map[string]interface{})
 		assert.NoError(t, json.Unmarshal(b.Bytes(), &o))
-
-		assert.Contains(t, b.String(), strconv.Itoa(test.expectedCode))
 		assert.Contains(t, b.String(), test.expectedMsg)
 
+		if test.expectedCode != 0 {
+			assert.Contains(t, b.String(), strconv.Itoa(test.expectedCode))
+		}
 		if test.expectedDetails != nil {
 			for _, detail := range test.expectedDetails {
 				assert.Contains(t, b.String(), detail)


### PR DESCRIPTION
### Description
PR adds a new error log handler that can (1) unpack a gRPC error and return the Status or (2) return the original error.

### Testing Performed
Unit tests
Locally

**examples**
1) a conventional error

```
ERROR   k8s/job.go:33   error deleting Job      {"serviceName": "clutch.service.k8s", "error": "jobs.batch \"foo\" not found"}
```

2) a gRPC error
```
ERROR   k8s/job.go:35   error deleting Job      {"serviceName": "clutch.service.k8s", "error": {"code":5,"message":"Job not found"}}
```

3) a gRPC error showing the extra details that had been appended to the Status
```
ERROR   k8s/job.go:36   error deleting Job      {"serviceName": "clutch.service.k8s", "error": {"code":5,"message":"Job not found","details":[{"@type":"type.googleapis.com/google.rpc.ResourceInfo","resourceType":"Job","description":"foo not found"},{"@type":"type.googleapis.com/google.rpc.ResourceInfo","resourceType":"Job","description":"foobar not found"}]}}
```