### PR TITLE
topology: alter table add composite primary key

### DIFF
--- a/backend/cmd/migrate/migrations/000008_topology_cache_add_composite_key.down.sql
+++ b/backend/cmd/migrate/migrations/000008_topology_cache_add_composite_key.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE topology_cache DROP CONSTRAINT topology_cache_pkey;
+ALTER TABLE topology_cache ADD CONSTRAINT topology_cache_id_key UNIQUE (id);

--- a/backend/cmd/migrate/migrations/000008_topology_cache_add_composite_key.up.sql
+++ b/backend/cmd/migrate/migrations/000008_topology_cache_add_composite_key.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE topology_cache DROP CONSTRAINT topology_cache_id_key;
+ALTER TABLE topology_cache ADD PRIMARY KEY (id, resolver_type_url);


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The unique identifier of `id` is not enough to uniquely identify a resource in kubernetes. Even if we are using the protos object pattern for example deployment. https://github.com/lyft/clutch/blob/a2e4ac8644837a1260b39c7c7c2e20cac465c85c/api/k8s/v1/k8s.proto#L406

This lacks information about which is resource type the `id` belongs to. In Kubernetes it's a common pattern to name primitives the same. For example a deployment and HPA can both be named `clutch`.

This change makes a composite key on `id` and the `resolver_type_url` which allows the cache to have duplicated `id` names for different resource types.

As an example we have many deployments and HPA's named the same, with this change this is how the data now looks.
```
clutch=# select id, resolver_type_url from topology_cache;
                         id                         |              resolver_type_url
----------------------------------------------------+----------------------------------------------
 clutch-production                                  | type.googleapis.com/clutch.k8s.v1.HPA
 clutch-staging                                     | type.googleapis.com/clutch.k8s.v1.HPA
 envoy-production                                   | type.googleapis.com/clutch.k8s.v1.HPA

 clutch-production                                  | type.googleapis.com/clutch.k8s.v1.Deployment
 clutch-staging                                     | type.googleapis.com/clutch.k8s.v1.Deployment
 envoy-production                                   | type.googleapis.com/clutch.k8s.v1.Deployment
 ```

To verify for the reader, you can see the new composite primary key is set.
```
clutch=# \d topology_cache;
                          Table "public.topology_cache"
      Column       |            Type             | Collation | Nullable | Default
-------------------+-----------------------------+-----------+----------+---------
 id                | character varying           |           | not null |
 data              | jsonb                       |           |          |
 resolver_type_url | character varying           |           | not null |
 metadata          | jsonb                       |           |          |
 updated_at        | timestamp without time zone |           |          | now()
Indexes:
    "topology_cache_pkey" PRIMARY KEY, btree (id, resolver_type_url)
    "topology_cache_id_search_idx" btree (id varchar_pattern_ops)
    "topology_cache_metadata_idx" gin (metadata jsonb_path_ops)
```


### Testing Performed
locally.

 DB up
