### PR TITLE
backend: ensure listener is up in testserver

### DIFF
--- a/backend/internal/test/integration/helper/testserver/testserver.go
+++ b/backend/internal/test/integration/helper/testserver/testserver.go
@@ -38,13 +38,12 @@ func (t *TestServer) Register(m module.Module) {
 }
 
 func (t *TestServer) Run() {
+	//nolint:gosec
+	l, err := net.Listen("tcp", "0.0.0.0:9000")
+	if err != nil {
+		panic(err)
+	}
 	go func() {
-		//nolint:gosec
-		l, err := net.Listen("tcp", "0.0.0.0:9000")
-		if err != nil {
-			panic(err)
-		}
-
 		err = t.registrar.GRPCServer().Serve(l)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Move the call to Listen() outside of the goroutine so we know the listener is open before the function returns. This prevents a race where the caller may hit the socket before it's listening.

### Testing Performed
Unit test, ran many times.