### PR TITLE
aws: replace simple errors with grpc status

### DIFF
--- a/backend/resolver/aws/asg.go
+++ b/backend/resolver/aws/asg.go
@@ -16,7 +16,7 @@ func (r *res) resolveAutoscalingGroupsForInput(ctx context.Context, input proto.
 	case *awsv1.AutoscalingGroupName:
 		return r.autoscalingGroupResults(ctx, i.Region, []string{i.Name}, 1)
 	default:
-		return nil, status.Errorf(codes.InvalidArgument, "unrecognized input type %T", i)
+		return nil, status.Errorf(codes.Internal, "unrecognized input type '%T'", i)
 	}
 }
 

--- a/backend/resolver/aws/asg.go
+++ b/backend/resolver/aws/asg.go
@@ -2,9 +2,10 @@ package aws
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	awsv1 "github.com/lyft/clutch/backend/api/resolver/aws/v1"
 	"github.com/lyft/clutch/backend/resolver"
@@ -15,7 +16,7 @@ func (r *res) resolveAutoscalingGroupsForInput(ctx context.Context, input proto.
 	case *awsv1.AutoscalingGroupName:
 		return r.autoscalingGroupResults(ctx, i.Region, []string{i.Name}, 1)
 	default:
-		return nil, fmt.Errorf("unrecognized input type %T", i)
+		return nil, status.Errorf(codes.InvalidArgument, "unrecognized input type %T", i)
 	}
 }
 

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,7 +7,6 @@ package aws
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
@@ -126,7 +125,7 @@ func (r *res) Resolve(ctx context.Context, wantTypeURL string, input proto.Messa
 		return r.resolveKinesisStreamForInput(ctx, input)
 
 	default:
-		return nil, fmt.Errorf("don't know how to resolve type %s", wantTypeURL)
+		return nil, status.Errorf(codes.Internal, "type resolution for '%s' not implemented", wantTypeURL)
 	}
 }
 
@@ -146,13 +145,13 @@ func (r *res) Search(ctx context.Context, typeURL, query string, limit uint32) (
 		return r.kinesisResults(ctx, resolver.OptionAll, query, limit)
 
 	default:
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("cannot search for type '%s'", typeURL))
+		return nil, status.Errorf(codes.Internal, "type search for '%s' not implemented", typeURL)
 	}
 }
 
 func (r *res) Autocomplete(ctx context.Context, typeURL, search string, limit uint64) ([]*resolverv1.AutocompleteResult, error) {
 	if r.topology == nil {
-		return nil, fmt.Errorf("to use the autocomplete api you must first setup the topology service")
+		return nil, status.Error(codes.FailedPrecondition, "topology service must be enabled to use the AWS autocomplete API")
 	}
 
 	var resultLimit uint64 = resolver.DefaultAutocompleteLimit

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -125,7 +125,7 @@ func (r *res) Resolve(ctx context.Context, wantTypeURL string, input proto.Messa
 		return r.resolveKinesisStreamForInput(ctx, input)
 
 	default:
-		return nil, status.Errorf(codes.Internal, "type resolution for '%s' not implemented", wantTypeURL)
+		return nil, status.Errorf(codes.Internal, "resolver for '%s' not implemented", wantTypeURL)
 	}
 }
 
@@ -145,7 +145,7 @@ func (r *res) Search(ctx context.Context, typeURL, query string, limit uint32) (
 		return r.kinesisResults(ctx, resolver.OptionAll, query, limit)
 
 	default:
-		return nil, status.Errorf(codes.Internal, "type search for '%s' not implemented", typeURL)
+		return nil, status.Errorf(codes.Internal, "resolver search for '%s' not implemented", typeURL)
 	}
 }
 

--- a/backend/resolver/aws/instances.go
+++ b/backend/resolver/aws/instances.go
@@ -30,7 +30,7 @@ func (r *res) resolveInstancesForInput(ctx context.Context, input proto.Message)
 	case *awsv1.InstanceID:
 		return r.instanceResults(ctx, i.Region, []string{i.Id}, 1)
 	default:
-		return nil, status.Errorf(codes.InvalidArgument, "unrecognized input type %T", i)
+		return nil, status.Errorf(codes.Internal, "unrecognized input type '%T'", i)
 	}
 }
 

--- a/backend/resolver/aws/instances.go
+++ b/backend/resolver/aws/instances.go
@@ -18,7 +18,7 @@ var instanceIDPattern = regexp.MustCompile("[a-fA-F0-9]{17}")
 func normalizeInstanceID(input string) (string, error) {
 	instanceID := instanceIDPattern.FindString(input)
 	if instanceID == "" {
-		return "", status.Error(codes.InvalidArgument, "did not understand input")
+		return "", status.Error(codes.InvalidArgument, "the expected format for instance IDs is i-0123456789abcdef0")
 	}
 
 	return fmt.Sprintf("i-%s", instanceID), nil
@@ -30,7 +30,7 @@ func (r *res) resolveInstancesForInput(ctx context.Context, input proto.Message)
 	case *awsv1.InstanceID:
 		return r.instanceResults(ctx, i.Region, []string{i.Id}, 1)
 	default:
-		return nil, fmt.Errorf("unrecognized input type %T", i)
+		return nil, status.Errorf(codes.InvalidArgument, "unrecognized input type %T", i)
 	}
 }
 

