### PR TITLE
slacksink: Add transformer to parse custom slack msg and audit event metadata

### DIFF
--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -117,7 +117,7 @@ func parseFile(path string, pb proto.Message, template bool) error {
 
 		Solution is to use Clutch-specific templating tokens in the config that are then replaced
 		with the Go Template synax
-		1) $$ in lieu $
+		1) $$ in lieu of $
 		2) [[ ]] in lieu of {{ }}
 	*/
 

--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -106,16 +106,17 @@ func parseFile(path string, pb proto.Message, template bool) error {
 		}
 	}
 
-	contents = []byte(processContents(contents))
+	// Interpolate environment variables
+	expandedData := os.ExpandEnv(string(contents))
+
+	contents = []byte(processTemplateToken(expandedData))
 
 	return parseYAML(contents, pb)
 }
 
-func processContents(contents []byte) string {
-	// Interpolate environment variables
-	expandedData := os.ExpandEnv(string(contents))
-	// Replace the Clutch-specific templating token with the Go $ templating token
-	return strings.ReplaceAll(expandedData, "%%", "$")
+// Replace the Clutch-specific templating token with the Go $ template syntax
+func processTemplateToken(data string) string {
+	return strings.ReplaceAll(data, "%%", "$")
 }
 
 func parseYAML(contents []byte, pb proto.Message) error {

--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
 	"time"
 
@@ -105,10 +106,16 @@ func parseFile(path string, pb proto.Message, template bool) error {
 		}
 	}
 
-	// Interpolate environment variables.
-	contents = []byte(os.ExpandEnv(string(contents)))
+	contents = []byte(processContents(contents))
 
 	return parseYAML(contents, pb)
+}
+
+func processContents(contents []byte) string {
+	// Interpolate environment variables
+	expandedData := os.ExpandEnv(string(contents))
+	// Replace the Clutch-specific templating token with the Go $ templating token
+	return strings.ReplaceAll(expandedData, "%%", "$")
 }
 
 func parseYAML(contents []byte, pb proto.Message) error {

--- a/backend/gateway/config_test.go
+++ b/backend/gateway/config_test.go
@@ -125,15 +125,30 @@ func TestComputeMaximumTimeout(t *testing.T) {
 	}
 }
 
