### PR TITLE
topology: cache to retry db connection

### DIFF
--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -55,7 +55,12 @@ func (c *client) acquireTopologyCacheLock(ctx context.Context) {
 	}
 }
 
+// Creates a new database connection if cacheLockConn is nil
+// This also handles checking the health of the connection
+// and attempts too reconnect.
 func (c *client) getCacheLockConn(ctx context.Context) error {
+	// Not only does this check if the database connection is active
+	// but will also reestablish a connection if it is not
 	err := c.db.PingContext(ctx)
 	if err != nil {
 		return err

--- a/backend/service/topology/cache_test.go
+++ b/backend/service/topology/cache_test.go
@@ -1,9 +1,10 @@
 package topology
 
 import (
-	"log"
+	"context"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,8 +33,21 @@ func TestConvertLockIdToAdvisoryLockId(t *testing.T) {
 		t.Run(tt.id, func(t *testing.T) {
 			t.Parallel()
 			id := convertLockIdToAdvisoryLockId(tt.input)
-			log.Printf("%v", id)
 			assert.Equal(t, tt.expect, id)
 		})
 	}
+}
+
+func TestGetCacheLockConn(t *testing.T) {
+	db, _, err := sqlmock.New()
+	assert.NoError(t, err)
+
+	topo := &client{
+		db: db,
+	}
+
+	// Assert that the cacheLockConn get created
+	err = topo.getCacheLockConn(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, topo.cacheLockConn)
 }

--- a/backend/service/topology/cache_test.go
+++ b/backend/service/topology/cache_test.go
@@ -1,10 +1,8 @@
 package topology
 
 import (
-	"context"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,18 +34,4 @@ func TestConvertLockIdToAdvisoryLockId(t *testing.T) {
 			assert.Equal(t, tt.expect, id)
 		})
 	}
-}
-
-func TestGetCacheLockConn(t *testing.T) {
-	db, _, err := sqlmock.New()
-	assert.NoError(t, err)
-
-	topo := &client{
-		db: db,
-	}
-
-	// Assert that the cacheLockConn get created
-	err = topo.getCacheLockConn(context.Background())
-	assert.NoError(t, err)
-	assert.NotNil(t, topo.cacheLockConn)
 }

--- a/backend/service/topology/topology.go
+++ b/backend/service/topology/topology.go
@@ -33,9 +33,10 @@ type Service interface {
 type client struct {
 	config *topologyv1cfg.Config
 
-	db    *sql.DB
-	log   *zap.Logger
-	scope tally.Scope
+	db            *sql.DB
+	log           *zap.Logger
+	scope         tally.Scope
+	cacheLockConn *sql.Conn
 }
 
 // CacheableTopology is implemented by a service that wishes to enable the topology API feature set

--- a/backend/service/topology/topology.go
+++ b/backend/service/topology/topology.go
@@ -33,10 +33,9 @@ type Service interface {
 type client struct {
 	config *topologyv1cfg.Config
 
-	db            *sql.DB
-	log           *zap.Logger
-	scope         tally.Scope
-	cacheLockConn *sql.Conn
+	db    *sql.DB
+	log   *zap.Logger
+	scope tally.Scope
 }
 
 // CacheableTopology is implemented by a service that wishes to enable the topology API feature set


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

We keep a separate database connection just for the topology cache advisory locks which are utilized when performing leader election. If there is any interruption to the database such a failover we were unable to reconnect and start operating normally again.

```
INFO	gateway/gateway.go:57	using configuration	{"file": "clutch-config.yaml"}
INFO	gateway/gateway.go:106	registering service	{"serviceName": "clutch.service.db.postgres"}
INFO	gateway/gateway.go:106	registering service	{"serviceName": "clutch.service.envoyadmin"}
INFO	gateway/gateway.go:106	registering service	{"serviceName": "clutch.service.topology"}
INFO	topology/topology.go:90	Topology caching is enabled	{"serviceName": "clutch.service.topology"}
INFO	gateway/gateway.go:168	registering middleware	{"moduleName": "clutch.middleware.stats"}
INFO	gateway/gateway.go:168	registering middleware	{"moduleName": "clutch.middleware.validate"}
INFO	topology/cache.go:29	trying to acquire advisory lock	{"serviceName": "clutch.service.topology"}
INFO	gateway/gateway.go:221	registering module	{"moduleName": "clutch.module.assets"}
INFO	gateway/gateway.go:221	registering module	{"moduleName": "clutch.module.healthcheck"}
INFO	gateway/gateway.go:221	registering module	{"moduleName": "clutch.module.resolver"}
INFO	gateway/gateway.go:221	registering module	{"moduleName": "clutch.module.envoytriage"}
INFO	gateway/gateway.go:221	registering module	{"moduleName": "clutch.module.topology"}
INFO	gateway/gateway.go:254	listening	{"tcp": {"addr": "0.0.0.0:8080"}}
DEBUG	stats/debug_reporter.go:41	counter	{"name": "clutch.gateway.start", "value": 1, "tags": {}, "type": "counter"}
INFO	topology/cache.go:29	trying to acquire advisory lock	{"serviceName": "clutch.service.topology"}
INFO	topology/cache.go:29	trying to acquire advisory lock	{"serviceName": "clutch.service.topology"}

# Lost database connection

INFO	topology/cache.go:29	trying to acquire advisory lock	{"serviceName": "clutch.service.topology"}
ERROR	topology/cache.go:44	lost connection to database, trying to reconnect...	{"serviceName": "clutch.service.topology", "error": "dial tcp 0.0.0.0:5432: connect: connection refused"}
github.com/lyft/clutch/backend/service/topology.(*client).acquireTopologyCacheLock
	/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/service/topology/cache.go:44

INFO	topology/cache.go:29	trying to acquire advisory lock	{"serviceName": "clutch.service.topology"}
ERROR	topology/cache.go:44	lost connection to database, trying to reconnect...	{"serviceName": "clutch.service.topology", "error": "dial tcp 0.0.0.0:5432: connect: connection refused"}
github.com/lyft/clutch/backend/service/topology.(*client).acquireTopologyCacheLock
	/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/service/topology/cache.go:44

INFO	topology/cache.go:29	trying to acquire advisory lock	{"serviceName": "clutch.service.topology"}
ERROR	topology/cache.go:44	lost connection to database, trying to reconnect...	{"serviceName": "clutch.service.topology", "error": "dial tcp 0.0.0.0:5432: connect: connection refused"}
github.com/lyft/clutch/backend/service/topology.(*client).acquireTopologyCacheLock
	/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/service/topology/cache.go:44

# Reconnected to database

INFO	topology/cache.go:29	trying to acquire advisory lock	{"serviceName": "clutch.service.topology"}
INFO	topology/cache.go:39	acquired the advisory lock, starting to cache topology now...	{"serviceName": "clutch.service.topology"}
INFO	topology/cache.go:202	successfully removed expired cache	{"serviceName": "clutch.service.topology", "count": 0}
DEBUG	stats/debug_reporter.go:41	counter	{"name": "clutch.service.topology.cache.expire.success", "value": 1, "tags": {}, "type": "counter"}

```

### Testing Performed
unit / tested locally, bringing my local db up and down to simulate interruption of service.

