### PR TITLE
ci: use cache for docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           tags: ${{ steps.tags.outputs.tags }}
           push: true
+          cache-from: type=registry,ref=lyft/clutch:latest


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Uses cached layers from the registry.

### Testing Performed
CI, only runs on main.