### PR TITLE
kubernetes: add cluster info to all cached resources

### DIFF
--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -39,13 +39,13 @@ func (s *svc) StartTopologyCaching(ctx context.Context) (<-chan *topologyv1.Upda
 	}
 	for name, cs := range clientsets {
 		s.log.Info("starting informer for", zap.String("cluster", name))
-		go s.startInformers(ctx, cs)
+		go s.startInformers(ctx, name, cs)
 	}
 
 	return s.topologyObjectChan, nil
 }
 
-func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
+func (s *svc) startInformers(ctx context.Context, clusterName string, cs ContextClientset) {
 	informerHandlers := cache.ResourceEventHandlerFuncs{
 		AddFunc:    s.informerAddHandler,
 		UpdateFunc: s.informerUpdateHandler,
@@ -57,6 +57,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		&corev1.Pod{},
 		informerHandlers,
 		false,
+		clusterName,
 	)
 
 	deploymentInformer := NewLightweightInformer(
@@ -64,6 +65,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		&appsv1.Deployment{},
 		informerHandlers,
 		true,
+		clusterName,
 	)
 
 	hpaInformer := NewLightweightInformer(
@@ -71,6 +73,7 @@ func (s *svc) startInformers(ctx context.Context, cs ContextClientset) {
 		&autoscalingv1.HorizontalPodAutoscaler{},
 		informerHandlers,
 		true,
+		clusterName,
 	)
 
 	stop := make(chan struct{})

--- a/backend/service/k8s/lightweightinformer.go
+++ b/backend/service/k8s/lightweightinformer.go
@@ -44,6 +44,7 @@ func NewLightweightInformer(
 	objType runtime.Object,
 	h cache.ResourceEventHandler,
 	recieveUpdates bool,
+	clusterName string,
 ) cache.Controller {
 	cacheStore := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
 	fifo := cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
@@ -68,6 +69,10 @@ func NewLightweightInformer(
 					Name:      incomingObjectMeta.GetName(),
 					Namespace: incomingObjectMeta.GetNamespace(),
 				}
+
+				// ClusterName is still not set in kube v1.20 so we are setting this manually.
+				// https://github.com/kubernetes/apimachinery/blob/2456ebdaba229616fab2161a615148884b46644b/pkg/apis/meta/v1/types.go#L266-L270
+				incomingObjectMeta.SetClusterName(clusterName)
 
 				switch d.Type {
 				case cache.Sync, cache.Replaced, cache.Added, cache.Updated:

--- a/backend/service/k8s/lightweightinformer_test.go
+++ b/backend/service/k8s/lightweightinformer_test.go
@@ -37,6 +37,7 @@ func TestLightweightInformer(t *testing.T) {
 		&v1.Pod{},
 		informerHandlers,
 		true,
+		"clusterName",
 	)
 
 	go podInformer.Run(stop)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Upstream Kubernetes does not populate the `ClusterName` on the [ObjectMeta](https://github.com/kubernetes/apimachinery/blob/2456ebdaba229616fab2161a615148884b46644b/pkg/apis/meta/v1/types.go#L266-L270), this is useful information that we can utilize and we can easily populate this information before writing the object to cache.

This is also required to complete autocomplete for kubernetes workflows as we are now utilizing the proto patterns defied in resource as the structure for a workflows query input https://github.com/lyft/clutch/blob/a2e4ac8644837a1260b39c7c7c2e20cac465c85c/api/k8s/v1/k8s.proto#L406

here is an example of one, but all kubernetes resources do and should require `cluster` in their pattern.

You can now see the `cluster` field is now populated
```
clutch=# select data->'name', data->'cluster' from topology_cache;
                       ?column?                       |      ?column?
------------------------------------------------------+---------------------
 "clutch-staging"                                     | "kind-clutch-local"
 "envoy-production"                                   | "kind-clutch-local"
 "coredns"                                            | "kind-clutch-local"
 "local-path-provisioner"                             | "kind-clutch-local"
 "clutch-production"                                  | "kind-clutch-local"
 "clutch-production-5d9b89bb5-trk8w"                  | "kind-clutch-local"
 "etcd-clutch-local-control-plane"                    | "kind-clutch-local"
 "kindnet-tcw9x"                                      | "kind-clutch-local"
 "kube-apiserver-clutch-local-control-plane"          | "kind-clutch-local"
 "local-path-provisioner-78776bfc44-998g9"            | "kind-clutch-local"
 "envoy-production-584ff8f8f9-tbg7x"                  | "kind-clutch-local"
 "coredns-74ff55c5b-spwrh"                            | "kind-clutch-local"
 "kube-scheduler-clutch-local-control-plane"          | "kind-clutch-local"
 "kube-proxy-m8f9r"                                   | "kind-clutch-local"
 "clutch-staging-dc4c7f595-qsp7q"                     | "kind-clutch-local"
 "coredns-74ff55c5b-c28cx"                            | "kind-clutch-local"
 "kube-controller-manager-clutch-local-control-plane" | "kind-clutch-local"
 ```

### Testing Performed
Verified locally
