### PR TITLE
kubernetes: cache to re-list resources hourly

### DIFF
--- a/backend/service/aws/cache.go
+++ b/backend/service/aws/cache.go
@@ -22,7 +22,7 @@ func (c *client) CacheEnabled() bool {
 	return true
 }
 
-func (c *client) StartTopologyCaching(ctx context.Context) (<-chan *topologyv1.UpdateCacheRequest, error) {
+func (c *client) StartTopologyCaching(ctx context.Context, ttl time.Duration) (<-chan *topologyv1.UpdateCacheRequest, error) {
 	if !c.topologyLock.TryAcquire(topologyLockId) {
 		return nil, errors.New("TopologyCaching is already in progress")
 	}

--- a/backend/service/aws/cache_test.go
+++ b/backend/service/aws/cache_test.go
@@ -20,12 +20,15 @@ func TestStartTopologyCache(t *testing.T) {
 		log:                log,
 	}
 
-	buff, err := c.StartTopologyCaching(context.Background())
+	// Not currently used by AWS caching but its a required parameter
+	cacheTtl := time.Minute * 1
+
+	buff, err := c.StartTopologyCaching(context.Background(), cacheTtl)
 	assert.NoError(t, err)
 	assert.NotNil(t, buff)
 
 	// Asserts that the topologyLock has already been aquired
-	_, err = c.StartTopologyCaching(context.Background())
+	_, err = c.StartTopologyCaching(context.Background(), cacheTtl)
 	assert.Error(t, err)
 }
 

--- a/backend/service/k8s/meta.go
+++ b/backend/service/k8s/meta.go
@@ -1,8 +1,10 @@
 package k8s
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
 )
@@ -16,4 +18,17 @@ func ApplyListOptions(listOpts *k8sapiv1.ListOptions) metav1.ListOptions {
 	}
 
 	return opts
+}
+
+// Applies the name of the cluster to a kube object
+// ClusterName is still not set in kube v1.20 so we are setting this manually.
+// https://github.com/kubernetes/apimachinery/blob/2456ebdaba229616fab2161a615148884b46644b/pkg/apis/meta/v1/types.go#L266-L270
+func ApplyClusterMetadata(cluster string, obj runtime.Object) error {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	objMeta.SetClusterName(cluster)
+	return nil
 }

--- a/backend/service/k8s/meta_test.go
+++ b/backend/service/k8s/meta_test.go
@@ -4,7 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
 )
@@ -43,6 +47,52 @@ func TestApplyListOptions(t *testing.T) {
 
 			listOpts := ApplyListOptions(tt.listOptions)
 			assert.Equal(t, listOpts, tt.expectedListOptions)
+		})
+	}
+}
+
+func TestApplyClusterMetadata(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		id          string
+		cluster     string
+		obj         runtime.Object
+		shouldError bool
+	}{
+		{
+			id:          "pod",
+			cluster:     "meow",
+			obj:         &corev1.Pod{},
+			shouldError: false,
+		},
+		{
+			id:          "deployment",
+			cluster:     "cat",
+			obj:         &appsv1.Deployment{},
+			shouldError: false,
+		},
+		{
+			id:          "should error",
+			cluster:     "",
+			obj:         nil,
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.id, func(t *testing.T) {
+			err := ApplyClusterMetadata(tt.cluster, tt.obj)
+			if !tt.shouldError {
+				assert.NoError(t, err)
+
+				objMeta, err := meta.Accessor(tt.obj)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.cluster, objMeta.GetClusterName())
+			} else {
+				assert.Error(t, err)
+			}
 		})
 	}
 }

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -86,7 +86,7 @@ func (c *client) startTopologyCache(ctx context.Context) {
 		if svc, ok := s.(CacheableTopology); ok {
 			if svc.CacheEnabled() {
 				c.log.Info("Processing Topology Objects for service", zap.String("service", name))
-				topologyChannel, err := svc.StartTopologyCaching(ctx, c.config.Cache.Ttl.AsDuration())
+				topologyChannel, err := svc.StartTopologyCaching(ctx, c.cacheTTL)
 				if err != nil {
 					c.log.Error("Unable to start topology caching", zap.String("service", name), zap.Error(err))
 					continue
@@ -182,7 +182,7 @@ func (c *client) expireCache(ctx context.Context) {
 
 	ticker := time.NewTicker(time.Minute * 20)
 	for {
-		result, err := c.db.ExecContext(ctx, expireQuery, strconv.Itoa(int(c.config.Cache.Ttl.AsDuration().Seconds())))
+		result, err := c.db.ExecContext(ctx, expireQuery, strconv.Itoa(int(c.cacheTTL.Seconds())))
 		if err != nil {
 			c.scope.SubScope("cache").Counter("expire.failure").Inc(1)
 			c.log.Error("unable to expire cache", zap.Error(err))


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Performs a full re-list for all watched resources types by the Kubernetes cache. This works in tandem with the LightweightInformer to keep the cache as fresh as possible while also keeping items in cache that may not see many updates. This is similar to upstream's informer's resync while still keeping the benefit to overall memory footprint and actually pulling fresh data from the api servers.

For example some Kubernetes resources dont see frequent enough updates which in-turn does not emit an informer event. If updates to these resources are so infrequent they can be cleaned up by the topology cache which removes stale items.

In order to thread through the TopologyCache TTL to the kubernetes cache I changed the Interface for `CacheableTopology` which could be useful for other services of the topology cache for similar situations like this one.

### Testing Performed
Locally.
