### PR TITLE
k8s: populate start time field in pod

### DIFF
--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -170,10 +169,7 @@ func podDescription(k8spod *corev1.Pod, cluster string) *k8sapiv1.Pod {
 	var startTimestamp *timestamppb.Timestamp
 	startTime := k8spod.Status.StartTime
 	if startTime != nil {
-		startTimeProto, err := ptypes.TimestampProto(startTime.Time)
-		if err == nil {
-			startTimestamp = startTimeProto
-		}
+		startTimestamp = timestamppb.New(startTime.Time)
 	}
 
 	clusterName := k8spod.ClusterName

--- a/backend/service/k8s/pods_test.go
+++ b/backend/service/k8s/pods_test.go
@@ -30,6 +30,7 @@ func TestProtoForContainerState(t *testing.T) {
 }
 
 func testPodClientset() *fake.Clientset {
+	now := metav1.Now()
 	testPods := []runtime.Object{
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -40,7 +41,7 @@ func testPodClientset() *fake.Clientset {
 				Annotations: map[string]string{"baz": "quuz"},
 			},
 			Status: corev1.PodStatus{
-				StartTime: &metav1.Time{},
+				StartTime: &now,
 				ContainerStatuses: []corev1.ContainerStatus{
 					{Name: "container1"},
 					{Name: "container2"},
@@ -57,7 +58,7 @@ func testPodClientset() *fake.Clientset {
 				Annotations: map[string]string{"baz": "quuz"},
 			},
 			Status: corev1.PodStatus{
-				StartTime: &metav1.Time{},
+				StartTime: &now,
 				ContainerStatuses: []corev1.ContainerStatus{
 					{Name: "container1"},
 					{Name: "container2"},
@@ -73,7 +74,7 @@ func testPodClientset() *fake.Clientset {
 				Annotations: map[string]string{"baz": "quuz"},
 			},
 			Status: corev1.PodStatus{
-				StartTime: &metav1.Time{},
+				StartTime: &now,
 				ContainerStatuses: []corev1.ContainerStatus{
 					{Name: "container1"},
 					{Name: "container2"},
@@ -88,6 +89,7 @@ func testPodClientset() *fake.Clientset {
 
 func testListFakeClientset(numPods int) *fake.Clientset {
 	var fakeClient fake.Clientset
+	now := metav1.Now()
 	fakeClient.AddReactor("list", "pods",
 		func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			pods := corev1.PodList{}
@@ -98,6 +100,9 @@ func testListFakeClientset(numPods int) *fake.Clientset {
 						Name:        fmt.Sprintf("testing-pod-name-%b", i),
 						Namespace:   "testing-namespace",
 						ClusterName: "staging",
+					},
+					Status: corev1.PodStatus{
+						StartTime: &now,
 					},
 				})
 			}
@@ -156,6 +161,7 @@ func TestDescribePod(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
+	assert.NotNil(t, result.StartTime)
 }
 
 func TestDeletePod(t *testing.T) {


### PR DESCRIPTION
### Description
Currently the start time field in the pod proto object is not populated, this PR populates the start time field in the pod proto

### Testing Performed
unit test