### PR TITLE
Revert "housekeeping: protoc-gen-validate to v0.5.0 (#1127)"

### DIFF
--- a/backend/api/api/v1/annotations.pb.validate.go
+++ b/backend/api/api/v1/annotations.pb.validate.go
@@ -32,3 +32,6 @@ var (
 	_ = (*mail.Address)(nil)
 	_ = ptypes.DynamicAny{}
 )
+
+// define the regex for a UUID once up-front
+var _annotations_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")

--- a/backend/api/api/v1/error.pb.validate.go
+++ b/backend/api/api/v1/error.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _error_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on ErrorDetails with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/api/v1/schema.pb.validate.go
+++ b/backend/api/api/v1/schema.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _schema_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Action with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Action) Validate() error {

--- a/backend/api/assets/v1/assets.pb.validate.go
+++ b/backend/api/assets/v1/assets.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _assets_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on FetchRequest with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/audit/v1/audit.pb.validate.go
+++ b/backend/api/audit/v1/audit.pb.validate.go
@@ -37,6 +37,9 @@ var (
 	_ = apiv1.ActionType(0)
 )
 
+// define the regex for a UUID once up-front
+var _audit_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on TimeRange with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *TimeRange) Validate() error {

--- a/backend/api/authn/v1/authn.pb.validate.go
+++ b/backend/api/authn/v1/authn.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _authn_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on LoginRequest with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/authz/v1/authz.pb.validate.go
+++ b/backend/api/authz/v1/authz.pb.validate.go
@@ -37,6 +37,9 @@ var (
 	_ = apiv1.ActionType(0)
 )
 
+// define the regex for a UUID once up-front
+var _authz_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Subject with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Subject) Validate() error {

--- a/backend/api/aws/ec2/v1/ec2.pb.validate.go
+++ b/backend/api/aws/ec2/v1/ec2.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _ec_2_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on AutoscalingGroupSize with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/aws/kinesis/v1/kinesis.pb.validate.go
+++ b/backend/api/aws/kinesis/v1/kinesis.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _kinesis_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on GetStreamRequest with the rules defined
 // in the proto definition for this message. If any rules are violated, an
 // error is returned.

--- a/backend/api/chaos/experimentation/v1/experiment.pb.validate.go
+++ b/backend/api/chaos/experimentation/v1/experiment.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _experiment_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Experiment with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Experiment) Validate() error {

--- a/backend/api/chaos/experimentation/v1/experiment_run_details.pb.validate.go
+++ b/backend/api/chaos/experimentation/v1/experiment_run_details.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _experiment_run_details_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on ExperimentRunDetails with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/chaos/experimentation/v1/experimentation.pb.validate.go
+++ b/backend/api/chaos/experimentation/v1/experimentation.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _experimentation_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on CreateExperimentRequest with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/chaos/experimentation/v1/list_view_item.pb.validate.go
+++ b/backend/api/chaos/experimentation/v1/list_view_item.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _list_view_item_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on ListViewItem with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/chaos/experimentation/v1/properties.pb.validate.go
+++ b/backend/api/chaos/experimentation/v1/properties.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _properties_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on PropertiesList with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/chaos/serverexperimentation/v1/serverexperimentation.pb.validate.go
+++ b/backend/api/chaos/serverexperimentation/v1/serverexperimentation.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _serverexperimentation_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on TestConfig with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *TestConfig) Validate() error {

--- a/backend/api/config/gateway/v1/gateway.pb.validate.go
+++ b/backend/api/config/gateway/v1/gateway.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _gateway_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/middleware/accesslog/v1/accesslog.pb.validate.go
+++ b/backend/api/config/middleware/accesslog/v1/accesslog.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _accesslog_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/module/chaos/experimentation/xds/v1/xds.pb.validate.go
+++ b/backend/api/config/module/chaos/experimentation/xds/v1/xds.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _xds_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/module/sourcecontrol/v1/sourcecontrol.pb.validate.go
+++ b/backend/api/config/module/sourcecontrol/v1/sourcecontrol.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _sourcecontrol_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/service/audit/v1/audit.pb.validate.go
+++ b/backend/api/config/service/audit/v1/audit.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _audit_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on EventFilter with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/config/service/auditsink/slack/v1/slack.pb.validate.go
+++ b/backend/api/config/service/auditsink/slack/v1/slack.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _slack_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on SlackConfig with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/config/service/authn/v1/authn.pb.validate.go
+++ b/backend/api/config/service/authn/v1/authn.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _authn_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on OIDC with the rules defined in the proto
 // definition for this message. If any rules are violated, an error is returned.
 func (m *OIDC) Validate() error {

--- a/backend/api/config/service/authn/v1/storage.pb.validate.go
+++ b/backend/api/config/service/authn/v1/storage.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _storage_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on StorageConfig with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/config/service/authz/v1/authz.pb.validate.go
+++ b/backend/api/config/service/authz/v1/authz.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _authz_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Principal with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Principal) Validate() error {

--- a/backend/api/config/service/aws/v1/aws.pb.validate.go
+++ b/backend/api/config/service/aws/v1/aws.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _aws_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/service/db/postgres/v1/database.pb.validate.go
+++ b/backend/api/config/service/db/postgres/v1/database.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _database_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Connection with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Connection) Validate() error {

--- a/backend/api/config/service/envoyadmin/v1/envoyadmin.pb.validate.go
+++ b/backend/api/config/service/envoyadmin/v1/envoyadmin.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _envoyadmin_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/service/github/v1/github.pb.validate.go
+++ b/backend/api/config/service/github/v1/github.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _github_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/service/k8s/v1/k8s.pb.validate.go
+++ b/backend/api/config/service/k8s/v1/k8s.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _k_8_s_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/config/service/topology/v1/topology.pb.validate.go
+++ b/backend/api/config/service/topology/v1/topology.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _topology_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Config with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Config) Validate() error {

--- a/backend/api/envoytriage/v1/envoytriage_api.pb.validate.go
+++ b/backend/api/envoytriage/v1/envoytriage_api.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _envoytriage_api_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on ReadRequest with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/envoytriage/v1/output.pb.validate.go
+++ b/backend/api/envoytriage/v1/output.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _output_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on HostStatus with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *HostStatus) Validate() error {

--- a/backend/api/healthcheck/v1/healthcheck.pb.validate.go
+++ b/backend/api/healthcheck/v1/healthcheck.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _healthcheck_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on HealthcheckRequest with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/k8s/v1/k8s.pb.validate.go
+++ b/backend/api/k8s/v1/k8s.pb.validate.go
@@ -37,6 +37,9 @@ var (
 	_ = structpb.NullValue(0)
 )
 
+// define the regex for a UUID once up-front
+var _k_8_s_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on DescribePodRequest with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/k8s/v1/status.pb.validate.go
+++ b/backend/api/k8s/v1/status.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _status_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on Status with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *Status) Validate() error {

--- a/backend/api/resolver/aws/v1/aws.pb.validate.go
+++ b/backend/api/resolver/aws/v1/aws.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _aws_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on InstanceID with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *InstanceID) Validate() error {

--- a/backend/api/resolver/k8s/v1/k8s.pb.validate.go
+++ b/backend/api/resolver/k8s/v1/k8s.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _k_8_s_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on PodID with the rules defined in the
 // proto definition for this message. If any rules are violated, an error is returned.
 func (m *PodID) Validate() error {

--- a/backend/api/resolver/v1/annotations.pb.validate.go
+++ b/backend/api/resolver/v1/annotations.pb.validate.go
@@ -32,3 +32,6 @@ var (
 	_ = (*mail.Address)(nil)
 	_ = ptypes.DynamicAny{}
 )
+
+// define the regex for a UUID once up-front
+var _annotations_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")

--- a/backend/api/resolver/v1/resolver_api.pb.validate.go
+++ b/backend/api/resolver/v1/resolver_api.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _resolver_api_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on AutocompleteResult with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/resolver/v1/schema.pb.validate.go
+++ b/backend/api/resolver/v1/schema.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _schema_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on StringField with the rules defined in
 // the proto definition for this message. If any rules are violated, an error
 // is returned.

--- a/backend/api/sourcecontrol/github/v1/github.pb.validate.go
+++ b/backend/api/sourcecontrol/github/v1/github.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _github_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on RepositoryParameters with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/sourcecontrol/v1/sourcecontrol.pb.validate.go
+++ b/backend/api/sourcecontrol/v1/sourcecontrol.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _sourcecontrol_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on GetRepositoryOptionsRequest with the
 // rules defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/api/topology/v1/topology_api.pb.validate.go
+++ b/backend/api/topology/v1/topology_api.pb.validate.go
@@ -33,6 +33,9 @@ var (
 	_ = ptypes.DynamicAny{}
 )
 
+// define the regex for a UUID once up-front
+var _topology_api_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 // Validate checks the field values on GetTopologyRequest with the rules
 // defined in the proto definition for this message. If any rules are
 // violated, an error is returned.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/envoyproxy/go-control-plane v0.9.9-0.20210304204206-e2b50f82e48e
-	github.com/envoyproxy/protoc-gen-validate v0.5.0
+	github.com/envoyproxy/protoc-gen-validate v0.4.1
 	github.com/fullstorydev/grpcurl v1.8.0
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.2.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -217,8 +217,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210304204206-e2b50f82e48e h1:LZh5hngtQKUUtRwMQDg+rArDnzj2tkPfkZZBHbOgoWw=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210304204206-e2b50f82e48e/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/envoyproxy/protoc-gen-validate v0.5.0 h1:+ltcA/hEtDde/2Z+9EvwamSsAzPNE6z17oSOChokJzU=
-github.com/envoyproxy/protoc-gen-validate v0.5.0/go.mod h1:xL5IroIBOR+aTp0IZk48epGwBV3+LcuaosPL0pr0hE0=
+github.com/envoyproxy/protoc-gen-validate v0.4.1 h1:7dLaJvASGRD7X49jSCSXXHwKPm0ZN9r9kJD+p+vS7dM=
+github.com/envoyproxy/protoc-gen-validate v0.4.1/go.mod h1:E+IEazqdaWv3FrnGtZIu3b9fPFMK8AzeTTrk9SfVwWs=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/frontend/api/src/index.d.ts
+++ b/frontend/api/src/index.d.ts
@@ -17401,9 +17401,6 @@ export namespace validate {
 
         /** FloatRules notIn */
         notIn?: (number[]|null);
-
-        /** FloatRules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a FloatRules. */
@@ -17435,9 +17432,6 @@ export namespace validate {
 
         /** FloatRules notIn. */
         public notIn: number[];
-
-        /** FloatRules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a FloatRules message.
@@ -17491,9 +17485,6 @@ export namespace validate {
 
         /** DoubleRules notIn */
         notIn?: (number[]|null);
-
-        /** DoubleRules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a DoubleRules. */
@@ -17525,9 +17516,6 @@ export namespace validate {
 
         /** DoubleRules notIn. */
         public notIn: number[];
-
-        /** DoubleRules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a DoubleRules message.
@@ -17581,9 +17569,6 @@ export namespace validate {
 
         /** Int32Rules notIn */
         notIn?: (number[]|null);
-
-        /** Int32Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents an Int32Rules. */
@@ -17615,9 +17600,6 @@ export namespace validate {
 
         /** Int32Rules notIn. */
         public notIn: number[];
-
-        /** Int32Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies an Int32Rules message.
@@ -17671,9 +17653,6 @@ export namespace validate {
 
         /** Int64Rules notIn */
         notIn?: ((number|Long)[]|null);
-
-        /** Int64Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents an Int64Rules. */
@@ -17705,9 +17684,6 @@ export namespace validate {
 
         /** Int64Rules notIn. */
         public notIn: (number|Long)[];
-
-        /** Int64Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies an Int64Rules message.
@@ -17761,9 +17737,6 @@ export namespace validate {
 
         /** UInt32Rules notIn */
         notIn?: (number[]|null);
-
-        /** UInt32Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a UInt32Rules. */
@@ -17795,9 +17768,6 @@ export namespace validate {
 
         /** UInt32Rules notIn. */
         public notIn: number[];
-
-        /** UInt32Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a UInt32Rules message.
@@ -17851,9 +17821,6 @@ export namespace validate {
 
         /** UInt64Rules notIn */
         notIn?: ((number|Long)[]|null);
-
-        /** UInt64Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a UInt64Rules. */
@@ -17885,9 +17852,6 @@ export namespace validate {
 
         /** UInt64Rules notIn. */
         public notIn: (number|Long)[];
-
-        /** UInt64Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a UInt64Rules message.
@@ -17941,9 +17905,6 @@ export namespace validate {
 
         /** SInt32Rules notIn */
         notIn?: (number[]|null);
-
-        /** SInt32Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a SInt32Rules. */
@@ -17975,9 +17936,6 @@ export namespace validate {
 
         /** SInt32Rules notIn. */
         public notIn: number[];
-
-        /** SInt32Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a SInt32Rules message.
@@ -18031,9 +17989,6 @@ export namespace validate {
 
         /** SInt64Rules notIn */
         notIn?: ((number|Long)[]|null);
-
-        /** SInt64Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a SInt64Rules. */
@@ -18065,9 +18020,6 @@ export namespace validate {
 
         /** SInt64Rules notIn. */
         public notIn: (number|Long)[];
-
-        /** SInt64Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a SInt64Rules message.
@@ -18121,9 +18073,6 @@ export namespace validate {
 
         /** Fixed32Rules notIn */
         notIn?: (number[]|null);
-
-        /** Fixed32Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a Fixed32Rules. */
@@ -18155,9 +18104,6 @@ export namespace validate {
 
         /** Fixed32Rules notIn. */
         public notIn: number[];
-
-        /** Fixed32Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a Fixed32Rules message.
@@ -18211,9 +18157,6 @@ export namespace validate {
 
         /** Fixed64Rules notIn */
         notIn?: ((number|Long)[]|null);
-
-        /** Fixed64Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a Fixed64Rules. */
@@ -18245,9 +18188,6 @@ export namespace validate {
 
         /** Fixed64Rules notIn. */
         public notIn: (number|Long)[];
-
-        /** Fixed64Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a Fixed64Rules message.
@@ -18301,9 +18241,6 @@ export namespace validate {
 
         /** SFixed32Rules notIn */
         notIn?: (number[]|null);
-
-        /** SFixed32Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a SFixed32Rules. */
@@ -18335,9 +18272,6 @@ export namespace validate {
 
         /** SFixed32Rules notIn. */
         public notIn: number[];
-
-        /** SFixed32Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a SFixed32Rules message.
@@ -18391,9 +18325,6 @@ export namespace validate {
 
         /** SFixed64Rules notIn */
         notIn?: ((number|Long)[]|null);
-
-        /** SFixed64Rules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a SFixed64Rules. */
@@ -18425,9 +18356,6 @@ export namespace validate {
 
         /** SFixed64Rules notIn. */
         public notIn: (number|Long)[];
-
-        /** SFixed64Rules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a SFixed64Rules message.
@@ -18583,9 +18511,6 @@ export namespace validate {
 
         /** StringRules strict */
         strict?: (boolean|null);
-
-        /** StringRules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a StringRules. */
@@ -18672,9 +18597,6 @@ export namespace validate {
         /** StringRules strict. */
         public strict: boolean;
 
-        /** StringRules ignoreEmpty. */
-        public ignoreEmpty: boolean;
-
         /** StringRules wellKnown. */
         public wellKnown?: ("email"|"hostname"|"ip"|"ipv4"|"ipv6"|"uri"|"uriRef"|"address"|"uuid"|"wellKnownRegex");
 
@@ -18755,9 +18677,6 @@ export namespace validate {
 
         /** BytesRules ipv6 */
         ipv6?: (boolean|null);
-
-        /** BytesRules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a BytesRules. */
@@ -18807,9 +18726,6 @@ export namespace validate {
 
         /** BytesRules ipv6. */
         public ipv6: boolean;
-
-        /** BytesRules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /** BytesRules wellKnown. */
         public wellKnown?: ("ip"|"ipv4"|"ipv6");
@@ -18977,9 +18893,6 @@ export namespace validate {
 
         /** RepeatedRules items */
         items?: (validate.IFieldRules|null);
-
-        /** RepeatedRules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a RepeatedRules. */
@@ -19002,9 +18915,6 @@ export namespace validate {
 
         /** RepeatedRules items. */
         public items?: (validate.IFieldRules|null);
-
-        /** RepeatedRules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a RepeatedRules message.
@@ -19052,9 +18962,6 @@ export namespace validate {
 
         /** MapRules values */
         values?: (validate.IFieldRules|null);
-
-        /** MapRules ignoreEmpty */
-        ignoreEmpty?: (boolean|null);
     }
 
     /** Represents a MapRules. */
@@ -19080,9 +18987,6 @@ export namespace validate {
 
         /** MapRules values. */
         public values?: (validate.IFieldRules|null);
-
-        /** MapRules ignoreEmpty. */
-        public ignoreEmpty: boolean;
 
         /**
          * Verifies a MapRules message.
@@ -20523,9 +20427,6 @@ export namespace google {
 
             /** MessageOptions .validate.disabled */
             ".validate.disabled"?: (boolean|null);
-
-            /** MessageOptions .validate.ignored */
-            ".validate.ignored"?: (boolean|null);
 
             /** MessageOptions .clutch.resolver.v1.schema */
             ".clutch.resolver.v1.schema"?: (clutch.resolver.v1.ISchemaMetadata|null);

--- a/frontend/api/src/index.js
+++ b/frontend/api/src/index.js
@@ -41830,7 +41830,6 @@ export const validate = $root.validate = (() => {
          * @property {number|null} [gte] FloatRules gte
          * @property {Array.<number>|null} ["in"] FloatRules in
          * @property {Array.<number>|null} [notIn] FloatRules notIn
-         * @property {boolean|null} [ignoreEmpty] FloatRules ignoreEmpty
          */
 
         /**
@@ -41907,14 +41906,6 @@ export const validate = $root.validate = (() => {
         FloatRules.prototype.notIn = $util.emptyArray;
 
         /**
-         * FloatRules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.FloatRules
-         * @instance
-         */
-        FloatRules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a FloatRules message.
          * @function verify
          * @memberof validate.FloatRules
@@ -41954,9 +41945,6 @@ export const validate = $root.validate = (() => {
                     if (typeof message.notIn[i] !== "number")
                         return "notIn: number[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -41996,8 +41984,6 @@ export const validate = $root.validate = (() => {
                 for (let i = 0; i < object.notIn.length; ++i)
                     message.notIn[i] = Number(object.notIn[i]);
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -42024,7 +42010,6 @@ export const validate = $root.validate = (() => {
                 object.lte = 0;
                 object.gt = 0;
                 object.gte = 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = options.json && !isFinite(message["const"]) ? String(message["const"]) : message["const"];
@@ -42046,8 +42031,6 @@ export const validate = $root.validate = (() => {
                 for (let j = 0; j < message.notIn.length; ++j)
                     object.notIn[j] = options.json && !isFinite(message.notIn[j]) ? String(message.notIn[j]) : message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -42078,7 +42061,6 @@ export const validate = $root.validate = (() => {
          * @property {number|null} [gte] DoubleRules gte
          * @property {Array.<number>|null} ["in"] DoubleRules in
          * @property {Array.<number>|null} [notIn] DoubleRules notIn
-         * @property {boolean|null} [ignoreEmpty] DoubleRules ignoreEmpty
          */
 
         /**
@@ -42155,14 +42137,6 @@ export const validate = $root.validate = (() => {
         DoubleRules.prototype.notIn = $util.emptyArray;
 
         /**
-         * DoubleRules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.DoubleRules
-         * @instance
-         */
-        DoubleRules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a DoubleRules message.
          * @function verify
          * @memberof validate.DoubleRules
@@ -42202,9 +42176,6 @@ export const validate = $root.validate = (() => {
                     if (typeof message.notIn[i] !== "number")
                         return "notIn: number[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -42244,8 +42215,6 @@ export const validate = $root.validate = (() => {
                 for (let i = 0; i < object.notIn.length; ++i)
                     message.notIn[i] = Number(object.notIn[i]);
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -42272,7 +42241,6 @@ export const validate = $root.validate = (() => {
                 object.lte = 0;
                 object.gt = 0;
                 object.gte = 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = options.json && !isFinite(message["const"]) ? String(message["const"]) : message["const"];
@@ -42294,8 +42262,6 @@ export const validate = $root.validate = (() => {
                 for (let j = 0; j < message.notIn.length; ++j)
                     object.notIn[j] = options.json && !isFinite(message.notIn[j]) ? String(message.notIn[j]) : message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -42326,7 +42292,6 @@ export const validate = $root.validate = (() => {
          * @property {number|null} [gte] Int32Rules gte
          * @property {Array.<number>|null} ["in"] Int32Rules in
          * @property {Array.<number>|null} [notIn] Int32Rules notIn
-         * @property {boolean|null} [ignoreEmpty] Int32Rules ignoreEmpty
          */
 
         /**
@@ -42403,14 +42368,6 @@ export const validate = $root.validate = (() => {
         Int32Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * Int32Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.Int32Rules
-         * @instance
-         */
-        Int32Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies an Int32Rules message.
          * @function verify
          * @memberof validate.Int32Rules
@@ -42450,9 +42407,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]))
                         return "notIn: integer[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -42492,8 +42446,6 @@ export const validate = $root.validate = (() => {
                 for (let i = 0; i < object.notIn.length; ++i)
                     message.notIn[i] = object.notIn[i] | 0;
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -42520,7 +42472,6 @@ export const validate = $root.validate = (() => {
                 object.lte = 0;
                 object.gt = 0;
                 object.gte = 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = message["const"];
@@ -42542,8 +42493,6 @@ export const validate = $root.validate = (() => {
                 for (let j = 0; j < message.notIn.length; ++j)
                     object.notIn[j] = message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -42574,7 +42523,6 @@ export const validate = $root.validate = (() => {
          * @property {number|Long|null} [gte] Int64Rules gte
          * @property {Array.<number|Long>|null} ["in"] Int64Rules in
          * @property {Array.<number|Long>|null} [notIn] Int64Rules notIn
-         * @property {boolean|null} [ignoreEmpty] Int64Rules ignoreEmpty
          */
 
         /**
@@ -42651,14 +42599,6 @@ export const validate = $root.validate = (() => {
         Int64Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * Int64Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.Int64Rules
-         * @instance
-         */
-        Int64Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies an Int64Rules message.
          * @function verify
          * @memberof validate.Int64Rules
@@ -42698,9 +42638,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]) && !(message.notIn[i] && $util.isInteger(message.notIn[i].low) && $util.isInteger(message.notIn[i].high)))
                         return "notIn: integer|Long[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -42789,8 +42726,6 @@ export const validate = $root.validate = (() => {
                     else if (typeof object.notIn[i] === "object")
                         message.notIn[i] = new $util.LongBits(object.notIn[i].low >>> 0, object.notIn[i].high >>> 0).toNumber();
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -42837,7 +42772,6 @@ export const validate = $root.validate = (() => {
                     object.gte = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.gte = options.longs === String ? "0" : 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 if (typeof message["const"] === "number")
@@ -42880,8 +42814,6 @@ export const validate = $root.validate = (() => {
                     else
                         object.notIn[j] = options.longs === String ? $util.Long.prototype.toString.call(message.notIn[j]) : options.longs === Number ? new $util.LongBits(message.notIn[j].low >>> 0, message.notIn[j].high >>> 0).toNumber() : message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -42912,7 +42844,6 @@ export const validate = $root.validate = (() => {
          * @property {number|null} [gte] UInt32Rules gte
          * @property {Array.<number>|null} ["in"] UInt32Rules in
          * @property {Array.<number>|null} [notIn] UInt32Rules notIn
-         * @property {boolean|null} [ignoreEmpty] UInt32Rules ignoreEmpty
          */
 
         /**
@@ -42989,14 +42920,6 @@ export const validate = $root.validate = (() => {
         UInt32Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * UInt32Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.UInt32Rules
-         * @instance
-         */
-        UInt32Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a UInt32Rules message.
          * @function verify
          * @memberof validate.UInt32Rules
@@ -43036,9 +42959,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]))
                         return "notIn: integer[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -43078,8 +42998,6 @@ export const validate = $root.validate = (() => {
                 for (let i = 0; i < object.notIn.length; ++i)
                     message.notIn[i] = object.notIn[i] >>> 0;
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -43106,7 +43024,6 @@ export const validate = $root.validate = (() => {
                 object.lte = 0;
                 object.gt = 0;
                 object.gte = 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = message["const"];
@@ -43128,8 +43045,6 @@ export const validate = $root.validate = (() => {
                 for (let j = 0; j < message.notIn.length; ++j)
                     object.notIn[j] = message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -43160,7 +43075,6 @@ export const validate = $root.validate = (() => {
          * @property {number|Long|null} [gte] UInt64Rules gte
          * @property {Array.<number|Long>|null} ["in"] UInt64Rules in
          * @property {Array.<number|Long>|null} [notIn] UInt64Rules notIn
-         * @property {boolean|null} [ignoreEmpty] UInt64Rules ignoreEmpty
          */
 
         /**
@@ -43237,14 +43151,6 @@ export const validate = $root.validate = (() => {
         UInt64Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * UInt64Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.UInt64Rules
-         * @instance
-         */
-        UInt64Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a UInt64Rules message.
          * @function verify
          * @memberof validate.UInt64Rules
@@ -43284,9 +43190,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]) && !(message.notIn[i] && $util.isInteger(message.notIn[i].low) && $util.isInteger(message.notIn[i].high)))
                         return "notIn: integer|Long[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -43375,8 +43278,6 @@ export const validate = $root.validate = (() => {
                     else if (typeof object.notIn[i] === "object")
                         message.notIn[i] = new $util.LongBits(object.notIn[i].low >>> 0, object.notIn[i].high >>> 0).toNumber(true);
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -43423,7 +43324,6 @@ export const validate = $root.validate = (() => {
                     object.gte = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.gte = options.longs === String ? "0" : 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 if (typeof message["const"] === "number")
@@ -43466,8 +43366,6 @@ export const validate = $root.validate = (() => {
                     else
                         object.notIn[j] = options.longs === String ? $util.Long.prototype.toString.call(message.notIn[j]) : options.longs === Number ? new $util.LongBits(message.notIn[j].low >>> 0, message.notIn[j].high >>> 0).toNumber(true) : message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -43498,7 +43396,6 @@ export const validate = $root.validate = (() => {
          * @property {number|null} [gte] SInt32Rules gte
          * @property {Array.<number>|null} ["in"] SInt32Rules in
          * @property {Array.<number>|null} [notIn] SInt32Rules notIn
-         * @property {boolean|null} [ignoreEmpty] SInt32Rules ignoreEmpty
          */
 
         /**
@@ -43575,14 +43472,6 @@ export const validate = $root.validate = (() => {
         SInt32Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * SInt32Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.SInt32Rules
-         * @instance
-         */
-        SInt32Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a SInt32Rules message.
          * @function verify
          * @memberof validate.SInt32Rules
@@ -43622,9 +43511,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]))
                         return "notIn: integer[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -43664,8 +43550,6 @@ export const validate = $root.validate = (() => {
                 for (let i = 0; i < object.notIn.length; ++i)
                     message.notIn[i] = object.notIn[i] | 0;
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -43692,7 +43576,6 @@ export const validate = $root.validate = (() => {
                 object.lte = 0;
                 object.gt = 0;
                 object.gte = 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = message["const"];
@@ -43714,8 +43597,6 @@ export const validate = $root.validate = (() => {
                 for (let j = 0; j < message.notIn.length; ++j)
                     object.notIn[j] = message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -43746,7 +43627,6 @@ export const validate = $root.validate = (() => {
          * @property {number|Long|null} [gte] SInt64Rules gte
          * @property {Array.<number|Long>|null} ["in"] SInt64Rules in
          * @property {Array.<number|Long>|null} [notIn] SInt64Rules notIn
-         * @property {boolean|null} [ignoreEmpty] SInt64Rules ignoreEmpty
          */
 
         /**
@@ -43823,14 +43703,6 @@ export const validate = $root.validate = (() => {
         SInt64Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * SInt64Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.SInt64Rules
-         * @instance
-         */
-        SInt64Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a SInt64Rules message.
          * @function verify
          * @memberof validate.SInt64Rules
@@ -43870,9 +43742,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]) && !(message.notIn[i] && $util.isInteger(message.notIn[i].low) && $util.isInteger(message.notIn[i].high)))
                         return "notIn: integer|Long[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -43961,8 +43830,6 @@ export const validate = $root.validate = (() => {
                     else if (typeof object.notIn[i] === "object")
                         message.notIn[i] = new $util.LongBits(object.notIn[i].low >>> 0, object.notIn[i].high >>> 0).toNumber();
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -44009,7 +43876,6 @@ export const validate = $root.validate = (() => {
                     object.gte = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.gte = options.longs === String ? "0" : 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 if (typeof message["const"] === "number")
@@ -44052,8 +43918,6 @@ export const validate = $root.validate = (() => {
                     else
                         object.notIn[j] = options.longs === String ? $util.Long.prototype.toString.call(message.notIn[j]) : options.longs === Number ? new $util.LongBits(message.notIn[j].low >>> 0, message.notIn[j].high >>> 0).toNumber() : message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -44084,7 +43948,6 @@ export const validate = $root.validate = (() => {
          * @property {number|null} [gte] Fixed32Rules gte
          * @property {Array.<number>|null} ["in"] Fixed32Rules in
          * @property {Array.<number>|null} [notIn] Fixed32Rules notIn
-         * @property {boolean|null} [ignoreEmpty] Fixed32Rules ignoreEmpty
          */
 
         /**
@@ -44161,14 +44024,6 @@ export const validate = $root.validate = (() => {
         Fixed32Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * Fixed32Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.Fixed32Rules
-         * @instance
-         */
-        Fixed32Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a Fixed32Rules message.
          * @function verify
          * @memberof validate.Fixed32Rules
@@ -44208,9 +44063,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]))
                         return "notIn: integer[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -44250,8 +44102,6 @@ export const validate = $root.validate = (() => {
                 for (let i = 0; i < object.notIn.length; ++i)
                     message.notIn[i] = object.notIn[i] >>> 0;
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -44278,7 +44128,6 @@ export const validate = $root.validate = (() => {
                 object.lte = 0;
                 object.gt = 0;
                 object.gte = 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = message["const"];
@@ -44300,8 +44149,6 @@ export const validate = $root.validate = (() => {
                 for (let j = 0; j < message.notIn.length; ++j)
                     object.notIn[j] = message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -44332,7 +44179,6 @@ export const validate = $root.validate = (() => {
          * @property {number|Long|null} [gte] Fixed64Rules gte
          * @property {Array.<number|Long>|null} ["in"] Fixed64Rules in
          * @property {Array.<number|Long>|null} [notIn] Fixed64Rules notIn
-         * @property {boolean|null} [ignoreEmpty] Fixed64Rules ignoreEmpty
          */
 
         /**
@@ -44409,14 +44255,6 @@ export const validate = $root.validate = (() => {
         Fixed64Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * Fixed64Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.Fixed64Rules
-         * @instance
-         */
-        Fixed64Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a Fixed64Rules message.
          * @function verify
          * @memberof validate.Fixed64Rules
@@ -44456,9 +44294,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]) && !(message.notIn[i] && $util.isInteger(message.notIn[i].low) && $util.isInteger(message.notIn[i].high)))
                         return "notIn: integer|Long[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -44547,8 +44382,6 @@ export const validate = $root.validate = (() => {
                     else if (typeof object.notIn[i] === "object")
                         message.notIn[i] = new $util.LongBits(object.notIn[i].low >>> 0, object.notIn[i].high >>> 0).toNumber();
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -44595,7 +44428,6 @@ export const validate = $root.validate = (() => {
                     object.gte = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.gte = options.longs === String ? "0" : 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 if (typeof message["const"] === "number")
@@ -44638,8 +44470,6 @@ export const validate = $root.validate = (() => {
                     else
                         object.notIn[j] = options.longs === String ? $util.Long.prototype.toString.call(message.notIn[j]) : options.longs === Number ? new $util.LongBits(message.notIn[j].low >>> 0, message.notIn[j].high >>> 0).toNumber() : message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -44670,7 +44500,6 @@ export const validate = $root.validate = (() => {
          * @property {number|null} [gte] SFixed32Rules gte
          * @property {Array.<number>|null} ["in"] SFixed32Rules in
          * @property {Array.<number>|null} [notIn] SFixed32Rules notIn
-         * @property {boolean|null} [ignoreEmpty] SFixed32Rules ignoreEmpty
          */
 
         /**
@@ -44747,14 +44576,6 @@ export const validate = $root.validate = (() => {
         SFixed32Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * SFixed32Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.SFixed32Rules
-         * @instance
-         */
-        SFixed32Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a SFixed32Rules message.
          * @function verify
          * @memberof validate.SFixed32Rules
@@ -44794,9 +44615,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]))
                         return "notIn: integer[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -44836,8 +44654,6 @@ export const validate = $root.validate = (() => {
                 for (let i = 0; i < object.notIn.length; ++i)
                     message.notIn[i] = object.notIn[i] | 0;
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -44864,7 +44680,6 @@ export const validate = $root.validate = (() => {
                 object.lte = 0;
                 object.gt = 0;
                 object.gte = 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = message["const"];
@@ -44886,8 +44701,6 @@ export const validate = $root.validate = (() => {
                 for (let j = 0; j < message.notIn.length; ++j)
                     object.notIn[j] = message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -44918,7 +44731,6 @@ export const validate = $root.validate = (() => {
          * @property {number|Long|null} [gte] SFixed64Rules gte
          * @property {Array.<number|Long>|null} ["in"] SFixed64Rules in
          * @property {Array.<number|Long>|null} [notIn] SFixed64Rules notIn
-         * @property {boolean|null} [ignoreEmpty] SFixed64Rules ignoreEmpty
          */
 
         /**
@@ -44995,14 +44807,6 @@ export const validate = $root.validate = (() => {
         SFixed64Rules.prototype.notIn = $util.emptyArray;
 
         /**
-         * SFixed64Rules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.SFixed64Rules
-         * @instance
-         */
-        SFixed64Rules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a SFixed64Rules message.
          * @function verify
          * @memberof validate.SFixed64Rules
@@ -45042,9 +44846,6 @@ export const validate = $root.validate = (() => {
                     if (!$util.isInteger(message.notIn[i]) && !(message.notIn[i] && $util.isInteger(message.notIn[i].low) && $util.isInteger(message.notIn[i].high)))
                         return "notIn: integer|Long[] expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -45133,8 +44934,6 @@ export const validate = $root.validate = (() => {
                     else if (typeof object.notIn[i] === "object")
                         message.notIn[i] = new $util.LongBits(object.notIn[i].low >>> 0, object.notIn[i].high >>> 0).toNumber();
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -45181,7 +44980,6 @@ export const validate = $root.validate = (() => {
                     object.gte = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.gte = options.longs === String ? "0" : 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 if (typeof message["const"] === "number")
@@ -45224,8 +45022,6 @@ export const validate = $root.validate = (() => {
                     else
                         object.notIn[j] = options.longs === String ? $util.Long.prototype.toString.call(message.notIn[j]) : options.longs === Number ? new $util.LongBits(message.notIn[j].low >>> 0, message.notIn[j].high >>> 0).toNumber() : message.notIn[j];
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -45374,7 +45170,6 @@ export const validate = $root.validate = (() => {
          * @property {boolean|null} [uuid] StringRules uuid
          * @property {validate.KnownRegex|null} [wellKnownRegex] StringRules wellKnownRegex
          * @property {boolean|null} [strict] StringRules strict
-         * @property {boolean|null} [ignoreEmpty] StringRules ignoreEmpty
          */
 
         /**
@@ -45594,14 +45389,6 @@ export const validate = $root.validate = (() => {
          */
         StringRules.prototype.strict = true;
 
-        /**
-         * StringRules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.StringRules
-         * @instance
-         */
-        StringRules.prototype.ignoreEmpty = false;
-
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
@@ -45755,9 +45542,6 @@ export const validate = $root.validate = (() => {
             if (message.strict != null && message.hasOwnProperty("strict"))
                 if (typeof message.strict !== "boolean")
                     return "strict: boolean expected";
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -45887,8 +45671,6 @@ export const validate = $root.validate = (() => {
             }
             if (object.strict != null)
                 message.strict = Boolean(object.strict);
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -45947,7 +45729,6 @@ export const validate = $root.validate = (() => {
                     object.lenBytes = options.longs === String ? "0" : 0;
                 object.notContains = "";
                 object.strict = true;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = message["const"];
@@ -46053,8 +45834,6 @@ export const validate = $root.validate = (() => {
             }
             if (message.strict != null && message.hasOwnProperty("strict"))
                 object.strict = message.strict;
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -46107,7 +45886,6 @@ export const validate = $root.validate = (() => {
          * @property {boolean|null} [ip] BytesRules ip
          * @property {boolean|null} [ipv4] BytesRules ipv4
          * @property {boolean|null} [ipv6] BytesRules ipv6
-         * @property {boolean|null} [ignoreEmpty] BytesRules ignoreEmpty
          */
 
         /**
@@ -46231,14 +46009,6 @@ export const validate = $root.validate = (() => {
          */
         BytesRules.prototype.ipv6 = false;
 
-        /**
-         * BytesRules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.BytesRules
-         * @instance
-         */
-        BytesRules.prototype.ignoreEmpty = false;
-
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
@@ -46322,9 +46092,6 @@ export const validate = $root.validate = (() => {
                 if (typeof message.ipv6 !== "boolean")
                     return "ipv6: boolean expected";
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -46415,8 +46182,6 @@ export const validate = $root.validate = (() => {
                 message.ipv4 = Boolean(object.ipv4);
             if (object.ipv6 != null)
                 message.ipv6 = Boolean(object.ipv6);
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -46482,7 +46247,6 @@ export const validate = $root.validate = (() => {
                     object.len = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.len = options.longs === String ? "0" : 0;
-                object.ignoreEmpty = false;
             }
             if (message["const"] != null && message.hasOwnProperty("const"))
                 object["const"] = options.bytes === String ? $util.base64.encode(message["const"], 0, message["const"].length) : options.bytes === Array ? Array.prototype.slice.call(message["const"]) : message["const"];
@@ -46534,8 +46298,6 @@ export const validate = $root.validate = (() => {
                     object.len = options.longs === String ? String(message.len) : message.len;
                 else
                     object.len = options.longs === String ? $util.Long.prototype.toString.call(message.len) : options.longs === Number ? new $util.LongBits(message.len.low >>> 0, message.len.high >>> 0).toNumber(true) : message.len;
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -46861,7 +46623,6 @@ export const validate = $root.validate = (() => {
          * @property {number|Long|null} [maxItems] RepeatedRules maxItems
          * @property {boolean|null} [unique] RepeatedRules unique
          * @property {validate.IFieldRules|null} [items] RepeatedRules items
-         * @property {boolean|null} [ignoreEmpty] RepeatedRules ignoreEmpty
          */
 
         /**
@@ -46912,14 +46673,6 @@ export const validate = $root.validate = (() => {
         RepeatedRules.prototype.items = null;
 
         /**
-         * RepeatedRules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.RepeatedRules
-         * @instance
-         */
-        RepeatedRules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a RepeatedRules message.
          * @function verify
          * @memberof validate.RepeatedRules
@@ -46944,9 +46697,6 @@ export const validate = $root.validate = (() => {
                 if (error)
                     return "items." + error;
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -46987,8 +46737,6 @@ export const validate = $root.validate = (() => {
                     throw TypeError(".validate.RepeatedRules.items: object expected");
                 message.items = $root.validate.FieldRules.fromObject(object.items);
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -47018,7 +46766,6 @@ export const validate = $root.validate = (() => {
                     object.maxItems = options.longs === String ? "0" : 0;
                 object.unique = false;
                 object.items = null;
-                object.ignoreEmpty = false;
             }
             if (message.minItems != null && message.hasOwnProperty("minItems"))
                 if (typeof message.minItems === "number")
@@ -47034,8 +46781,6 @@ export const validate = $root.validate = (() => {
                 object.unique = message.unique;
             if (message.items != null && message.hasOwnProperty("items"))
                 object.items = $root.validate.FieldRules.toObject(message.items, options);
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -47064,7 +46809,6 @@ export const validate = $root.validate = (() => {
          * @property {boolean|null} [noSparse] MapRules noSparse
          * @property {validate.IFieldRules|null} [keys] MapRules keys
          * @property {validate.IFieldRules|null} [values] MapRules values
-         * @property {boolean|null} [ignoreEmpty] MapRules ignoreEmpty
          */
 
         /**
@@ -47123,14 +46867,6 @@ export const validate = $root.validate = (() => {
         MapRules.prototype.values = null;
 
         /**
-         * MapRules ignoreEmpty.
-         * @member {boolean} ignoreEmpty
-         * @memberof validate.MapRules
-         * @instance
-         */
-        MapRules.prototype.ignoreEmpty = false;
-
-        /**
          * Verifies a MapRules message.
          * @function verify
          * @memberof validate.MapRules
@@ -47160,9 +46896,6 @@ export const validate = $root.validate = (() => {
                 if (error)
                     return "values." + error;
             }
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                if (typeof message.ignoreEmpty !== "boolean")
-                    return "ignoreEmpty: boolean expected";
             return null;
         };
 
@@ -47208,8 +46941,6 @@ export const validate = $root.validate = (() => {
                     throw TypeError(".validate.MapRules.values: object expected");
                 message.values = $root.validate.FieldRules.fromObject(object.values);
             }
-            if (object.ignoreEmpty != null)
-                message.ignoreEmpty = Boolean(object.ignoreEmpty);
             return message;
         };
 
@@ -47240,7 +46971,6 @@ export const validate = $root.validate = (() => {
                 object.noSparse = false;
                 object.keys = null;
                 object.values = null;
-                object.ignoreEmpty = false;
             }
             if (message.minPairs != null && message.hasOwnProperty("minPairs"))
                 if (typeof message.minPairs === "number")
@@ -47258,8 +46988,6 @@ export const validate = $root.validate = (() => {
                 object.keys = $root.validate.FieldRules.toObject(message.keys, options);
             if (message.values != null && message.hasOwnProperty("values"))
                 object.values = $root.validate.FieldRules.toObject(message.values, options);
-            if (message.ignoreEmpty != null && message.hasOwnProperty("ignoreEmpty"))
-                object.ignoreEmpty = message.ignoreEmpty;
             return object;
         };
 
@@ -51229,7 +50957,6 @@ export const google = $root.google = (() => {
              * @property {clutch.api.v1.IIdentifier|null} [".clutch.api.v1.id"] MessageOptions .clutch.api.v1.id
              * @property {boolean|null} [".clutch.api.v1.redacted"] MessageOptions .clutch.api.v1.redacted
              * @property {boolean|null} [".validate.disabled"] MessageOptions .validate.disabled
-             * @property {boolean|null} [".validate.ignored"] MessageOptions .validate.ignored
              * @property {clutch.resolver.v1.ISchemaMetadata|null} [".clutch.resolver.v1.schema"] MessageOptions .clutch.resolver.v1.schema
              */
 
@@ -51322,14 +51049,6 @@ export const google = $root.google = (() => {
             MessageOptions.prototype[".validate.disabled"] = false;
 
             /**
-             * MessageOptions .validate.ignored.
-             * @member {boolean} .validate.ignored
-             * @memberof google.protobuf.MessageOptions
-             * @instance
-             */
-            MessageOptions.prototype[".validate.ignored"] = false;
-
-            /**
              * MessageOptions .clutch.resolver.v1.schema.
              * @member {clutch.resolver.v1.ISchemaMetadata|null|undefined} .clutch.resolver.v1.schema
              * @memberof google.protobuf.MessageOptions
@@ -51385,9 +51104,6 @@ export const google = $root.google = (() => {
                 if (message[".validate.disabled"] != null && message.hasOwnProperty(".validate.disabled"))
                     if (typeof message[".validate.disabled"] !== "boolean")
                         return ".validate.disabled: boolean expected";
-                if (message[".validate.ignored"] != null && message.hasOwnProperty(".validate.ignored"))
-                    if (typeof message[".validate.ignored"] !== "boolean")
-                        return ".validate.ignored: boolean expected";
                 if (message[".clutch.resolver.v1.schema"] != null && message.hasOwnProperty(".clutch.resolver.v1.schema")) {
                     let error = $root.clutch.resolver.v1.SchemaMetadata.verify(message[".clutch.resolver.v1.schema"]);
                     if (error)
@@ -51440,8 +51156,6 @@ export const google = $root.google = (() => {
                     message[".clutch.api.v1.redacted"] = Boolean(object[".clutch.api.v1.redacted"]);
                 if (object[".validate.disabled"] != null)
                     message[".validate.disabled"] = Boolean(object[".validate.disabled"]);
-                if (object[".validate.ignored"] != null)
-                    message[".validate.ignored"] = Boolean(object[".validate.ignored"]);
                 if (object[".clutch.resolver.v1.schema"] != null) {
                     if (typeof object[".clutch.resolver.v1.schema"] !== "object")
                         throw TypeError(".google.protobuf.MessageOptions..clutch.resolver.v1.schema: object expected");
@@ -51471,7 +51185,6 @@ export const google = $root.google = (() => {
                     object.deprecated = false;
                     object.mapEntry = false;
                     object[".validate.disabled"] = false;
-                    object[".validate.ignored"] = false;
                     object[".clutch.api.v1.reference"] = null;
                     object[".clutch.api.v1.id"] = null;
                     object[".clutch.api.v1.redacted"] = false;
@@ -51492,8 +51205,6 @@ export const google = $root.google = (() => {
                 }
                 if (message[".validate.disabled"] != null && message.hasOwnProperty(".validate.disabled"))
                     object[".validate.disabled"] = message[".validate.disabled"];
-                if (message[".validate.ignored"] != null && message.hasOwnProperty(".validate.ignored"))
-                    object[".validate.ignored"] = message[".validate.ignored"];
                 if (message[".clutch.api.v1.reference"] != null && message.hasOwnProperty(".clutch.api.v1.reference"))
                     object[".clutch.api.v1.reference"] = $root.clutch.api.v1.Reference.toObject(message[".clutch.api.v1.reference"], options);
                 if (message[".clutch.api.v1.id"] != null && message.hasOwnProperty(".clutch.api.v1.id"))


### PR DESCRIPTION
This reverts commit 49f42bbf300faec5279b21d340ac80f8f3e00962.

<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
