### PR TITLE
ci: update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,10 +25,18 @@
   "packageRules": [
     {
       "extends": ["schedule:weekly"],
-      "packageNames": [
-        "github.com/aws/aws-sdk-go",
-        "golang.org/x/net",
+      "matchPackageNames": [
         "google.golang.org/genproto"
+      ],
+      "matchPackagePatterns": [
+        "^golang.org/x/",
+        "^github.com/aws/"
+      ]
+    },
+    {
+      "enabled": false,
+      "matchPackagePatterns": [
+        "^github.com/cactus/go-statsd-client"
       ]
     }
   ],


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Updates our rules to result in a little less renovate churn:
- Use pattern matching for AWS and golang `x` modules
- Ignore cactus statsd updates (cannot be updated without `tally` updating)

### Testing Performed
CI