### PR TITLE
tools: fix scaffolding compat with go 1.16

### DIFF
--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -29,5 +29,3 @@ jobs:
       - name: build scaffolding
         run: make
         working-directory: ${{ github.workspace }}/go/src/github.com/runner/clutch-custom-gateway
-        env:
-          GOFLAGS: -mod=mod # allow modules file to update itself based on actual dependencies for first compile

--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -29,3 +29,5 @@ jobs:
       - name: build scaffolding
         run: make
         working-directory: ${{ github.workspace }}/go/src/github.com/runner/clutch-custom-gateway
+        env:
+          GOFLAGS: -mod=mod # allow modules file to update itself based on actual dependencies for first compile

--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -8,7 +8,7 @@ TOOLS_MODULE_DIR := $(shell cd backend && go list -f "{{ "{{" }} .Dir {{ "}}" }}
 MY_ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: all # Generate API, Frontend, and backend assets.
-all: api frontend backend-with-assets
+all: api frontend backend-tidy backend-with-assets
 
 .PHONY: api
 api: yarn-ensure
@@ -25,6 +25,9 @@ backend-dev:
 .PHONY: backend-test
 backend-test:
 	cd backend && go test -race -covermode=atomic ./...
+
+backend-tidy:
+	cd backend && go mod tidy
 
 .PHONY: backend-with-assets
 backend-with-assets: frontend

--- a/tools/scaffolding/templates/gateway/backend/tools.go
+++ b/tools/scaffolding/templates/gateway/backend/tools.go
@@ -5,5 +5,13 @@
 package tools
 
 import (
+	_ "github.com/bufbuild/buf/cmd/protoc-gen-buf-check-lint"
+	_ "github.com/envoyproxy/protoc-gen-validate"
+	_ "github.com/fullstorydev/grpcurl"
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
 	_ "github.com/lyft/clutch/tools"
+	_ "github.com/shurcooL/vfsgen"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )

--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -18,7 +18,7 @@
     "upgrade": "yarn upgrade"
   },
   "dependencies": {
-    "protobufjs": "https://github.com/natiz/protobuf.js#1d626f84db4a4f339004609f654a9f24a211b716"
+    "protobufjs": "6.10.2"
   },
   "devDependencies": {
     "lerna": "^3.20.0",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Fixes scaffolding compatibility with go 1.16, which changed the default for `go` commands from `-mod=mod` to `-mod=readonly`.

### Testing Performed
Local, CI on main only.
