### PR TITLE
frontend: autocomplete dont query on empty string

### DIFF
--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -32,6 +32,12 @@ interface QueryResolverProps {
 }
 
 const autoComplete = async (type: string, search: string): Promise<any> => {
+  // Check the length of the search query as the user might empty out the search
+  // which will still trigger the on change handler
+  if (search.length === 0) {
+    return { results: [] };
+  }
+
   const response = await client.post("/v1/resolver/autocomplete", {
     want: `type.googleapis.com/${type}`,
     search,


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Currently if the user empties out their search query, the frontend will still trigger a query for an empty string `""`. The resolver autocomplete api requires the `search` field be at least one byte which produces a 400 error.

eg:
```{"code":3,"message":"invalid AutocompleteRequest.Search: value length must be at least 1 bytes","details":[]}```

### Testing Performed
locally