### PR TITLE
frontend: autocomplete propagate onChange event

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -251,6 +251,9 @@ export const TextField = ({
         getOptionLabel={option => (option?.id ? option.id : option)}
         onInputChange={(__, v) => autoCompleteDebounce(v)}
         renderOption={option => <AutocompleteResult id={option.id} label={option.label} />}
+        onSelectCapture={e =>
+          onChange(e as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>)
+        }
         renderInput={inputProps => (
           <StyledTextField
             {...inputProps}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
When select an item from the list of auto complete options, we were not triggering the `onChange` handler which is necessary to propagate the value of the selected item up to the consumer of the component.

### Testing Performed
locally