### PR TITLE
tools: add protobuf lint missing include path

### DIFF
--- a/tools/compile-protos.sh
+++ b/tools/compile-protos.sh
@@ -103,7 +103,7 @@ main() {
 
       for proto in "${PROTOS[@]}"; do
         if ! output=$("${PROTOC_BIN}" \
-          -I"${PROTOC_INCLUDE_DIR}" -I"${API_ROOT}" \
+          -I"${PROTOC_INCLUDE_DIR}" -I"${API_ROOT}" -I"${CLUTCH_API_ROOT}" \
           -I"${grpc_gateway_include_path}" -I"${pg_validate_include_path}" \
           --buf-check-lint_out=. \
           "--buf-check-lint_opt={\"input_config\": ${buf_lint_config}}" \


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Adds a missing argument to the call to the protoc buf linter plugin. This only affects custom gateways' linting. Without this arg the custom gateway is unable to locate the core APIs from Clutch when linting.

### Testing Performed
Manual.