--- a/backend/resolver/aws/kinesis.go
+++ b/backend/resolver/aws/kinesis.go
@@ -2,9 +2,10 @@ package aws
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	awsv1resolver "github.com/lyft/clutch/backend/api/resolver/aws/v1"
 	"github.com/lyft/clutch/backend/resolver"
@@ -15,7 +16,7 @@ func (r *res) resolveKinesisStreamForInput(ctx context.Context, input proto.Mess
 	case *awsv1resolver.KinesisStreamName:
 		return r.kinesisResults(ctx, i.Region, i.Name, 1)
 	default:
-		return nil, fmt.Errorf("unrecognized input type %T", i)
+		return nil, status.Errorf(codes.Internal, "resolution for type '%T' not implemented", i)
 	}
 }
 

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -60,7 +60,8 @@ func TestNew(t *testing.T) {
 
 func TestNewWithWrongConfigType(t *testing.T) {
 	_, err := New(&any.Any{TypeUrl: "foo"}, nil, nil)
-	assert.EqualError(t, err, "mismatched message type: got \"foo\" want \"clutch.config.service.aws.v1.Config\"")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mismatched message type")
 }
 
 func TestRegions(t *testing.T) {
@@ -75,13 +76,28 @@ func TestMissingRegionOnEachServiceCall(t *testing.T) {
 	}
 
 	_, err := c.DescribeInstances(context.Background(), "us-north-5", nil)
-	assert.EqualError(t, err, "no client found for region 'us-north-5'")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no client found")
 
 	err = c.TerminateInstances(context.Background(), "us-north-5", nil)
-	assert.EqualError(t, err, "no client found for region 'us-north-5'")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no client found")
 
 	err = c.RebootInstances(context.Background(), "us-north-5", nil)
-	assert.EqualError(t, err, "no client found for region 'us-north-5'")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no client found")
+}
+
+func TestGetRegionalClient(t *testing.T) {
+	c := &client{
+		clients: map[string]*regionalClient{"us-east-1": nil},
+	}
+	_, err := c.getRegionalClient("us-east-1")
+	assert.NoError(t, err)
+
+	_, err = c.getRegionalClient("us-north-5")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no client found")
 }
 
 var testInstance = ec2types.Instance{

--- a/backend/service/aws/kinesis_test.go
+++ b/backend/service/aws/kinesis_test.go
@@ -90,7 +90,8 @@ func TestDescribeStreamWithBadData(t *testing.T) {
 	}
 
 	_, err := c.DescribeKinesisStream(context.Background(), "us-east-1", "test-stream")
-	assert.EqualError(t, err, "AWS returned a negative value for the current shard count")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS returned a negative value for the current shard count")
 }
 
 func TestUpdateShardCount(t *testing.T) {
@@ -109,7 +110,8 @@ func TestUpdateShardCount(t *testing.T) {
 	assert.EqualError(t, err1, "error")
 
 	err2 := c.UpdateKinesisShardCount(context.Background(), "us-east-1", "test-stream", 10)
-	assert.EqualError(t, err2, "new shard count should be a 25% increment of current shard count ranging from 50-200%")
+	assert.Error(t, err2)
+	assert.Contains(t, err2.Error(), "new shard count should be a 25% increment of current shard count ranging from 50-200%")
 }
 
 func TestGetRecommendedShardSizes(t *testing.T) {
@@ -155,8 +157,9 @@ func TestIsRecommendedChangeWithGoodData(t *testing.T) {
 }
 
 func TestIsRecommendedChangeWithBadData(t *testing.T) {
-	err1 := isRecommendedChange(testAwsStreamOuputWithBadData, int32(-100))
-	assert.EqualError(t, err1, "AWS returned a negative value for the current shard count")
+	err := isRecommendedChange(testAwsStreamOuputWithBadData, int32(-100))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS returned a negative value for the current shard count")
 }
 
 type mockKinesis struct {

--- a/backend/service/aws/s3.go
+++ b/backend/service/aws/s3.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -10,9 +9,9 @@ import (
 )
 
 func (c *client) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
-	rc, ok := c.clients[region]
-	if !ok {
-		return nil, fmt.Errorf("no client found for region '%s'", region)
+	rc, err := c.getRegionalClient(region)
+	if err != nil {
+		return nil, err
 	}
 
 	in := &s3.GetObjectInput{


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Replace instances of  `fmt.Errorf` and `errors.New` that occur in the RPC path with `status.Error`.

### Testing Performed
Unit, audit.