### PR TITLE
docs: add middleware to example config in Security Auditing

### DIFF
--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -136,7 +136,7 @@ All of this information is passed along to the audit [service](./###Service) to 
 
 The configuration for the audit middleware looks like:
 
-```yaml title="backend/clutch-config.yaml
+```yaml title="backend/clutch-config.yaml"
 gateway:
 ...
   middleware:

--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -134,6 +134,19 @@ On each request, the [above annotations](#annotations) are read along with what 
 
 All of this information is passed along to the audit [service](./###Service) to persist.
 
+The configuration for the audit middleware looks like:
+
+```yaml title="backend/clutch-config.yaml
+gateway:
+...
+  middleware:
+    ...
+    // highlight-start
+    - name: clutch.middleware.audit
+    // highlight-end
+...
+```
+
 ### Service
 
 The audit service has two behaviors: write requests somewhere, and read them back out. It takes events from the middleware and saves them, and it also pushes them to later "sinks" for further processing.

--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -187,6 +187,13 @@ process shutting down.
 
 
 ```yaml title="backend/clutch-config.yaml"
+gateway:
+...
+  middleware:
+    ...
+    // highlight-start
+    - name: clutch.middleware.audit
+    // highlight-end
 ...
 services:
   ...
@@ -213,6 +220,13 @@ services:
 Below is sample configuration to show how the services described are enabled. Note that because services are instantiated in the order they are listed, order matters! Since the audit service depends on both the database and the sink, it needs to be listed after them.
 
 ```yaml title="backend/clutch-config.yaml"
+gateway:
+...
+  middleware:
+    ...
+    // highlight-start
+    - name: clutch.middleware.audit
+    // highlight-end
 ...
 services:
   ...


### PR DESCRIPTION
### Description
Add `audit` middleware to example config in [Security Auditing](https://clutch.sh/docs/advanced/security-auditing/#example-config) to head off possible oversight by folks new to the project.

### Testing Performed
Validated with local markdown preview.

### GitHub Issue
Fixes #

### TODOs
- [x] Verify that highlights render correctly.
