### PR TITLE
k8s: always return a gRPC status

### DIFF
--- a/backend/module/k8s/job.go
+++ b/backend/module/k8s/job.go
@@ -2,8 +2,9 @@ package k8s
 
 import (
 	"context"
-	"errors"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -28,7 +29,7 @@ func (a *k8sAPI) ListJobs(ctx context.Context, req *k8sapiv1.ListJobsRequest) (*
 
 func (a *k8sAPI) CreateJob(ctx context.Context, req *k8sapiv1.CreateJobRequest) (*k8sapiv1.CreateJobResponse, error) {
 	if req.JobConfig == nil {
-		return nil, errors.New("unable to create Job object. Job configuration is missing")
+		return nil, status.Error(codes.InvalidArgument, "unable to create job object, job configuration is missing")
 	}
 	// convert Job config into a runtime object and then type cast to a
 	// batch job
@@ -40,7 +41,7 @@ func (a *k8sAPI) CreateJob(ctx context.Context, req *k8sapiv1.CreateJobRequest) 
 	}
 	job, ok := obj.(*batchv1.Job)
 	if !ok {
-		return nil, errors.New("unable to create Job object. Type assertion to Job failed")
+		return nil, status.Error(codes.Internal, "unable to create Job object. Type assertion to Job failed")
 	}
 	result, err := a.k8s.CreateJob(ctx, req.Clientset, req.Cluster, req.Namespace, job)
 	if err != nil {

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -2,8 +2,10 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
@@ -149,11 +151,11 @@ func (m *managerImpl) Clientsets(ctx context.Context) (map[string]ContextClients
 func (m *managerImpl) GetK8sClientset(ctx context.Context, clientset, cluster, namespace string) (ContextClientset, error) {
 	cs, ok := m.clientsets[clientset]
 	if !ok {
-		return nil, errors.New("not found")
+		return nil, status.Errorf(codes.NotFound, "clientset '%s' not found", clientset)
 	}
 
 	if cluster != "" && cluster != cs.cluster {
-		return nil, errors.New("specified cluster does not match clientset")
+		return nil, status.Errorf(codes.InvalidArgument, "specified cluster '%s' does not match clientset '%s'", cluster, clientset)
 	}
 
 	// Shallow copy and update namespace.

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/backend/service/k8s/configmap.go
+++ b/backend/service/k8s/configmap.go
@@ -5,7 +5,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/backend/service/k8s/configmap.go
+++ b/backend/service/k8s/configmap.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
-	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,9 +29,9 @@ func (s *svc) DescribeConfigMap(ctx context.Context, clientset, cluster, namespa
 	if len(configMapList.Items) == 1 {
 		return protoForConfigMap(cs.Cluster(), &configMapList.Items[0]), nil
 	} else if len(configMapList.Items) > 1 {
-		return nil, fmt.Errorf("Located multiple configMaps with name %s", name)
+		return nil, status.Errorf(codes.FailedPrecondition, "located multiple config maps with name '%s'", name)
 	}
-	return nil, fmt.Errorf("Unable to locate configMap")
+	return nil, status.Error(codes.NotFound, "unable to locate specified config map")
 }
 
 func (s *svc) DeleteConfigMap(ctx context.Context, clientset, cluster, namespace, name string) error {

--- a/backend/service/k8s/cronjob.go
+++ b/backend/service/k8s/cronjob.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"strings"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/golang/protobuf/ptypes/wrappers"
 	v1beta1 "k8s.io/api/batch/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/backend/service/k8s/cronjob.go
+++ b/backend/service/k8s/cronjob.go
@@ -2,8 +2,10 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	v1beta1 "k8s.io/api/batch/v1beta1"
@@ -28,9 +30,9 @@ func (s *svc) DescribeCronJob(ctx context.Context, clientset, cluster, namespace
 	if len(cronJobs.Items) == 1 {
 		return ProtoForCronJob(cs.Cluster(), &cronJobs.Items[0]), nil
 	} else if len(cronJobs.Items) > 1 {
-		return nil, fmt.Errorf("Located multiple CronJobs")
+		return nil, status.Error(codes.FailedPrecondition, "located multiple cron jobs")
 	}
-	return nil, fmt.Errorf("Unable to locate cronJob")
+	return nil, status.Error(codes.NotFound, "unable to locate specified cron job")
 }
 
 func (s *svc) ListCronJobs(ctx context.Context, clientset, cluster, namespace string, listOptions *k8sapiv1.ListOptions) ([]*k8sapiv1.CronJob, error) {

--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
-	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,10 +31,10 @@ func (s *svc) DescribeDeployment(ctx context.Context, clientset, cluster, namesp
 	if len(deployments.Items) == 1 {
 		return ProtoForDeployment(cs.Cluster(), &deployments.Items[0]), nil
 	} else if len(deployments.Items) > 1 {
-		return nil, fmt.Errorf("Located multiple Deployments")
+		return nil, status.Error(codes.FailedPrecondition, "located multiple deployments")
 	}
 
-	return nil, fmt.Errorf("Unable to locate Deployment")
+	return nil, status.Error(codes.NotFound, "unable to locate specified deployment")
 }
 
 func (s *svc) ListDeployments(ctx context.Context, clientset, cluster, namespace string, listOptions *k8sapiv1.ListOptions) ([]*k8sapiv1.Deployment, error) {

--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -5,7 +5,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/backend/service/k8s/hpa.go
+++ b/backend/service/k8s/hpa.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
-	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,10 +29,10 @@ func (s *svc) DescribeHPA(ctx context.Context, clientset, cluster, namespace, na
 	if len(hpas.Items) == 1 {
 		return ProtoForHPA(cs.Cluster(), &hpas.Items[0]), nil
 	} else if len(hpas.Items) > 1 {
-		return nil, fmt.Errorf("Located multiple HPAs")
+		return nil, status.Error(codes.FailedPrecondition, "located multiple HPAs")
 	}
 
-	return nil, fmt.Errorf("Unable to locate HPA")
+	return nil, status.Error(codes.NotFound, "unable to locate specified HPA")
 }
 
 func ProtoForHPA(cluster string, autoscaler *autoscalingv1.HorizontalPodAutoscaler) *k8sapiv1.HPA {

--- a/backend/service/k8s/hpa.go
+++ b/backend/service/k8s/hpa.go
@@ -5,7 +5,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"

--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -2,9 +2,10 @@ package k8s
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,9 +29,9 @@ func (s *svc) DescribePod(ctx context.Context, clientset, cluster, namespace, na
 	if len(pods.Items) == 1 {
 		return podDescription(&pods.Items[0], cs.Cluster()), nil
 	} else if len(pods.Items) > 1 {
-		return nil, fmt.Errorf("Located multiple Pods")
+		return nil, status.Error(codes.FailedPrecondition, "located multiple pods")
 	}
-	return nil, fmt.Errorf("Unable to locate pod")
+	return nil, status.Error(codes.NotFound, "unable to locate specified pod")
 }
 
 func (s *svc) DeletePod(ctx context.Context, clientset, cluster, namespace, name string) error {
@@ -73,7 +74,7 @@ func (s *svc) ListPods(ctx context.Context, clientset, cluster, namespace string
 // TODO: add support for updating pod labels
 func (s *svc) UpdatePod(ctx context.Context, clientset, cluster, namespace, name string, expectedObjectMetaFields *k8sapiv1.ExpectedObjectMetaFields, objectMetaFields *k8sapiv1.ObjectMetaFields, removeObjectMetaFields *k8sapiv1.RemoveObjectMetaFields) error {
 	if len(objectMetaFields.GetLabels()) > 0 || len(removeObjectMetaFields.GetLabels()) > 0 {
-		return errors.New("update of pod labels not implemented")
+		return status.Error(codes.InvalidArgument, "update of pod labels not implemented")
 	}
 
 	// Ensure that the caller is not trying to delete an annotation and update it at the same time
@@ -81,7 +82,7 @@ func (s *svc) UpdatePod(ctx context.Context, clientset, cluster, namespace, name
 	for _, annotation := range removeObjectMetaFields.GetAnnotations() {
 		_, annotationIsUpdated := newAnnotations[annotation]
 		if annotationIsUpdated {
-			return fmt.Errorf("annotation '%s' can't be updated and removed at once", annotation)
+			return status.Errorf(codes.InvalidArgument, "annotation '%s' can't be updated and removed at once", annotation)
 		}
 	}
 
@@ -120,7 +121,7 @@ func (s *svc) UpdatePod(ctx context.Context, clientset, cluster, namespace, name
 
 func (s *svc) checkExpectedObjectMetaFields(expectedObjectMetaFields *k8sapiv1.ExpectedObjectMetaFields, object metav1.Object) error {
 	if len(expectedObjectMetaFields.Labels) > 0 {
-		return errors.New("checking label expectations not implemented")
+		return status.Error(codes.InvalidArgument, "checking label expectations not implemented")
 	}
 
 	podAnnotations := object.GetAnnotations()

--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -6,7 +6,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/backend/service/k8s/service.go
+++ b/backend/service/k8s/service.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
-	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/iancoleman/strcase"
 	corev1 "k8s.io/api/core/v1"
@@ -27,9 +29,9 @@ func (s *svc) DescribeService(ctx context.Context, clientset, cluster, namespace
 	if len(services.Items) == 1 {
 		return ProtoForService(cs.Cluster(), &services.Items[0]), nil
 	} else if len(services.Items) > 1 {
-		return nil, fmt.Errorf("Located multiple Services")
+		return nil, status.Error(codes.FailedPrecondition, "located multiple services")
 	}
-	return nil, fmt.Errorf("Unable to locate service")
+	return nil, status.Error(codes.NotFound, "unable to locate specified service")
 }
 
 func (s *svc) DeleteService(ctx context.Context, clientset, cluster, namespace, name string) error {

--- a/backend/service/k8s/service.go
+++ b/backend/service/k8s/service.go
@@ -3,10 +3,9 @@ package k8s
 import (
 	"context"
 
+	"github.com/iancoleman/strcase"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/iancoleman/strcase"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/backend/service/k8s/statefulset.go
+++ b/backend/service/k8s/statefulset.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
-	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,10 +31,10 @@ func (s *svc) DescribeStatefulSet(ctx context.Context, clientset, cluster, names
 	if len(statefulSets.Items) == 1 {
 		return ProtoForStatefulSet(cs.Cluster(), &statefulSets.Items[0]), nil
 	} else if len(statefulSets.Items) > 1 {
-		return nil, fmt.Errorf("Located multiple StatefulSets")
+		return nil, status.Error(codes.FailedPrecondition, "located multiple stateful sets")
 	}
 
-	return nil, fmt.Errorf("Unable to locate StatefulSet")
+	return nil, status.Error(codes.NotFound, "unable to locate specified stateful set")
 }
 
 func (s *svc) ListStatefulSets(ctx context.Context, clientset, cluster, namespace string, listOptions *k8sapiv1.ListOptions) ([]*k8sapiv1.StatefulSet, error) {

--- a/backend/service/k8s/statefulset.go
+++ b/backend/service/k8s/statefulset.go
@@ -5,7 +5,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Replaces all uses of `fmt.Errorf` and `errors.New` in the `k8s` service and module with their proper gRPC status and code.

This will ensure accurate metrics and sensible error information is displayed to the user.

### Testing Performed
Manual audit.