### PR TITLE
aws: error converter and interceptor

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
+	github.com/aws/smithy-go v1.1.0
 	github.com/bufbuild/buf v0.30.0
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200623234511-94959e3146b2
 	github.com/coreos/go-oidc/v3 v3.0.0

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -120,6 +120,11 @@ type regionalClient struct {
 	autoscaling autoscalingClient
 }
 
+// Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.
+func (c *client) InterceptError(e error) error {
+	return ConvertError(e)
+}
+
 func (c *client) ResizeAutoscalingGroup(ctx context.Context, region string, name string, size *ec2v1.AutoscalingGroupSize) error {
 	rc, ok := c.clients[region]
 	if !ok {

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -6,10 +6,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/aws/smithy-go"
-	"google.golang.org/grpc/status"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -7,16 +7,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/smithy-go"
+	"google.golang.org/grpc/status"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc/status"
 
 	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
 	awsv1 "github.com/lyft/clutch/backend/api/config/service/aws/v1"
@@ -341,6 +346,21 @@ func TestDescribeAutoscalingGroupsErrorHandling(t *testing.T) {
 	asg2, err2 := c.DescribeAutoscalingGroups(context.Background(), "unknown-region", []string{"asgname"})
 	assert.Nil(t, asg2)
 	assert.Error(t, err2)
+}
+
+func TestErrorIntercept(t *testing.T) {
+	c := &client{}
+	{
+		origErr := newResponseError(400, &smithy.GenericAPIError{Code: "whoopsie", Message: "bad"})
+		err := c.InterceptError(origErr)
+		_, ok := status.FromError(err)
+		assert.True(t, ok)
+	}
+	{
+		origErr := errors.New("foo")
+		err := c.InterceptError(origErr)
+		assert.Equal(t, origErr, err)
+	}
 }
 
 type mockEC2 struct {

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"

--- a/backend/service/aws/error.go
+++ b/backend/service/aws/error.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/smithy-go"
+	"google.golang.org/grpc/status"
+
+	"github.com/lyft/clutch/backend/service"
+)
+
+// Use error handling techniques outlined in https://aws.github.io/aws-sdk-go-v2/docs/handling-errors/
+// to extract embedded HTTP status information and error messages from AWS SDK errors and create the
+// corresponding gRPC status.
+func ConvertError(e error) error {
+	// Extract HTTP status details.
+	var re *awshttp.ResponseError
+	if !errors.As(e, &re) {
+		return e
+	}
+	code := service.CodeFromHTTPStatus(re.Response.StatusCode)
+
+	// Extract AWS API error details.
+	var msg string
+	var ae smithy.APIError
+	if errors.As(re.Err, &ae) {
+		// e.g. InvalidAccessKeyId: The key you provided does not exist in the database.
+		msg = fmt.Sprintf("%s: %s", ae.ErrorCode(), ae.ErrorMessage())
+	} else {
+		// Use the original error message if APIError not found, though it should never happen.
+		msg = e.Error()
+	}
+
+	// TODO: unpack remaining error information, e.g. AWS request ID into error details.
+	return status.Error(code, msg)
+}

--- a/backend/service/aws/error_test.go
+++ b/backend/service/aws/error_test.go
@@ -1,0 +1,70 @@
+package aws
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/lyft/clutch/backend/middleware/errorintercept"
+)
+
+func TestImplementsInterceptorInterface(t *testing.T) {
+	assert.Implements(t, (*errorintercept.Interceptor)(nil), (*client)(nil))
+}
+
+func TestConvertError(t *testing.T) {
+	re := &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{
+				Response: &http.Response{
+					StatusCode: 401,
+				},
+			},
+			Err: &smithy.GenericAPIError{Code: "whoopsie", Message: "bad things happened"},
+		},
+		RequestID: "amzrequestid",
+	}
+
+	e := ConvertError(re)
+
+	s, ok := status.FromError(e)
+	assert.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, s.Code())
+}
+
+func TestConvertErrorNoEmbeddedAPIError(t *testing.T) {
+	origErr := errors.New("something went wrong")
+	re := &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{
+				Response: &http.Response{
+					StatusCode: 401,
+				},
+			},
+			Err: origErr,
+		},
+		RequestID: "amzrequestid",
+	}
+
+	e := ConvertError(re)
+
+	s, ok := status.FromError(e)
+	assert.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, s.Code())
+	assert.Equal(t, s.Message(), re.Error())
+}
+
+func TestConvertErrorNotAWSError(t *testing.T) {
+	e := errors.New("whoopsie")
+	s := ConvertError(e)
+	_, ok := status.FromError(s)
+	assert.False(t, ok)
+	assert.Equal(t, e, s)
+}

--- a/backend/service/aws/error_test.go
+++ b/backend/service/aws/error_test.go
@@ -42,6 +42,7 @@ func TestConvertError(t *testing.T) {
 	s, ok := status.FromError(e)
 	assert.True(t, ok)
 	assert.Equal(t, codes.Unauthenticated, s.Code())
+	assert.Equal(t, "whoopsie: bad things happened", s.Message())
 }
 
 func TestConvertErrorNoEmbeddedAPIError(t *testing.T) {

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -128,6 +128,7 @@ func (s *svc) Clientsets(ctx context.Context) ([]string, error) {
 	return ret, nil
 }
 
+// Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.
 func (s *svc) InterceptError(e error) error {
 	return ConvertError(e)
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Extract the code and relevant message from AWS SDK errors rather than returning the stringified error with all of the information as an unknown error.

**Before:**
- **`Code 2 (UNKNOWN)`**
- `{"code": 2, "message": "operation error S3: GetObject, https response error StatusCode: 403, RequestID: DSFEFFCCWE7, HostID: O5ErieRNfwEFWEJFIWJEFIWJEFWCJJCCJCJCIWJECICJWEOCWECJW3ZHDCrc=, api error InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records."}`

**After:**
- **`Code 7 (PERMISSION_DENIED)`**
- `{"code": 7, "message":"InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records."}`

### Testing Performed
Unit and manual integration.