### PR TITLE
frontend: data-layout only merge data of same types on hydration end

### DIFF
--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -44,9 +44,23 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
         [layoutKey]: { ...state[layoutKey], isLoading: true },
       };
     case ManagerAction.HYDRATE_END: {
+      const newData: any = action.payload?.result;
+      const existingData: any = state[layoutKey]?.data;
+      const newDataIsArray = Array.isArray(newData);
+      const existingDataIsArray = Array.isArray(existingData);
+      let data: object;
+      if ((newDataIsArray && !existingDataIsArray) || (!newDataIsArray && existingDataIsArray)) {
+        data = newData;
+      } else {
+        if (newDataIsArray) {
+          data = [ ...newData, ...existingData ];
+        } else {
+          data = { ...newData, ...existingData };
+        }
+      }
       const update = {
         isLoading: false,
-        data: { ...(action.payload?.result || {}), ...state[layoutKey]?.data },
+        data: data,
         error: action.payload?.error,
       };
       return {

--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -51,16 +51,14 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
       let data: object;
       if ((newDataIsArray && !existingDataIsArray) || (!newDataIsArray && existingDataIsArray)) {
         data = newData;
+      } else if (newDataIsArray) {
+        data = [...newData, ...existingData];
       } else {
-        if (newDataIsArray) {
-          data = [ ...newData, ...existingData ];
-        } else {
-          data = { ...newData, ...existingData };
-        }
+        data = { ...newData, ...existingData };
       }
       const update = {
         isLoading: false,
-        data: data,
+        data,
         error: action.payload?.error,
       };
       return {

--- a/frontend/packages/data-layout/src/tests/state.test.tsx
+++ b/frontend/packages/data-layout/src/tests/state.test.tsx
@@ -5,7 +5,10 @@ describe("Manager State", () => {
     describe("preserves existing data", () => {
       it("of lists", () => {
         let state = {};
-        state = reducer(state, { type: ManagerAction.SET, payload: { key: "layout", value: [{ update: "value" }] } });
+        state = reducer(state, {
+          type: ManagerAction.SET,
+          payload: { key: "layout", value: [{ update: "value" }] },
+        });
         state = reducer(state, {
           type: ManagerAction.HYDRATE_END,
           payload: { key: "layout", result: [{ hydrate: "value" }] },
@@ -15,7 +18,10 @@ describe("Manager State", () => {
 
       it("of objects", () => {
         let state = {};
-        state = reducer(state, { type: ManagerAction.SET, payload: { key: "layout", value: { update: "value" } } });
+        state = reducer(state, {
+          type: ManagerAction.SET,
+          payload: { key: "layout", value: { update: "value" } },
+        });
         state = reducer(state, {
           type: ManagerAction.HYDRATE_END,
           payload: { key: "layout", result: { hydrate: "value" } },
@@ -26,7 +32,10 @@ describe("Manager State", () => {
 
     it("gives priority to existing data", () => {
       let state = {};
-      state = reducer(state, { type: ManagerAction.SET, payload: { key: "layout", value: { update: "initialValue" } } });
+      state = reducer(state, {
+        type: ManagerAction.SET,
+        payload: { key: "layout", value: { update: "initialValue" } },
+      });
       state = reducer(state, {
         type: ManagerAction.HYDRATE_END,
         payload: { key: "layout", result: { update: "endingValue" } },

--- a/frontend/packages/data-layout/src/tests/state.test.tsx
+++ b/frontend/packages/data-layout/src/tests/state.test.tsx
@@ -1,18 +1,67 @@
 import { ManagerAction, reducer } from "../state";
 
 describe("Manager State", () => {
-  describe("hydrate", () => {
-    it("preserves existing data", () => {
-      let state = {};
-      state = reducer(state, {
-        type: ManagerAction.SET,
-        payload: { key: "layout1", value: { update: "value" } },
+  describe("hydrate end", () => {
+    describe("preserves existing data", () => {
+      it("of lists", () => {
+        let state = {};
+        state = reducer(state, { type: ManagerAction.SET, payload: { key: "layout", value: [{ update: "value" }] } });
+        state = reducer(state, {
+          type: ManagerAction.HYDRATE_END,
+          payload: { key: "layout", result: [{ hydrate: "value" }] },
+        });
+        expect(state.layout.data).toEqual([{ hydrate: "value" }, { update: "value" }]);
       });
+
+      it("of objects", () => {
+        let state = {};
+        state = reducer(state, { type: ManagerAction.SET, payload: { key: "layout", value: { update: "value" } } });
+        state = reducer(state, {
+          type: ManagerAction.HYDRATE_END,
+          payload: { key: "layout", result: { hydrate: "value" } },
+        });
+        expect(state.layout.data).toStrictEqual({ update: "value", hydrate: "value" });
+      });
+    });
+
+    it("gives priority to existing data", () => {
+      let state = {};
+      state = reducer(state, { type: ManagerAction.SET, payload: { key: "layout", value: { update: "initialValue" } } });
       state = reducer(state, {
         type: ManagerAction.HYDRATE_END,
-        payload: { key: "layout1", result: { hydrate: "value" } },
+        payload: { key: "layout", result: { update: "endingValue" } },
       });
-      expect(state.layout1.data).toStrictEqual({ update: "value", hydrate: "value" });
+      expect(state.layout.data).toStrictEqual({ update: "initialValue" });
+    });
+
+    describe("on type mismatch", () => {
+      describe("overwrites existing data", () => {
+        it("of objects", () => {
+          let state = {};
+          state = reducer(state, {
+            type: ManagerAction.SET,
+            payload: { key: "layout", value: { update: "value" } },
+          });
+          state = reducer(state, {
+            type: ManagerAction.HYDRATE_END,
+            payload: { key: "layout", result: [{ hydrate: "value" }] },
+          });
+          expect(state.layout.data).toStrictEqual([{ hydrate: "value" }]);
+        });
+
+        it("of lists", () => {
+          let state = {};
+          state = reducer(state, {
+            type: ManagerAction.SET,
+            payload: { key: "layout", value: [{ update: "value" }] },
+          });
+          state = reducer(state, {
+            type: ManagerAction.HYDRATE_END,
+            payload: { key: "layout", result: { hydrate: "value" } },
+          });
+          expect(state.layout.data).toStrictEqual({ hydrate: "value" });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Update data-layout to only merge existing data and new data when the types are the same.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
added tests