-func TestProcessTemplateToken(t *testing.T) {
+func TestReplaceClutchTokens(t *testing.T) {
 	config := `
 	foo: bar
-	message: {{range %%v, %%k := .Bar}}{{%%k}}: {{%%v}}{{end}}
+	message: [[range $$v, $$k := .Bar]][[$$k]]: [[$$v]][[end]]
 	`
+	expected := `
+	foo: bar
+	message: {{range @#@v, @#@k := .Bar}}{{@#@k}}: {{@#@v}}{{end}}
+	`
+	contents := replaceClutchTokens(config)
+	assert.Equal(t, expected, contents)
+}
+
+func TestReplaceToken(t *testing.T) {
+	config := `
+	foo: bar
+	message: {{range @#@v, @#@k := .Bar}}{{@#@k}}: {{@#@v}}{{end}}
+	`
+
 	expected := `
 	foo: bar
 	message: {{range $v, $k := .Bar}}{{$k}}: {{$v}}{{end}}
 	`
-	contents := processTemplateToken(config)
+
+	contents := replaceToken(config, "@#@", "$")
 	assert.Equal(t, expected, contents)
 }

--- a/backend/gateway/config_test.go
+++ b/backend/gateway/config_test.go
@@ -138,7 +138,7 @@ func TestBulkReplaceTemplateTokens(t *testing.T) {
 	assert.Equal(t, expected, contents)
 }
 
-func TestReplaceToken(t *testing.T) {
+func TestReplaceVarTemplateToken(t *testing.T) {
 	config := `
 	foo: bar
 	message: {{range @#@v, @#@k := .Bar}}{{@#@k}}: {{@#@v}}{{end}}

--- a/backend/gateway/config_test.go
+++ b/backend/gateway/config_test.go
@@ -124,3 +124,16 @@ func TestComputeMaximumTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessTemplateToken(t *testing.T) {
+	config := `
+	foo: bar
+	message: {{range %%v, %%k := .Bar}}{{%%k}}: {{%%v}}{{end}}
+	`
+	expected := `
+	foo: bar
+	message: {{range $v, $k := .Bar}}{{$k}}: {{$v}}{{end}}
+	`
+	contents := processTemplateToken(config)
+	assert.Equal(t, expected, contents)
+}

--- a/backend/gateway/config_test.go
+++ b/backend/gateway/config_test.go
@@ -125,7 +125,7 @@ func TestComputeMaximumTimeout(t *testing.T) {
 	}
 }
 
-func TestReplaceClutchTokens(t *testing.T) {
+func TestBulkReplaceTemplateTokens(t *testing.T) {
 	config := `
 	foo: bar
 	message: [[range $$v, $$k := .Bar]][[$$k]]: [[$$v]][[end]]
@@ -134,7 +134,7 @@ func TestReplaceClutchTokens(t *testing.T) {
 	foo: bar
 	message: {{range @#@v, @#@k := .Bar}}{{@#@k}}: {{@#@v}}{{end}}
 	`
-	contents := replaceClutchTokens(config)
+	contents := bulkReplaceTemplateTokens(config)
 	assert.Equal(t, expected, contents)
 }
 
@@ -149,6 +149,6 @@ func TestReplaceToken(t *testing.T) {
 	message: {{range $v, $k := .Bar}}{{$k}}: {{$v}}{{end}}
 	`
 
-	contents := replaceToken(config, "@#@", "$")
+	contents := replaceVarTemplateToken(config)
 	assert.Equal(t, expected, contents)
 }

--- a/backend/service/auditsink/slack/slack.go
+++ b/backend/service/auditsink/slack/slack.go
@@ -189,7 +189,7 @@ func slackList(data interface{}, name string) (string, error) {
 
 func resolveSlice(list protoreflect.List) string {
 	var text string
-	const listFormat = "\n%v"
+	const listFormat = "\n- %v"
 
 	for i := 0; i < list.Len(); i++ {
 		v := list.Get(i)
@@ -200,7 +200,7 @@ func resolveSlice(list protoreflect.List) string {
 
 func resolveMap(mapValue protoreflect.Map) string {
 	var text string
-	const mapFormat = "\n%v: %v"
+	const mapFormat = "\n- %v: %v"
 
 	mapValue.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
 		var value interface{}

--- a/backend/service/auditsink/slack/slack.go
+++ b/backend/service/auditsink/slack/slack.go
@@ -56,7 +56,7 @@ type auditTemplateData struct {
 // TODO: (sperry) expand on helper funcs
 // helper functions to format values in the Go template
 var funcMap = template.FuncMap{
-	// for inputs that are type slice/map, returns a formatted slack list OR `N/A` if the slice/map is empty
+	// for inputs that are type slice/map, returns a formatted slack list
 	// currently only iterates 1-level deep
 	"slackList": slackList,
 }
@@ -128,7 +128,7 @@ func formatText(username string, event *auditv1.RequestEvent) string {
 	return messageText
 }
 
-// FormatCustomText parses out the audit event metdata request for the custom slack message text
+// FormatCustomText applies the audit event metadata to the custom slack message
 func FormatCustomText(message string, event *auditv1.RequestEvent) (string, error) {
 	tmpl, err := template.New("customText").Funcs(funcMap).Parse(message)
 	if err != nil {

--- a/backend/service/auditsink/slack/slack.go
+++ b/backend/service/auditsink/slack/slack.go
@@ -5,13 +5,18 @@ package slack
 // <!-- END clutchdoc -->
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"text/template"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/slack-go/slack"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"
 	auditconfigv1 "github.com/lyft/clutch/backend/api/config/service/audit/v1"
@@ -36,6 +41,18 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 		channel: config.Channel,
 	}
 	return s, nil
+}
+
+// The struct is used in a Go template and the fields need to be exported
+type auditEventMetadata struct {
+	Request  proto.Message
+	Response proto.Message
+}
+
+// helper functions to format values in the Go template
+var funcMap = template.FuncMap{
+	// for values that are type List or Map, returns a formatted slack list
+	"slackList": slackList,
 }
 
 type svc struct {
@@ -103,4 +120,99 @@ func formatText(username string, event *auditv1.RequestEvent) string {
 	}
 
 	return messageText
+}
+
+// FormatCustomText parses out the audit event metdata request for the custom slack message text
+func FormatCustomText(message string, event *auditv1.RequestEvent) (string, error) {
+	tmpl := template.Must(template.New("customText").Funcs(funcMap).Parse(message))
+
+	data, err := getAuditMetadata(event)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// returns the API request/response details contained in a audit event
+func getAuditMetadata(event *auditv1.RequestEvent) (*auditEventMetadata, error) {
+	requestMetadata := event.RequestMetadata.Body
+	// UnmarshalNew returns the message of the specified type based on the TypeURL
+	requestProto, err := requestMetadata.UnmarshalNew()
+	if err != nil {
+		return nil, err
+	}
+
+	responseMetdata := event.ResponseMetadata.Body
+	responseProto, err := responseMetdata.UnmarshalNew()
+	if err != nil {
+		return nil, err
+	}
+
+	return &auditEventMetadata{
+		Request:  requestProto,
+		Response: responseProto,
+	}, nil
+}
+
+func slackList(data interface{}, name string) (string, error) {
+	pb, ok := data.(proto.Message)
+	if !ok {
+		// not the type we can process
+		return "", errors.New("could not use input as proto message")
+	}
+	m := pb.ProtoReflect()
+
+	fd := m.Descriptor().Fields().ByName(protoreflect.Name(name))
+	if fd == nil {
+		// didn't find field by name
+		return "", errors.New("could not find field by name")
+	}
+
+	v := m.Get(fd)
+
+	if fd.IsList() {
+		return resolveSlice(v.List()), nil
+	}
+
+	if fd.IsMap() {
+		return resolveMap(v.Map()), nil
+	}
+
+	return "", errors.New("input is not type List or Map")
+}
+
+func resolveSlice(list protoreflect.List) string {
+	var text string
+	const listFormat = "\n%v"
+
+	for i := 0; i < list.Len(); i++ {
+		v := list.Get(i)
+		text += fmt.Sprintf(listFormat, v.Interface())
+	}
+	return text
+}
+
+func resolveMap(mapValue protoreflect.Map) string {
+	var text string
+	const mapFormat = "\n%v: %v"
+
+	mapValue.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		var value interface{}
+		switch v.Interface().(type) {
+		case protoreflect.Message:
+			value = v.Message().Interface()
+		default:
+			value = v.Interface()
+		}
+
+		text += fmt.Sprintf(mapFormat, k.Interface(), value)
+		return true
+	})
+	return text
 }

--- a/backend/service/auditsink/slack/slack.go
+++ b/backend/service/auditsink/slack/slack.go
@@ -142,8 +142,8 @@ func FormatCustomText(message string, event *auditv1.RequestEvent) (string, erro
 		return "", err
 	}
 
-	// When a value is nil, the Go Template returns "<no value>" in its place. Replacing this with null instead.
-	// We hit this scenario with https://github.com/lyft/clutch/blob/main/api/k8s/v1/k8s.proto#L860
+	// When a value is nil, the Go Template sets the value as "<no value>".
+	// Ex of when we hit this scenario: https://github.com/lyft/clutch/blob/main/api/k8s/v1/k8s.proto#L860
 	sanitized := strings.ReplaceAll(buf.String(), "<no value>", "null")
 
 	return sanitized, nil
@@ -179,11 +179,12 @@ func getAuditTemplateData(event *auditv1.RequestEvent) (*auditTemplateData, erro
 	}, nil
 }
 
-// for inputs that are type slice/map, returns a formatted slack list OR "None" if the slice/map is empty
+// for inputs that are type slice/map, returns a formatted slack list
 func slackList(data interface{}) string {
 	if data == nil {
 		return "None"
 	}
+
 	var b strings.Builder
 	const sliceItemFormat = "\n- %v"
 	const mapItemFormat = "\n- %v: %v"

--- a/backend/service/auditsink/slack/slack_test.go
+++ b/backend/service/auditsink/slack/slack_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap/zaptest"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	apiv1 "github.com/lyft/clutch/backend/api/api/v1"
 	auditv1 "github.com/lyft/clutch/backend/api/audit/v1"
+	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
 	configv1 "github.com/lyft/clutch/backend/api/config/service/auditsink/slack/v1"
+	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
 	"github.com/lyft/clutch/backend/service/auditsink"
 )
 
@@ -50,4 +53,99 @@ func TestFormat(t *testing.T) {
 
 	actual := formatText(username, event)
 	assert.Equal(t, expected, actual)
+}
+
+// TODO: add more test cases (ie map and list)
+func TestFormatCustomText(t *testing.T) {
+	k8sRequest := &k8sapiv1.DescribePodRequest{Name: "foo"}
+	k8sResponse := &k8sapiv1.DescribePodResponse{Pod: &k8sapiv1.Pod{PodIp: "000"}}
+	anyK8sReq, _ := anypb.New(k8sRequest)
+	anyK8sResp, _ := anypb.New(k8sResponse)
+
+	ec2Request := &ec2v1.ResizeAutoscalingGroupRequest{Size: &ec2v1.AutoscalingGroupSize{Min: 2, Max: 4, Desired: 3}}
+	ec2Response := &ec2v1.ResizeAutoscalingGroupResponse{}
+	anyEc2Req, _ := anypb.New(ec2Request)
+	anyEc2Resp, _ := anypb.New(ec2Response)
+
+	testCases := []struct {
+		text           string
+		event          *auditv1.RequestEvent
+		expectedErr    bool
+		expectedOutput string
+	}{
+		{
+			text: "{{.Request.Name}} ip address is {{.Response.Pod.PodIp}}",
+			event: &auditv1.RequestEvent{
+				RequestMetadata:  &auditv1.RequestMetadata{Body: anyK8sReq},
+				ResponseMetadata: &auditv1.ResponseMetadata{Body: anyK8sResp},
+			},
+			expectedOutput: "foo ip address is 000",
+		},
+		{
+			text: "`Min size` is {{.Request.Size.Min}}, `Max size` is {{.Request.Size.Max}}, `Desired size` is {{.Request.Size.Desired}}",
+			event: &auditv1.RequestEvent{
+				RequestMetadata:  &auditv1.RequestMetadata{Body: anyEc2Req},
+				ResponseMetadata: &auditv1.ResponseMetadata{Body: anyEc2Resp},
+			},
+			expectedOutput: "`Min size` is 2, `Max size` is 4, `Desired size` is 3",
+		},
+		{
+			text: "Name is {{.Foo}}",
+			event: &auditv1.RequestEvent{
+				RequestMetadata:  &auditv1.RequestMetadata{Body: anyK8sReq},
+				ResponseMetadata: &auditv1.ResponseMetadata{Body: anyK8sResp},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		result, err := FormatCustomText(test.text, test.event)
+		if test.expectedErr {
+			assert.Error(t, err)
+			assert.Empty(t, result)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedOutput, result)
+		}
+	}
+}
+
+func TestGetAuditMetadata(t *testing.T) {
+	request := &k8sapiv1.DescribePodRequest{}
+	response := &k8sapiv1.DescribePodResponse{}
+
+	anyReq, _ := anypb.New(request)
+	anyResp, _ := anypb.New(response)
+
+	testCases := []struct {
+		event       *auditv1.RequestEvent
+		expectedErr bool
+	}{
+		{
+			event: &auditv1.RequestEvent{
+				RequestMetadata:  &auditv1.RequestMetadata{Body: anyReq},
+				ResponseMetadata: &auditv1.ResponseMetadata{Body: anyResp},
+			},
+		},
+		{
+			event: &auditv1.RequestEvent{
+				RequestMetadata:  &auditv1.RequestMetadata{Body: anyReq},
+				ResponseMetadata: &auditv1.ResponseMetadata{Body: (*anypb.Any)(nil)},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		result, err := getAuditMetadata(test.event)
+		if test.expectedErr {
+			assert.Error(t, err)
+			assert.Nil(t, result)
+		} else {
+			assert.NoError(t, err)
+			assert.IsType(t, request, result.Request)
+			assert.IsType(t, response, result.Response)
+		}
+	}
 }

--- a/backend/service/auditsink/slack/slack_test.go
+++ b/backend/service/auditsink/slack/slack_test.go
@@ -101,7 +101,7 @@ func TestFormatCustomText(t *testing.T) {
 			},
 			expectedOutput: "foo ip address is 000",
 		},
-		// metdata (labels) value is nil
+		// metadata (labels) value is nil
 		{
 			text: "{{.Request.name}} labels: {{slackList .Response.pod.labels}}",
 			event: &auditv1.RequestEvent{
@@ -119,7 +119,7 @@ func TestFormatCustomText(t *testing.T) {
 			},
 			expectedOutput: "*Updated labels*:\n- foo: new-value",
 		},
-		// metdata that is a list, uses helper slackList
+		// metadata that is a list, uses helper slackList
 		{
 			text: "*Removed annotations*:{{slackList .Request.removeObjectMetaFields.annotations}}",
 			event: &auditv1.RequestEvent{
@@ -128,7 +128,7 @@ func TestFormatCustomText(t *testing.T) {
 			},
 			expectedOutput: "*Removed annotations*:\n- foo\n- bar",
 		},
-		// metdata that is a map, map value is a another map
+		// metadata that is a map, map value is a another map
 		// uses the Golang template `range`
 		{
 			text: "*Expected Preconditions*:{{range $key, $val := .Request.expectedObjectMetaFields.annotations}}\n- {{$key}}: {{range $i, $j := $val}}{{$j}}{{end}}{{end}}",

--- a/backend/service/auditsink/slack/slack_test.go
+++ b/backend/service/auditsink/slack/slack_test.go
@@ -83,7 +83,7 @@ func TestFormatCustomText(t *testing.T) {
 		expectedErr    bool
 		expectedOutput string
 	}{
-		// metdata from the API request
+		// metadata from the API request
 		{
 			text: "`Min size` is {{.Request.size.min}}, `Max size` is {{.Request.size.max}}, `Desired size` is {{.Request.size.desired}}",
 			event: &auditv1.RequestEvent{
@@ -136,7 +136,7 @@ func TestFormatCustomText(t *testing.T) {
 				RequestMetadata:  &auditv1.RequestMetadata{Body: anyK8sUpdateReq},
 				ResponseMetadata: &auditv1.ResponseMetadata{Body: anyK8UpdateResp},
 			},
-			expectedOutput: "*Expected Preconditions*:\n- baz: null\n- foo: new-value",
+			expectedOutput: "*Expected Preconditions*:\n- baz: None\n- foo: new-value",
 		},
 		// invalid field name
 		{

--- a/backend/service/auditsink/slack/slack_test.go
+++ b/backend/service/auditsink/slack/slack_test.go
@@ -155,11 +155,10 @@ func TestSlackList(t *testing.T) {
 	testCases := []struct {
 		input          interface{}
 		expectedOutput string
-		expectedErr    bool
 	}{
 		{
-			input:       "hello",
-			expectedErr: true,
+			input:          "hello",
+			expectedOutput: "ERR_INPUT_NOT_SLICE_OR_MAP",
 		},
 		{
 			input:          []string{"foo"},
@@ -179,26 +178,21 @@ func TestSlackList(t *testing.T) {
 		},
 		{
 			input:          map[string]string{},
-			expectedOutput: "`N/A`",
+			expectedOutput: "None",
 		},
 		{
 			input:          []string{},
-			expectedOutput: "`N/A`",
+			expectedOutput: "None",
 		},
 	}
 
 	for _, test := range testCases {
-		result, err := slackList(test.input)
-		if test.expectedErr {
-			assert.Error(t, err)
-			assert.Empty(t, result)
-		} else {
-			assert.Equal(t, test.expectedOutput, result)
-		}
+		result := slackList(test.input)
+		assert.Equal(t, test.expectedOutput, result)
 	}
 }
 
-func TestGetAuditMetadata(t *testing.T) {
+func TestGetAuditTemplateData(t *testing.T) {
 	anyReq, _ := anypb.New(&k8sapiv1.DescribePodRequest{})
 	anyResp, _ := anypb.New(&k8sapiv1.DescribePodResponse{})
 
@@ -226,7 +220,7 @@ func TestGetAuditMetadata(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		result, err := getAuditMetadata(test.event)
+		result, err := getAuditTemplateData(test.event)
 		assert.NoError(t, err)
 		if test.expectedEmpty {
 			assert.Empty(t, result.Request)


### PR DESCRIPTION
### Description
PR adds logic to parse audit event metadata based on what's requested for the custom slack message. A separate PR https://github.com/lyft/clutch/pull/1089 updates the slack config to allow users to specify this custom slack message.

### Testing Performed
**Examples**:

**(1) Custom slack message for ResizeHPA wants metadata from the API request**
```
"*Min size*: [[.Request.sizing.min]]\n*Max size*: [[.Request.sizing.max]]"
```
slack message [preview](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22%60UNKNOWN%60%20performed%20%60ResizeHPA%60%20via%20%60clutch.k8s.v1.K8sAPI%60%20using%20Clutch%20on%20resource(s)%3A%5Cn-%20kind-clutch-local%2Fenvoy-staging%2Fenvoy%20(%60clutch.k8s.v1.HPA%60)%5Cn*Min%20size*%3A%201%5Cn*Max%20size*%3A%202%22%7D)
```
`UNKNOWN` performed `ResizeHPA` via `clutch.k8s.v1.K8sAPI` using Clutch on resource(s):
- kind-clutch-local/envoy-staging/envoy (`clutch.k8s.v1.HPA`)
`Min size` is 2 and `Max size` is 3
```

**(2) Custom slack message for DescribePod wants metadata from the API request AND response**
```
"Pod [[.Request.name]] status is `[[.Response.pod.state]]`"
```
slack message [preview](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22Pod%20envoy-958dcf4fc-2mztk%20status%20is%20%60RUNNING%60%22%7D)
```
...<default message>...
Pod envoy-958dcf4fc-2mztk status is `RUNNING`
```
**(3) Custom slack messages where the metadata requested is type Map or List**
Custom slack message for UpdateDeployment uses `slackList` helper to format a message
```
"*Updated labels*:[[slackList .Request.fields.labels]]"
```
slack message [preview](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22%60UNKNOWN%60%20performed%20%60UpdateDeployment%60%20via%20%60clutch.k8s.v1.K8sAPI%60%20using%20Clutch%20on%20resource(s)%3A%5Cn-%20kind-clutch-local%2Fenvoy-staging%2Fenvoy%20(%60clutch.k8s.v1.Deployment%60)%5Cn*Updated%20labels*%3A%5Cn-%20bar%3A%20value%5Cn-%20foo%3A%20value%22%7D)
```
`UNKNOWN` performed `UpdateDeployment` via `clutch.k8s.v1.K8sAPI` using Clutch on resource(s):
- kind-clutch-local/envoy-staging/envoy (`clutch.k8s.v1.Deployment`)
*Updated labels*:
- bar: value
- foo: value
```
Custom slack message for UpdatePod uses `slackList` helper and Go Template `range` to format a message
```
 "*Expected Preconditions*:[[range $$k, $$v := .Request.expectedObjectMetaFields.annotations]]
 \n- [[$$k]]: [[range $$i, $$j := $$v]][[$$j]][[end]][[end]]
 \n*Updated Annotations*:[[slackList .Request.objectMetaFields.annotations]]
 \n*Removed Annotations*:[[slackList .Request.removeObjectMetaFields.annotations]]"
```
slack message [preview](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22%60UNKNOWN%60%20performed%20%60UpdatePod%60%20via%20%60clutch.k8s.v1.K8sAPI%60%20using%20Clutch%20on%20resource(s)%3A%5Cn-%20kind-clutch-local%2Fenvoy-production%2Fenvoy-7784b58d-txdg2%20(%60clutch.k8s.v1.Pod%60)%5Cn*Expected%20Preconditions*%3A%5Cn-%20foo%3A%20old%20value%5Cn*Updated%20Annotations*%3A%5Cn-%20foo%3A%20new%20value%5Cn-%20bar%3A%20new%20value%5Cn*Removed%20Annotations*%3A%5Cn-%20foo%5Cn-%20bar%22%7D)
```
`UNKNOWN` performed `UpdatePod` via `clutch.k8s.v1.K8sAPI` using Clutch on resource(s):
- kind-clutch-local/envoy-production/envoy-7784b58d-txdg2 (`clutch.k8s.v1.Pod`)
*Expected Preconditions*:
- foo: old value
*Updated Annotations*:
- foo: new value
- bar: new value
*Removed Annotations*:
- foo
- bar
```

### TODOs
- [x] Add unit tests