### PR TITLE
frontend: add network helpers

### DIFF
--- a/frontend/packages/core/src/Network/errors.ts
+++ b/frontend/packages/core/src/Network/errors.ts
@@ -268,6 +268,7 @@ const grpcResponseToError = (clientError: AxiosError): ClutchError => {
   } as ClutchError;
 
   if (data?.details !== undefined && data.details.length > 0) {
+    // reassign the @type prop to make the details TS friendly.
     const details = data.details.map(detail => {
       const filteredDetail = { ...detail, type: detail["@type"] };
       delete filteredDetail["@type"];

--- a/frontend/packages/core/src/Network/errors.ts
+++ b/frontend/packages/core/src/Network/errors.ts
@@ -4,7 +4,7 @@ import type { AxiosError } from "axios";
 import type { HttpStatus } from "./index";
 
 interface Details {
-  type: string;
+  _type: string;
 }
 
 /**
@@ -270,7 +270,7 @@ const grpcResponseToError = (clientError: AxiosError): ClutchError => {
   if (data?.details !== undefined && data.details.length > 0) {
     // reassign the @type prop to make the details TS friendly.
     const details = data.details.map(detail => {
-      const filteredDetail = { ...detail, type: detail["@type"] };
+      const filteredDetail = { ...detail, _type: detail["@type"] };
       delete filteredDetail["@type"];
       return filteredDetail;
     });
@@ -280,12 +280,14 @@ const grpcResponseToError = (clientError: AxiosError): ClutchError => {
   return error;
 };
 
+/* eslint-disable no-underscore-dangle */
 const isHelpDetails = (details: ErrorDetails): details is Help => {
-  return details.type === "types.google.com/google.rpc.Help";
+  return details._type === "types.googleapis.com/google.rpc.Help";
 };
 
 const isClutchErrorDetails = (details: ErrorDetails): details is IClutch.api.v1.ErrorDetails => {
-  return details.type === "type.googleapis.com/clutch.api.v1.ErrorDetails";
+  return details._type === "type.googleapis.com/clutch.api.v1.ErrorDetails";
 };
+/* eslint-enable */
 
 export { grpcResponseToError, isClutchErrorDetails, isHelpDetails };

--- a/frontend/packages/core/src/Network/errors.ts
+++ b/frontend/packages/core/src/Network/errors.ts
@@ -1,3 +1,4 @@
+import type { clutch as IClutch } from "@clutch-sh/api";
 import type { AxiosError } from "axios";
 
 import type { HttpStatus } from "./index";
@@ -213,6 +214,19 @@ export interface Help {
   }[];
 }
 
+export type ErrorDetails =
+  | RetryInfo
+  | DebugInfo
+  | QuotaFailure
+  | ErrorInfo
+  | PreconditionFailure
+  | BadRequest
+  | RequestInfo
+  | ResourceInfo
+  | Help
+  | IClutch.api.v1.ErrorDetails
+  | any;
+
 /** An error received from the backend of Clutch. */
 export interface ClutchError extends Error {
   /** The HTTP status information. */
@@ -225,18 +239,7 @@ export interface ClutchError extends Error {
    */
   message: string;
   /** A list of objects that carry error details from the server. */
-  details?: (
-    | RetryInfo
-    | DebugInfo
-    | QuotaFailure
-    | ErrorInfo
-    | PreconditionFailure
-    | BadRequest
-    | RequestInfo
-    | ResourceInfo
-    | Help
-    | any
-  )[];
+  details?: ErrorDetails[];
   /** Data present on the response object, if any. */
   data?: any;
 }
@@ -265,4 +268,12 @@ const grpcResponseToError = (clientError: AxiosError): ClutchError => {
   return error;
 };
 
-export default grpcResponseToError;
+const isHelpDetails = (details: ErrorDetails): details is Help => {
+  return (details as Help).links !== undefined;
+};
+
+const isClutchErrorDetails = (details: ErrorDetails): details is IClutch.api.v1.ErrorDetails => {
+  return (details as IClutch.api.v1.ErrorDetails).wrapped !== undefined;
+};
+
+export { grpcResponseToError, isClutchErrorDetails, isHelpDetails };

--- a/frontend/packages/core/src/Network/errors.ts
+++ b/frontend/packages/core/src/Network/errors.ts
@@ -3,6 +3,10 @@ import type { AxiosError } from "axios";
 
 import type { HttpStatus } from "./index";
 
+interface Details {
+  type: string;
+}
+
 /**
  * Describes when a failed request can be retried.
  *
@@ -10,13 +14,13 @@ import type { HttpStatus } from "./index";
  * increase the delay between retries based on `retryDelay`, until either a maximum number of retries
  * have been reached or a maximum retry delay cap has been reached.
  */
-export interface RetryInfo {
+export interface RetryInfo extends Details {
   /** Amount of time to wait since receiving the error response before retrying. */
   retryDelay?: number;
 }
 
 /** Describes additional debugging info. */
-export interface DebugInfo {
+export interface DebugInfo extends Details {
   /** The stack trace entries indicating where the error occurred. */
   stackEntries?: string[];
   /** Additional debugging information provided by the server. */
@@ -33,7 +37,7 @@ export interface DebugInfo {
  * the server could respond with the project id and set `service_disabled`
  * to true.
  */
-export interface QuotaFailure {
+export interface QuotaFailure extends Details {
   /**
    * A message type used to describe a single quota violation. For example, a
    * daily quota or a custom quota that was exceeded.
@@ -59,7 +63,7 @@ export interface QuotaFailure {
 }
 
 /** Describes the cause of the error with structured details. */
-export interface ErrorInfo {
+export interface ErrorInfo extends Details {
   /**
    * The reason of the error. This is a constant value that identifies the
    * proximate cause of the error. Error reasons are unique within a particular
@@ -100,7 +104,7 @@ export interface ErrorInfo {
  * acknowledged, it could list the terms of service violation in the
  * PreconditionFailure message.
  */
-export interface PreconditionFailure {
+export interface PreconditionFailure extends Details {
   /** Describes all precondition violations. */
   violations?: {
     /**
@@ -131,7 +135,7 @@ export interface PreconditionFailure {
  * Describes violations in a client request. This error type focuses on the
  * syntactic aspects of the request.
  */
-export interface BadRequest {
+export interface BadRequest extends Details {
   /** Describes all violations in a client request. */
   fieldViolations: {
     /**
@@ -149,7 +153,7 @@ export interface BadRequest {
  * Contains metadata about the request that can be attached when filing a bug
  * or providing other forms of feedback.
  */
-export interface RequestInfo {
+export interface RequestInfo extends Details {
   /**
    * An opaque string that should only be interpreted by the service generating
    * it.
@@ -167,7 +171,7 @@ export interface RequestInfo {
 }
 
 /** Describes the resource that is being accessed. */
-export interface ResourceInfo {
+export interface ResourceInfo extends Details {
   /**
    * A name for the type of resource being accessed, e.g. "sql table",
    * "cloud storage bucket", "file", "Google calendar"; or the type URL
@@ -202,7 +206,7 @@ export interface ResourceInfo {
  * project hasn't enabled the accessed service, this can contain a URL pointing
  * directly to the right place in the developer console to flip the bit.
  */
-export interface Help {
+export interface Help extends Details {
   /** URL(s) pointing to additional information on handling the current error. */
   links?: {
     /** Describes what the link offers. */
@@ -214,6 +218,8 @@ export interface Help {
   }[];
 }
 
+export interface ClutchErrorDetails extends IClutch.api.v1.ErrorDetails, Details {}
+
 export type ErrorDetails =
   | RetryInfo
   | DebugInfo
@@ -224,7 +230,7 @@ export type ErrorDetails =
   | RequestInfo
   | ResourceInfo
   | Help
-  | IClutch.api.v1.ErrorDetails
+  | ClutchErrorDetails
   | any;
 
 /** An error received from the backend of Clutch. */
@@ -262,18 +268,23 @@ const grpcResponseToError = (clientError: AxiosError): ClutchError => {
   } as ClutchError;
 
   if (data?.details !== undefined && data.details.length > 0) {
-    error.details = data.details;
+    const details = data.details.map(detail => {
+      const filteredDetail = { ...detail, type: detail["@type"] };
+      delete filteredDetail["@type"];
+      return filteredDetail;
+    });
+    error.details = details;
   }
 
   return error;
 };
 
 const isHelpDetails = (details: ErrorDetails): details is Help => {
-  return (details as Help).links !== undefined;
+  return details.type === "types.google.com/google.rpc.Help";
 };
 
 const isClutchErrorDetails = (details: ErrorDetails): details is IClutch.api.v1.ErrorDetails => {
-  return (details as IClutch.api.v1.ErrorDetails).wrapped !== undefined;
+  return details.type === "type.googleapis.com/clutch.api.v1.ErrorDetails";
 };
 
 export { grpcResponseToError, isClutchErrorDetails, isHelpDetails };

--- a/frontend/packages/core/src/Network/index.ts
+++ b/frontend/packages/core/src/Network/index.ts
@@ -2,7 +2,7 @@ import type { AxiosError } from "axios";
 import axios from "axios";
 
 import type { ClutchError } from "./errors";
-import grpcResponseToError from "./errors";
+import { grpcResponseToError } from "./errors";
 
 /**
  * HTTP response status.

--- a/frontend/packages/core/src/Network/tests/errors.test.ts
+++ b/frontend/packages/core/src/Network/tests/errors.test.ts
@@ -48,7 +48,7 @@ describe("clutch error", () => {
       const complexAxiosError = { ...axiosError };
       complexAxiosError.response.data.details = [
         {
-          "@type": "types.google.com/google.rpc.Help",
+          "@type": "types.googleapis.com/google.rpc.Help",
           links: [
             {
               description: "This is a link",
@@ -74,7 +74,7 @@ describe("clutch error", () => {
 describe("isHelpDetails", () => {
   it("returns true for help details", () => {
     const details = {
-      type: "types.google.com/google.rpc.Help",
+      _type: "types.googleapis.com/google.rpc.Help",
       links: [
         {
           description: "Please file a ticket here for more help.",
@@ -102,7 +102,7 @@ describe("isHelpDetails", () => {
 describe("isClutchErrorDetails", () => {
   it("returns true for Clutch specific error details", () => {
     const details = {
-      type: "type.googleapis.com/clutch.api.v1.ErrorDetails",
+      _type: "type.googleapis.com/clutch.api.v1.ErrorDetails",
       wrapped: [
         {
           code: 2,

--- a/frontend/packages/core/src/Network/tests/errors.test.ts
+++ b/frontend/packages/core/src/Network/tests/errors.test.ts
@@ -1,7 +1,6 @@
-import type { clutch as IClutch } from "@clutch-sh/api";
 import type { AxiosError } from "axios";
 
-import type { ClutchError, Help } from "../errors";
+import type { ClutchError, ClutchErrorDetails, Help } from "../errors";
 import { grpcResponseToError, isClutchErrorDetails, isHelpDetails } from "../errors";
 
 describe("clutch error", () => {
@@ -75,6 +74,7 @@ describe("clutch error", () => {
 describe("isHelpDetails", () => {
   it("returns true for help details", () => {
     const details = {
+      type: "types.google.com/google.rpc.Help",
       links: [
         {
           description: "Please file a ticket here for more help.",
@@ -88,7 +88,7 @@ describe("isHelpDetails", () => {
 
   it("returns false for non-help details", () => {
     const details = {
-      type: "randomType",
+      type: "unknownType",
       something: [
         {
           key: "value",
@@ -102,6 +102,7 @@ describe("isHelpDetails", () => {
 describe("isClutchErrorDetails", () => {
   it("returns true for Clutch specific error details", () => {
     const details = {
+      type: "type.googleapis.com/clutch.api.v1.ErrorDetails",
       wrapped: [
         {
           code: 2,
@@ -112,14 +113,14 @@ describe("isClutchErrorDetails", () => {
           message: "core-staging-1: nono",
         },
       ],
-    } as IClutch.api.v1.ErrorDetails;
+    } as ClutchErrorDetails;
 
     expect(isClutchErrorDetails(details)).toBe(true);
   });
 
   it("returns false for non-Clutch specific error details", () => {
     const details = {
-      type: "randomType",
+      type: "unknownType",
       something: [
         {
           key: "value",

--- a/frontend/packages/core/src/Network/tests/errors.test.ts
+++ b/frontend/packages/core/src/Network/tests/errors.test.ts
@@ -1,7 +1,8 @@
+import type { clutch as IClutch } from "@clutch-sh/api";
 import type { AxiosError } from "axios";
 
 import type { ClutchError, Help } from "../errors";
-import grpcResponseToError from "../errors";
+import { grpcResponseToError, isClutchErrorDetails, isHelpDetails } from "../errors";
 
 describe("clutch error", () => {
   const axiosError = {
@@ -68,5 +69,63 @@ describe("clutch error", () => {
       const helpDetails = err.details[0] as Help;
       expect(helpDetails.links).toHaveLength(1);
     });
+  });
+});
+
+describe("isHelpDetails", () => {
+  it("returns true for help details", () => {
+    const details = {
+      links: [
+        {
+          description: "Please file a ticket here for more help.",
+          url: "https://www.example.com",
+        },
+      ],
+    } as Help;
+
+    expect(isHelpDetails(details)).toBe(true);
+  });
+
+  it("returns false for non-help details", () => {
+    const details = {
+      type: "randomType",
+      something: [
+        {
+          key: "value",
+        },
+      ],
+    };
+    expect(isHelpDetails(details)).toBe(false);
+  });
+});
+
+describe("isClutchErrorDetails", () => {
+  it("returns true for Clutch specific error details", () => {
+    const details = {
+      wrapped: [
+        {
+          code: 2,
+          message: "core-staging-0: yikes",
+        },
+        {
+          code: 16,
+          message: "core-staging-1: nono",
+        },
+      ],
+    } as IClutch.api.v1.ErrorDetails;
+
+    expect(isClutchErrorDetails(details)).toBe(true);
+  });
+
+  it("returns false for non-Clutch specific error details", () => {
+    const details = {
+      type: "randomType",
+      something: [
+        {
+          key: "value",
+        },
+      ],
+    };
+    expect(isClutchErrorDetails(details)).toBe(false);
   });
 });


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add type guard helpers for relevant network detail types. At the moment we only care about determining Help and Clutch details.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Unit
