### PR TITLE
topology: emit channel queue depth

### DIFF
--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -82,16 +82,16 @@ func convertLockIdToAdvisoryLockId(lockID string) uint32 {
 // topology objects until the context has been cancelled.
 //
 func (c *client) startTopologyCache(ctx context.Context) {
-	for n, s := range service.Registry {
+	for name, s := range service.Registry {
 		if svc, ok := s.(CacheableTopology); ok {
 			if svc.CacheEnabled() {
-				c.log.Info("Processing Topology Objects for service", zap.String("service", n))
+				c.log.Info("Processing Topology Objects for service", zap.String("service", name))
 				topologyChannel, err := svc.StartTopologyCaching(ctx)
 				if err != nil {
-					c.log.Error("Unable to start topology caching", zap.String("service", n), zap.Error(err))
+					c.log.Error("Unable to start topology caching", zap.String("service", name), zap.Error(err))
 					continue
 				}
-				go c.processTopologyObjectChannel(ctx, topologyChannel, n)
+				go c.processTopologyObjectChannel(ctx, topologyChannel, name)
 			}
 		}
 	}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Emit a stat for the queue depth of the topology channel for each service that implements it. This will be useful to keep track of back pressure which we can alarm on.

```
counter	{"name": "clutch.gateway.start", "value": 1, "tags": {}, "type": "counter"}
gauge	{"name": "clutch.service.topology.cache.object_channel.queue_depth", "value": 0, "tags": {"service":"clutch.service.k8s"}, "type": "gauge"}
counter	{"name": "clutch.service.topology.cache.expire.success", "value": 1, "tags": {}, "type": "counter"}
gauge	{"name": "clutch.service.topology.cache.object_channel.queue_depth", "value": 1054, "tags": {"service":"clutch.service.aws"}, "type": "gauge"}
counter	{"name": "clutch.service.topology.cache.set.success", "value": 158, "tags": {}, "type": "counter"}
gauge	{"name": "clutch.service.topology.cache.object_channel.queue_depth", "value": 868, "tags": {"service":"clutch.service.aws"}, "type": "gauge"}
counter	{"name": "clutch.service.topology.cache.set.success", "value": 199, "tags": {}, "type": "counter"}
gauge	{"name": "clutch.service.topology.cache.object_channel.queue_depth", "value": 798, "tags": {"service":"clutch.service.aws"}, "type": "gauge"}
counter	{"name": "clutch.service.topology.cache.set.success", "value": 181, "tags": {}, "type": "counter"}
gauge	{"name": "clutch.service.topology.cache.object_channel.queue_depth", "value": 719, "tags": {"service":"clutch.service.aws"}, "type": "gauge"}
```

### Testing Performed
Local