### PR TITLE
ci: ensure backend & frontend start in e2e test

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -10,6 +10,7 @@ on:
     - 'frontend/**'
     - .github/workflows/frontend.yml
     - Makefile
+    - tools/frontend-e2e.sh
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/tools/frontend-e2e.sh
+++ b/tools/frontend-e2e.sh
@@ -14,7 +14,7 @@ until curl --output /dev/null --silent --head --fail http://localhost:3000; do
     #     echo "Error: could not start frontend dev server"
     #     exit 1
     # fi;
-    # ((FE_STARTUP_COUNT++))
+    ((FE_STARTUP_COUNT++))
     sleep 1
 done
 
@@ -23,7 +23,7 @@ until curl --output /dev/null --silent --fail http://localhost:8080/healthcheck;
     #     echo "Error: could not start backend mock server"
     #     exit 1
     # fi;
-    # ((BE_STARTUP_COUNT++))
+    ((BE_STARTUP_COUNT++))
     sleep 1
 done
 (

--- a/tools/frontend-e2e.sh
+++ b/tools/frontend-e2e.sh
@@ -10,20 +10,20 @@ STARTUP_WAIT=30
 make backend-dev-mock &
 yarn --cwd frontend workspace @clutch-sh/app start &
 until curl --output /dev/null --silent --head --fail http://localhost:3000; do
-    if [ "$FE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
-        echo "Error: could not start frontend dev server"
-        exit 1
-    fi;
-    ((FE_STARTUP_COUNT++))
+    # if [ "$FE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
+    #     echo "Error: could not start frontend dev server"
+    #     exit 1
+    # fi;
+    # ((FE_STARTUP_COUNT++))
     sleep 1
 done
 
 until curl --output /dev/null --silent --fail http://localhost:8080/healthcheck; do
-    if [ "$BE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
-        echo "Error: could not start backend mock server"
-        exit 1
-    fi;
-    ((BE_STARTUP_COUNT++))
+    # if [ "$BE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
+    #     echo "Error: could not start backend mock server"
+    #     exit 1
+    # fi;
+    # ((BE_STARTUP_COUNT++))
     sleep 1
 done
 (

--- a/tools/frontend-e2e.sh
+++ b/tools/frontend-e2e.sh
@@ -10,19 +10,19 @@ STARTUP_WAIT=30
 make backend-dev-mock &
 yarn --cwd frontend workspace @clutch-sh/app start &
 until curl --output /dev/null --silent --head --fail http://localhost:3000; do
-    # if [ "$FE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
-    #     echo "Error: could not start frontend dev server"
-    #     exit 1
-    # fi;
+    if [ "$FE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
+        echo "Error: could not start frontend dev server"
+        exit 1
+    fi;
     BE_STARTUP_COUNT=$((BE_STARTUP_COUNT+1))
     sleep 1
 done
 
 until curl --output /dev/null --silent --fail http://localhost:8080/healthcheck; do
-    # if [ "$BE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
-    #     echo "Error: could not start backend mock server"
-    #     exit 1
-    # fi;
+    if [ "$BE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
+        echo "Error: could not start backend mock server"
+        exit 1
+    fi;
     FE_STARTUP_COUNT=$((FE_STARTUP_COUNT+1))
     sleep 1
 done

--- a/tools/frontend-e2e.sh
+++ b/tools/frontend-e2e.sh
@@ -14,7 +14,7 @@ until curl --output /dev/null --silent --head --fail http://localhost:3000; do
     #     echo "Error: could not start frontend dev server"
     #     exit 1
     # fi;
-    ((FE_STARTUP_COUNT++))
+    BE_STARTUP_COUNT=$((BE_STARTUP_COUNT+1))
     sleep 1
 done
 
@@ -23,7 +23,7 @@ until curl --output /dev/null --silent --fail http://localhost:8080/healthcheck;
     #     echo "Error: could not start backend mock server"
     #     exit 1
     # fi;
-    ((BE_STARTUP_COUNT++))
+    FE_STARTUP_COUNT=$((FE_STARTUP_COUNT+1))
     sleep 1
 done
 (

--- a/tools/frontend-e2e.sh
+++ b/tools/frontend-e2e.sh
@@ -3,9 +3,27 @@ trap "exit" INT TERM
 trap 'kill $(jobs -p)' EXIT
 set -euo pipefail
 
+BE_STARTUP_COUNT=0
+FE_STARTUP_COUNT=0
+STARTUP_WAIT=30
+
 make backend-dev-mock &
 yarn --cwd frontend workspace @clutch-sh/app start &
 until curl --output /dev/null --silent --head --fail http://localhost:3000; do
+    if [ "$FE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
+        echo "Error: could not start frontend dev server"
+        exit 1
+    fi;
+    ((FE_STARTUP_COUNT++))
+    sleep 1
+done
+
+until curl --output /dev/null --silent --fail http://localhost:8080/healthcheck; do
+    if [ "$BE_STARTUP_COUNT" -ge "$STARTUP_WAIT" ]; then
+        echo "Error: could not start backend mock server"
+        exit 1
+    fi;
+    ((BE_STARTUP_COUNT++))
     sleep 1
 done
 (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Modify the frontend-e2e script to:
- wait until backend has successfully started
- limit both frontend and backend startup window to 30 seconds before failing

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
