### PR TITLE
resolver: kubernetes autocomplete

### DIFF
--- a/backend/mock/service/topologymock/topologymock.go
+++ b/backend/mock/service/topologymock/topologymock.go
@@ -39,3 +39,15 @@ func (s *svc) Search(context.Context, *topologyv1.SearchRequest) ([]*topologyv1.
 		},
 	}, "1", nil
 }
+
+func (s *svc) Autocomplete(ctx context.Context, typeURL, search string, limit uint64) ([]*topologyv1.Resource, error) {
+	return []*topologyv1.Resource{
+		{
+			Id: "autocomplete-result",
+			Pb: &any.Any{},
+			Metadata: map[string]*structpb.Value{
+				"label": &structpb.Value{},
+			},
+		},
+	}, nil
+}

--- a/backend/resolver/aws/aws_test.go
+++ b/backend/resolver/aws/aws_test.go
@@ -99,10 +99,10 @@ type mockTopologySearch struct {
 	autoCompleteResults []*topologyv1.Resource
 }
 
-func (m *mockTopologySearch) Search(ctx context.Context, search *topologyv1.SearchRequest) ([]*topologyv1.Resource, string, error) {
+func (m *mockTopologySearch) Autocomplete(ctx context.Context, typeURL, search string, limit uint64) ([]*topologyv1.Resource, error) {
 	if m.autoCompleteError != nil {
-		return nil, "", m.autoCompleteError
+		return nil, m.autoCompleteError
 	}
 
-	return m.autoCompleteResults, "0", nil
+	return m.autoCompleteResults, nil
 }

--- a/backend/resolver/k8s/k8s.go
+++ b/backend/resolver/k8s/k8s.go
@@ -75,7 +75,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (resolver.Resolver
 		if !ok {
 			return nil, errors.New("incorrect topology service type")
 		}
-		logger.Debug("enabling autocomplete api for the aws resolver")
+		logger.Debug("enabling autocomplete api for the k8s resolver")
 	}
 
 	schemas, err := resolver.InputsToSchemas(typeSchemas)

--- a/backend/resolver/k8s/k8s.go
+++ b/backend/resolver/k8s/k8s.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lyft/clutch/backend/resolver"
 	"github.com/lyft/clutch/backend/service"
 	"github.com/lyft/clutch/backend/service/k8s"
+	"github.com/lyft/clutch/backend/service/topology"
 )
 
 const Name = "clutch.resolver.k8s"
@@ -68,6 +69,15 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (resolver.Resolver
 		return nil, errors.New("service was not the correct type")
 	}
 
+	var topologyService topology.Service
+	if svc, ok := service.Registry[topology.Name]; ok {
+		topologyService, ok = svc.(topology.Service)
+		if !ok {
+			return nil, errors.New("incorrect topology service type")
+		}
+		logger.Debug("enabling autocomplete api for the aws resolver")
+	}
+
 	schemas, err := resolver.InputsToSchemas(typeSchemas)
 	if err != nil {
 		return nil, err
@@ -83,15 +93,17 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (resolver.Resolver
 	})
 
 	r := &res{
-		svc:     svc,
-		schemas: schemas,
+		svc:      svc,
+		topology: topologyService,
+		schemas:  schemas,
 	}
 	return r, nil
 }
 
 type res struct {
-	svc     k8s.Service
-	schemas resolver.TypeURLToSchemasMap
+	svc      k8s.Service
+	topology topology.Service
+	schemas  resolver.TypeURLToSchemasMap
 }
 
 func (r *res) Schemas() resolver.TypeURLToSchemasMap { return r.schemas }
@@ -203,6 +215,30 @@ func (r *res) Search(ctx context.Context, typeURL, query string, limit uint32) (
 	return handler.Results(limit)
 }
 
-func (r *res) Autocomplete(ctx context.Context, typeURLs, search string, limit uint64) ([]*resolverv1.AutocompleteResult, error) {
-	return []*resolverv1.AutocompleteResult{}, nil
+func (r *res) Autocomplete(ctx context.Context, typeURL, search string, limit uint64) ([]*resolverv1.AutocompleteResult, error) {
+	if r.topology == nil {
+		return nil, fmt.Errorf("to use the autocomplete api you must first setup the topology service")
+	}
+
+	var resultLimit uint64 = resolver.DefaultAutocompleteLimit
+	if limit > 0 {
+		resultLimit = limit
+	}
+
+	results, err := r.topology.Autocomplete(ctx, typeURL, search, resultLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	autoCompleteValue := make([]*resolverv1.AutocompleteResult, len(results))
+	for i, r := range results {
+		autoCompleteValue[i] = &resolverv1.AutocompleteResult{
+			Id: r.Id,
+			// TODO (mcutalo): Add more detailed information to the label
+			// the labels value will vary based on resource
+			Label: "",
+		}
+	}
+
+	return autoCompleteValue, nil
 }

--- a/backend/service/topology/topology.go
+++ b/backend/service/topology/topology.go
@@ -28,6 +28,7 @@ const Name = "clutch.service.topology"
 type Service interface {
 	GetTopology(ctx context.Context) error
 	Search(ctx context.Context, search *topologyv1.SearchRequest) ([]*topologyv1.Resource, string, error)
+	Autocomplete(ctx context.Context, typeURL, search string, limit uint64) ([]*topologyv1.Resource, error)
 }
 
 type client struct {
@@ -157,4 +158,29 @@ func (c *client) Search(ctx context.Context, req *topologyv1.SearchRequest) ([]*
 	}
 
 	return results, nextPageTokenStr, nil
+}
+
+func (c *client) Autocomplete(ctx context.Context, typeURL, search string, limit uint64) ([]*topologyv1.Resource, error) {
+	searchRequest := &topologyv1.SearchRequest{
+		PageToken: "0",
+		Limit:     limit,
+		Sort: &topologyv1.SearchRequest_Sort{
+			Direction: topologyv1.SearchRequest_Sort_ASCENDING,
+			Field:     "column.id",
+		},
+		Filter: &topologyv1.SearchRequest_Filter{
+			TypeUrl: typeURL,
+			Search: &topologyv1.SearchRequest_Filter_Search{
+				Field: "column.id",
+				Text:  search,
+			},
+		},
+	}
+
+	results, _, err := c.Search(ctx, searchRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, err
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

Adds basic autocomplete to all kubernetes workflows. This also includes a small refactor to abstract some of the boilerplate of the topology search request away.

![ossk8sautocomplete](https://user-images.githubusercontent.com/2250844/109034416-7a9c0680-767c-11eb-94e9-936b371e51b1.gif)

### Testing Performed
Locally.

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

This makes progress on issues #921 and #30.


