### PR TITLE
Fix incorrect name attached to cluster radio group props

### DIFF
--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -76,7 +76,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
   };
 
   const faultInjectionClusterRadioGroup = {
-    name: "faultInjectionCluster",
+    name: "upstreamClusterType",
     label: "Upstream Cluster Type",
     type: "radio-group",
     visible:

--- a/frontend/workflows/serverexperimentation/src/tests/__snapshots__/experiment-details.test.tsx.snap
+++ b/frontend/workflows/serverexperimentation/src/tests/__snapshots__/experiment-details.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Start Experiment workflow renders correctly with host percentage based 
   </h3>
   <TextField name=\\"downstreamCluster\\" label=\\"Downstream Cluster\\" defaultValue={[undefined]} type=\\"text\\" onChange={[Function: onChange]} inputRef={[Function: register]} error={false} helperText=\\"\\" />
   <TextField name=\\"upstreamCluster\\" label=\\"Upstream Cluster\\" defaultValue={[undefined]} type=\\"text\\" onChange={[Function: onChange]} inputRef={[Function: register]} error={false} helperText=\\"\\" />
-  <RadioGroup name=\\"faultInjectionCluster\\" label=\\"Upstream Cluster Type\\" disabled={false} options={{...}} defaultOption={0} onChange={[Function: onChange]} />
+  <RadioGroup name=\\"upstreamClusterType\\" label=\\"Upstream Cluster Type\\" disabled={false} options={{...}} defaultOption={0} onChange={[Function: onChange]} />
   <h3 style={{...}}>
     Targeting
   </h3>
@@ -66,7 +66,7 @@ exports[`Start Experiment workflow renders correctly with upstream cluster type 
   </h3>
   <TextField name=\\"downstreamCluster\\" label=\\"Downstream Cluster\\" defaultValue={[undefined]} type=\\"text\\" onChange={[Function: onChange]} inputRef={[Function: register]} error={false} helperText=\\"\\" />
   <TextField name=\\"upstreamCluster\\" label=\\"Upstream Cluster\\" defaultValue={[undefined]} type=\\"text\\" onChange={[Function: onChange]} inputRef={[Function: register]} error={false} helperText=\\"\\" />
-  <RadioGroup name=\\"faultInjectionCluster\\" label=\\"Upstream Cluster Type\\" disabled={false} options={{...}} defaultOption={0} onChange={[Function: onChange]} />
+  <RadioGroup name=\\"upstreamClusterType\\" label=\\"Upstream Cluster Type\\" disabled={false} options={{...}} defaultOption={0} onChange={[Function: onChange]} />
   <h3 style={{...}}>
     Targeting
   </h3>


### PR DESCRIPTION
The `upstreamClusterType` was no longer being updated when selecting one of the values from the radio group. This fixes the bug, and I have some ideas on how to refactor our React code to follow paradigms to prevent this kind of logic leak.

### Description
When migrating our fields, we didn't update the property name passed into the onChange() prop function in the <RadioGroup> component.

### Testing Performed
Tested locally by verifying state in <ExperimentDetail> before & after.

