### PR TITLE
tools: sanitize proto3 package names

### DIFF
--- a/tools/scaffolding/scaffolder.go
+++ b/tools/scaffolding/scaffolder.go
@@ -19,6 +19,13 @@ const (
 	defaultRepoName              = "clutch-custom-gateway"
 )
 
+// Replace any special characters, that might appear in repository owners or organizations names, but are not supported
+// in proto3 package names.
+var sanitizeProto3Identifier = strings.NewReplacer(
+	"-", "_",
+	"/", "_",
+)
+
 type workflowTemplateValues struct {
 	Name           string
 	PackageName    string
@@ -33,6 +40,11 @@ type gatewayTemplateValues struct {
 	RepoOwner    string
 	RepoName     string
 	RepoProvider string
+}
+
+// SanitizeProto3 identifiers by replacing unsupported characters.
+func (gatewayTemplateValues) SanitizeProto3(s string) string {
+	return sanitizeProto3Identifier.Replace(s)
 }
 
 func promptOrDefault(prompt string, defaultValue string) string {

--- a/tools/scaffolding/templates/gateway/api/echo/v1/echo.proto
+++ b/tools/scaffolding/templates/gateway/api/echo/v1/echo.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package {{ .RepoOwner }}.echo.v1;
+package {{ .RepoOwner | .SanitizeProto3 }}.echo.v1;
 
 option go_package = "{{ .RepoProvider}}/{{ .RepoOwner }}/{{ .RepoName}}/backend/api/echo/v1;echov1";
 


### PR DESCRIPTION
### Description
Add a function to replace special characters, that are unsupported in proto3 identifiers. Use that function during scaffolding to sanitize repository owner / organization names.

### Testing Performed
Tested locally.

### GitHub Issue
Fixes #289