```
➜  docker-compose down && docker-compose up -d && go run migrate.go -c ../../clutch-config.yaml
Stopping clutch_db_1 ... done
Removing clutch_db_1 ... done
Creating clutch_db_1 ... done
2021-02-25T21:26:34.654-0800	INFO	migrate/migrate.go:129	using migration table	{"migrationTable": "schema_migrations"}
2021-02-25T21:26:34.665-0800	INFO	migrate/migrate.go:149	using migration directory	{"migrationDir": "/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/cmd/migrate/migrations", "absoluteMigrationDir": "/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/cmd/migrate/migrations"}
2021-02-25T21:26:34.666-0800	INFO	migrate/migrate.go:97	using database	{"hostInfo": "clutch@0.0.0.0:5432"}
2021-02-25T21:26:34.666-0800	WARN	migrate/migrate.go:99	migration has the potential to cause irrevocable data loss, verify information above

*** Continue with migration? [y/N] y

2021-02-25T21:26:38.025-0800	INFO	migrate/migrate.go:172	applying up migrations
2021-02-25T21:26:38.031-0800	INFO	migrate/migrate.go:49	Start buffering 1/u create_audit_event_table
2021-02-25T21:26:38.031-0800	INFO	migrate/migrate.go:49	Start buffering 2/u create_experiments_table
2021-02-25T21:26:38.031-0800	INFO	migrate/migrate.go:49	Start buffering 3/u add_audit_pending_column
2021-02-25T21:26:38.031-0800	INFO	migrate/migrate.go:49	Start buffering 4/u experiments_schema_changes
2021-02-25T21:26:38.031-0800	INFO	migrate/migrate.go:49	Start buffering 5/u create_topology_cache_table
2021-02-25T21:26:38.032-0800	INFO	migrate/migrate.go:49	Start buffering 6/u experimentation_add_canceled_at_column
2021-02-25T21:26:38.032-0800	INFO	migrate/migrate.go:49	Start buffering 7/u authn_tokens_create
2021-02-25T21:26:38.032-0800	INFO	migrate/migrate.go:49	Start buffering 8/u topology_cache_add_composite_key
2021-02-25T21:26:38.045-0800	INFO	migrate/migrate.go:49	Read and execute 1/u create_audit_event_table
2021-02-25T21:26:38.065-0800	INFO	migrate/migrate.go:49	Finished 1/u create_audit_event_table (read 13.632436ms, ran 20.166368ms)
2021-02-25T21:26:38.072-0800	INFO	migrate/migrate.go:49	Read and execute 2/u create_experiments_table
2021-02-25T21:26:38.085-0800	INFO	migrate/migrate.go:49	Finished 2/u create_experiments_table (read 41.003732ms, ran 12.46344ms)
2021-02-25T21:26:38.095-0800	INFO	migrate/migrate.go:49	Read and execute 3/u add_audit_pending_column
2021-02-25T21:26:38.106-0800	INFO	migrate/migrate.go:49	Finished 3/u add_audit_pending_column (read 63.608423ms, ran 11.356966ms)
2021-02-25T21:26:38.113-0800	INFO	migrate/migrate.go:49	Read and execute 4/u experiments_schema_changes
2021-02-25T21:26:38.134-0800	INFO	migrate/migrate.go:49	Finished 4/u experiments_schema_changes (read 81.677809ms, ran 20.565782ms)
2021-02-25T21:26:38.140-0800	INFO	migrate/migrate.go:49	Read and execute 5/u create_topology_cache_table
2021-02-25T21:26:38.154-0800	INFO	migrate/migrate.go:49	Finished 5/u create_topology_cache_table (read 108.54879ms, ran 14.161529ms)
2021-02-25T21:26:38.160-0800	INFO	migrate/migrate.go:49	Read and execute 6/u experimentation_add_canceled_at_column
2021-02-25T21:26:38.168-0800	INFO	migrate/migrate.go:49	Finished 6/u experimentation_add_canceled_at_column (read 128.533494ms, ran 7.65722ms)
2021-02-25T21:26:38.174-0800	INFO	migrate/migrate.go:49	Read and execute 7/u authn_tokens_create
2021-02-25T21:26:38.186-0800	INFO	migrate/migrate.go:49	Finished 7/u authn_tokens_create (read 141.891846ms, ran 12.06928ms)
2021-02-25T21:26:38.193-0800	INFO	migrate/migrate.go:49	Read and execute 8/u topology_cache_add_composite_key
2021-02-25T21:26:38.203-0800	INFO	migrate/migrate.go:49	Finished 8/u topology_cache_add_composite_key (read 161.652155ms, ran 9.253367ms)
```

DB Down to test down script
```
➜  go run migrate.go -down -c ../../clutch-config.yaml
2021-02-25T21:26:55.155-0800	INFO	migrate/migrate.go:129	using migration table	{"migrationTable": "schema_migrations"}
2021-02-25T21:26:55.163-0800	INFO	migrate/migrate.go:149	using migration directory	{"migrationDir": "/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/cmd/migrate/migrations", "absoluteMigrationDir": "/Users/mcutalo/gocode/src/github.com/lyft/clutch/backend/cmd/migrate/migrations"}
2021-02-25T21:26:55.165-0800	INFO	migrate/migrate.go:97	using database	{"hostInfo": "clutch@0.0.0.0:5432"}
2021-02-25T21:26:55.165-0800	WARN	migrate/migrate.go:99	Migrating DOWN by ONE version from (8 -> 7) this migration has the potential to cause irrevocable data loss, verify host information above

*** Continue with migration? [y/N] y

2021-02-25T21:27:00.769-0800	INFO	migrate/migrate.go:193	applying migrations down
2021-02-25T21:27:00.775-0800	INFO	migrate/migrate.go:49	Start buffering 8/d topology_cache_add_composite_key
2021-02-25T21:27:00.794-0800	INFO	migrate/migrate.go:49	Read and execute 8/d topology_cache_add_composite_key
2021-02-25T21:27:00.808-0800	INFO	migrate/migrate.go:49	Finished 8/d topology_cache_add_composite_key (read 19.762481ms, ran 13.444147ms)
```