### PR TITLE
ci: stale bot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,7 @@ on:
     - cron: '0 15,22 * * 1-5'
 jobs:
   check_stale:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3
       with:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+jobs:
+  check_stale:
+    steps:
+    - uses: actions/stale@v3
+      with:
+        debug-only: true # dry run
+        days-before-stale: 7
+        days-before-close: 3
+        exempt-pr-labels: 'on hold'
+        stale-pr-message: >
+          This PR has been marked as stale after 7 days of inactivity.
+          Please have a maintainer add the `on hold` label if this PR should remain open.
+          If there is no further activity or the `on hold` label is not added, this PR will be closed in 3 days.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 */4 * * *'
 jobs:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 15,22 * * 1-5'
 jobs:
   check_stale:
     steps:
@@ -12,6 +12,6 @@ jobs:
         days-before-close: 3
         exempt-pr-labels: 'on hold'
         stale-pr-message: >
-          This PR has been marked as stale after 7 days of inactivity.
+          This PR has been marked as stale after 7 or more days of inactivity.
           Please have a maintainer add the `on hold` label if this PR should remain open.
           If there is no further activity or the `on hold` label is not added, this PR will be closed in 3 days.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Close stale PRs after a week of inactivity unless they have the `on hold` label. This will make it easier to see what PRs are active at a glance.

### Testing Performed
Can perform manual run in dry run mode after merge.