### PR TITLE
frontend: fix welcome title on landing page

### DIFF
--- a/frontend/packages/core/src/landing.tsx
+++ b/frontend/packages/core/src/landing.tsx
@@ -75,10 +75,7 @@ const Landing: React.FC<{}> = () => {
       <div className="welcome">
         <MonsterGraphic />
         <div className="welcomeText">
-          <div className="title">
-            Welcome
-            {userId()}
-          </div>
+          <div className="title">Welcome&nbsp;{userId()}</div>
           <div className="subtitle">
             Clutch will assist you in safely modifying resources outside of the normal orchestration
             process.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Fixes the welcome title on the landing page which is currently missing a space.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-03-03 at 10 38 41 AM](https://user-images.githubusercontent.com/1004789/109855035-a4b96f80-7c0c-11eb-85c0-a33711272ab0.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
