### PR TITLE
frontend: support tab variants

### DIFF
--- a/frontend/packages/core/src/stories/tabs.stories.tsx
+++ b/frontend/packages/core/src/stories/tabs.stories.tsx
@@ -12,8 +12,8 @@ export default {
   },
 } as Meta;
 
-const Template = ({ tabCount, value }: TabsProps & { tabCount: number }) => (
-  <Tabs value={value - 1}>
+const Template = ({ tabCount, value, variant }: TabsProps & { tabCount: number }) => (
+  <Tabs value={value - 1} variant={variant}>
     {[...Array(tabCount)].map((_, index: number) => (
       // eslint-disable-next-line react/no-array-index-key
       <Tab key={index} label={`Tab ${index + 1}`} value={index}>
@@ -27,4 +27,11 @@ export const Primary = Template.bind({});
 Primary.args = {
   tabCount: 2,
   value: 1,
+};
+
+export const FullWidth = Template.bind({});
+FullWidth.args = {
+  tabCount: 2,
+  value: 1,
+  variant: "fullWidth"
 };

--- a/frontend/packages/core/src/stories/tabs.stories.tsx
+++ b/frontend/packages/core/src/stories/tabs.stories.tsx
@@ -33,5 +33,5 @@ export const FullWidth = Template.bind({});
 FullWidth.args = {
   tabCount: 2,
   value: 1,
-  variant: "fullWidth"
+  variant: "fullWidth",
 };

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -78,7 +78,7 @@ export const Tabs = ({ children, value, variant }: TabsProps) => {
 
   return (
     <div style={{ width: "100%" }}>
-      <TabContext value={selectedIndex} >
+      <TabContext value={selectedIndex}>
         <StyledTabs variant={variant} onChange={onChangeMiddleware}>
           {React.Children.map(children, (child, index) =>
             React.cloneElement(child, { value: index.toString() })

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -66,26 +66,28 @@ const TabPanel = styled(MuiTabPanel)({
   maxWidth: "100%",
 });
 
-export interface TabsProps extends Pick<MuiTabsProps, "value"> {
+export interface TabsProps extends Pick<MuiTabsProps, "value" | "variant"> {
   children: React.ReactElement<TabProps> | React.ReactElement<TabProps>[];
 }
 
-export const Tabs = ({ children, value }: TabsProps) => {
+export const Tabs = ({ children, value, variant }: TabsProps) => {
   const [selectedIndex, setSelectedIndex] = React.useState((value || 0).toString());
   const onChangeMiddleware = (_, v: string) => {
     setSelectedIndex(v);
   };
 
   return (
-    <TabContext value={selectedIndex}>
-      <StyledTabs onChange={onChangeMiddleware}>
-        {React.Children.map(children, (child, index) =>
-          React.cloneElement(child, { value: index.toString() })
-        )}
-      </StyledTabs>
-      {React.Children.map(children, (tab, index) => (
-        <TabPanel value={index.toString()}>{tab.props?.children}</TabPanel>
-      ))}
-    </TabContext>
+    <div style={{ width: "100%" }}>
+      <TabContext value={selectedIndex} >
+        <StyledTabs variant={variant} onChange={onChangeMiddleware}>
+          {React.Children.map(children, (child, index) =>
+            React.cloneElement(child, { value: index.toString() })
+          )}
+        </StyledTabs>
+        {React.Children.map(children, (tab, index) => (
+          <TabPanel value={index.toString()}>{tab.props?.children}</TabPanel>
+        ))}
+      </TabContext>
+    </div>
   );
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Adds support for the variant prop in the Tab component. This allows for full width tabs.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-03-17 at 11 44 14 PM](https://user-images.githubusercontent.com/1004789/111584366-fb7d8800-877a-11eb-80a8-eaee9a8a2e23.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
stories & manual
