### PR TITLE
chaos: serve up information on redis experimentation in list/detail view

### DIFF
--- a/backend/gateway/core.go
+++ b/backend/gateway/core.go
@@ -14,6 +14,7 @@ import (
 	authzmod "github.com/lyft/clutch/backend/module/authz"
 	awsmod "github.com/lyft/clutch/backend/module/aws"
 	experimentationapi "github.com/lyft/clutch/backend/module/chaos/experimentation/api"
+	"github.com/lyft/clutch/backend/module/chaos/redisexperimentation"
 	"github.com/lyft/clutch/backend/module/chaos/serverexperimentation"
 	xdsmod "github.com/lyft/clutch/backend/module/chaos/serverexperimentation/xds"
 	"github.com/lyft/clutch/backend/module/envoytriage"
@@ -63,6 +64,7 @@ var Modules = module.Factory{
 	resolvermod.Name:           resolvermod.New,
 	xdsmod.Name:                xdsmod.New,
 	serverexperimentation.Name: serverexperimentation.New,
+	redisexperimentation.Name:  redisexperimentation.New,
 	sourcecontrol.Name:         sourcecontrol.New,
 	topologymod.Name:           topologymod.New,
 }

--- a/backend/module/chaos/redisexperimentation/redis_experimentation.go
+++ b/backend/module/chaos/redisexperimentation/redis_experimentation.go
@@ -1,0 +1,98 @@
+package redisexperimentation
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+
+	experimentation "github.com/lyft/clutch/backend/api/chaos/experimentation/v1"
+	redisexperimentation "github.com/lyft/clutch/backend/api/chaos/redisexperimentation/v1"
+	"github.com/lyft/clutch/backend/module"
+	"github.com/lyft/clutch/backend/service"
+	"github.com/lyft/clutch/backend/service/chaos/experimentation/experimentstore"
+)
+
+const (
+	Name = "clutch.module.chaos.redisexperimentation"
+)
+
+type Service struct {
+	storer experimentstore.Storer
+}
+
+// New instantiates a Service object.
+func New(_ *any.Any, logger *zap.Logger, scope tally.Scope) (module.Module, error) {
+	store, ok := service.Registry[experimentstore.Name]
+	if !ok {
+		return nil, errors.New("could not find experiment store service")
+	}
+
+	storer, ok := store.(experimentstore.Storer)
+	if !ok {
+		return nil, errors.New("service was not the correct type")
+	}
+
+	return &Service{
+		storer: storer,
+	}, nil
+}
+
+func (s *Service) Register(r module.Registrar) error {
+	transformation := experimentstore.Transformation{ConfigTypeUrl: "type.googleapis.com/clutch.chaos.redisexperimentation.v1.RedisFaultConfig", RunTransform: s.transform}
+	return s.storer.RegisterTransformation(transformation)
+}
+
+func (s *Service) transform(_ *experimentstore.ExperimentRun, config *experimentstore.ExperimentConfig) ([]*experimentation.Property, error) {
+	var experimentConfig = redisexperimentation.RedisFaultConfig{}
+	if err := ptypes.UnmarshalAny(config.Config, &experimentConfig); err != nil {
+		return []*experimentation.Property{}, err
+	}
+
+	faultsDescription, err := experimentConfigToString(&experimentConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var downstream, upstream string
+	downstream = experimentConfig.GetServiceName()
+	upstream = strings.Join(experimentConfig.GetRedisCommands(), ",")
+
+	return []*experimentation.Property{
+		{
+			Id:    "type",
+			Label: "Type",
+			Value: &experimentation.Property_StringValue{StringValue: "Redis"},
+		},
+		{
+			Id:    "target",
+			Label: "Target",
+			Value: &experimentation.Property_StringValue{StringValue: fmt.Sprintf("%s ➡️ %s", downstream, upstream)},
+		},
+		{
+			Id:    "fault_types",
+			Label: "Fault Types",
+			Value: &experimentation.Property_StringValue{StringValue: faultsDescription},
+		},
+	}, nil
+}
+
+func experimentConfigToString(experiment *redisexperimentation.RedisFaultConfig) (string, error) {
+	if experiment == nil {
+		return "", errors.New("experiment is nil")
+	}
+
+	switch experiment.GetFault().(type) {
+	case *redisexperimentation.RedisFaultConfig_AbortFault:
+		return "Abort", nil
+	case *redisexperimentation.RedisFaultConfig_LatencyFault:
+		return "Latency", nil
+	default:
+		return "", fmt.Errorf("unexpected fault type %v", experiment.GetFault())
+	}
+}
+


### PR DESCRIPTION
### Description
Create a module class for redis experimentation to transform [RedisFaultConfig experiment configs](https://github.com/lyft/clutch/pull/1020) to a consumable format for the frontend list and detail UIs. 

### Testing Performed
Test locally with frontend to make sure that Redis faults are returned.

<img width="1311" alt="Screen Shot 2021-02-16 at 4 05 27 PM" src="https://user-images.githubusercontent.com/1103836/108399926-a8023380-71e8-11eb-8543-930aeda1bcb0.png">

