### PR TITLE
serverexperimentation: fix fault injection bug

### DIFF
--- a/backend/module/chaos/serverexperimentation/xds/xds_cache_test.go
+++ b/backend/module/chaos/serverexperimentation/xds/xds_cache_test.go
@@ -144,7 +144,7 @@ func TestSetSnapshotV3(t *testing.T) {
 
 	runtimeResource := generateRTDSResource(testClusterFaults, &rtdsConfig, nil, zap.NewNop().Sugar())
 	assert.Nil(t, runtimeResource[0].Ttl)
-	err := setSnapshot(runtimeResource, testCluster, testCache)
+	err := setSnapshot(runtimeResource, testCluster, testCache, zap.NewNop().Sugar())
 	if err != nil {
 		t.Errorf("setSnapshot failed %v", err)
 	}
@@ -206,7 +206,7 @@ func TestSetSnapshotV3WithTTL(t *testing.T) {
 	}
 
 	runtimeResource := generateRTDSResource(testClusterFaults, &rtdsConfig, &ttl, zap.NewNop().Sugar())
-	err := setSnapshot(runtimeResource, testCluster, testCache)
+	err := setSnapshot(runtimeResource, testCluster, testCache, zap.NewNop().Sugar())
 	if err != nil {
 		t.Errorf("setSnapshot failed %v", err)
 	}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Currently, RTDS updates runtime on the downstream cluster when it's supposed to update on the upstream cluster and vice versa. This bug prevents from running fault injection tests. This PR fixes it along with some improved logging. 

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Locally performed testing

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
