### PR TITLE
resolver: remove use of deprecated proto APIs

### DIFF
--- a/backend/module/resolver/response.go
+++ b/backend/module/resolver/response.go
@@ -2,10 +2,9 @@ package resolver
 
 import (
 	"fmt"
+	"google.golang.org/protobuf/types/known/anypb"
 	"strings"
 
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,14 +16,14 @@ import (
 
 func newResponse() *response {
 	return &response{
-		Results:         []*any.Any{},
+		Results:         []*anypb.Any{},
 		PartialFailures: []*statuspb.Status{},
 	}
 }
 
 // Generic object to handle common operations for SearchResponse and ResolveResponse.
 type response struct {
-	Results         []*any.Any
+	Results         []*anypb.Any
 	PartialFailures []*statuspb.Status
 }
 
@@ -47,7 +46,7 @@ func (r *response) truncate(limit uint32) {
 
 func (r *response) marshalResults(results *resolver.Results) error {
 	for _, result := range results.Messages {
-		asAny, err := ptypes.MarshalAny(result)
+		asAny, err := anypb.New(result)
 		if err != nil {
 			return err
 		}

--- a/backend/module/resolver/response.go
+++ b/backend/module/resolver/response.go
@@ -2,12 +2,12 @@ package resolver
 
 import (
 	"fmt"
-	"google.golang.org/protobuf/types/known/anypb"
 	"strings"
 
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	apiv1 "github.com/lyft/clutch/backend/api/api/v1"
 	"github.com/lyft/clutch/backend/gateway/statuserr"

--- a/backend/module/resolver/response_test.go
+++ b/backend/module/resolver/response_test.go
@@ -3,11 +3,11 @@ package resolver
 import (
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	apiv1 "github.com/lyft/clutch/backend/api/api/v1"

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,8 +7,8 @@ package aws
 import (
 	"context"
 	"errors"
+	proto2 "google.golang.org/protobuf/proto"
 
-	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
@@ -34,7 +34,7 @@ var typeURLInstance = meta.TypeURL((*ec2v1api.Instance)(nil))
 var typeURLAutoscalingGroup = meta.TypeURL((*ec2v1api.AutoscalingGroup)(nil))
 var typeURLKinesisStream = meta.TypeURL((*kinesisv1api.Stream)(nil))
 
-var typeSchemas = map[string][]descriptor.Message{
+var typeSchemas = map[string][]proto2.Message{
 	typeURLInstance: {
 		(*awsv1resolver.InstanceID)(nil),
 	},

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,6 +7,7 @@ package aws
 import (
 	"context"
 	"errors"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,8 +7,6 @@ package aws
 import (
 	"context"
 	"errors"
-	proto2 "google.golang.org/protobuf/proto"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
@@ -34,7 +32,7 @@ var typeURLInstance = meta.TypeURL((*ec2v1api.Instance)(nil))
 var typeURLAutoscalingGroup = meta.TypeURL((*ec2v1api.AutoscalingGroup)(nil))
 var typeURLKinesisStream = meta.TypeURL((*kinesisv1api.Stream)(nil))
 
-var typeSchemas = map[string][]proto2.Message{
+var typeSchemas = resolver.TypeURLToSchemaMessagesMap{
 	typeURLInstance: {
 		(*awsv1resolver.InstanceID)(nil),
 	},

--- a/backend/resolver/fanouthandler.go
+++ b/backend/resolver/fanouthandler.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type FanoutResult struct {

--- a/backend/resolver/fanouthandler_test.go
+++ b/backend/resolver/fanouthandler_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 
 	healthcheckv1 "github.com/lyft/clutch/backend/api/healthcheck/v1"
 )

--- a/backend/resolver/k8s/k8s.go
+++ b/backend/resolver/k8s/k8s.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	proto2 "google.golang.org/protobuf/proto"
 	"regexp"
 
-	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
@@ -34,7 +34,7 @@ const Name = "clutch.resolver.k8s"
 var typeURLPod = meta.TypeURL((*k8sv1api.Pod)(nil))
 var typeURLHPA = meta.TypeURL((*k8sv1api.HPA)(nil))
 
-var typeSchemas = map[string][]descriptor.Message{
+var typeSchemas = map[string][]proto2.Message{
 	typeURLPod: {
 		(*k8sv1resolver.PodID)(nil),
 	},

--- a/backend/resolver/k8s/k8s.go
+++ b/backend/resolver/k8s/k8s.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	proto2 "google.golang.org/protobuf/proto"
 	"regexp"
 
 	"github.com/golang/protobuf/proto"
@@ -34,7 +33,7 @@ const Name = "clutch.resolver.k8s"
 var typeURLPod = meta.TypeURL((*k8sv1api.Pod)(nil))
 var typeURLHPA = meta.TypeURL((*k8sv1api.HPA)(nil))
 
-var typeSchemas = map[string][]proto2.Message{
+var typeSchemas = resolver.TypeURLToSchemaMessagesMap{
 	typeURLPod: {
 		(*k8sv1resolver.PodID)(nil),
 	},

--- a/backend/resolver/resolver.go
+++ b/backend/resolver/resolver.go
@@ -3,12 +3,12 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"google.golang.org/protobuf/types/known/anypb"
 	"reflect"
 
 	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
@@ -25,7 +25,7 @@ const (
 
 type TypeURLToSchemasMap map[string][]*resolverv1.Schema
 
-type Factory map[string]func(*any.Any, *zap.Logger, tally.Scope) (Resolver, error)
+type Factory map[string]func(*anypb.Any, *zap.Logger, tally.Scope) (Resolver, error)
 
 var Registry = map[string]Resolver{}
 
@@ -53,7 +53,7 @@ func TypeURL(m proto.Message) string {
 	return TypePrefix + string(proto.MessageReflect(m).Descriptor().FullName())
 }
 
-func MarshalProtoSlice(pbs interface{}) ([]*any.Any, error) {
+func MarshalProtoSlice(pbs interface{}) ([]*anypb.Any, error) {
 	if pbs == nil {
 		return nil, nil
 	}
@@ -66,7 +66,7 @@ func MarshalProtoSlice(pbs interface{}) ([]*any.Any, error) {
 	}
 
 	s := reflect.ValueOf(pbs)
-	ret := make([]*any.Any, s.Len())
+	ret := make([]*anypb.Any, s.Len())
 	for i := 0; i < s.Len(); i++ {
 		item := s.Index(i)
 

--- a/backend/resolver/resolver.go
+++ b/backend/resolver/resolver.go
@@ -5,16 +5,15 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/lyft/clutch/backend/gateway/meta"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
-
 	protodeprecated "github.com/golang/protobuf/proto"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	resolverv1 "github.com/lyft/clutch/backend/api/resolver/v1"
+	"github.com/lyft/clutch/backend/gateway/meta"
 )
 
 const (

--- a/backend/resolver/resolver.go
+++ b/backend/resolver/resolver.go
@@ -3,13 +3,13 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	"github.com/lyft/clutch/backend/gateway/meta"
 	proto2 "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-	"reflect"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
@@ -31,7 +31,7 @@ type Factory map[string]func(*anypb.Any, *zap.Logger, tally.Scope) (Resolver, er
 var Registry = map[string]Resolver{}
 
 type Results struct {
-	Messages        []proto.Message
+	Messages        []proto2.Message
 	PartialFailures []*status.Status
 }
 
@@ -71,11 +71,11 @@ func MarshalProtoSlice(pbs interface{}) ([]*anypb.Any, error) {
 	for i := 0; i < s.Len(); i++ {
 		item := s.Index(i)
 
-		v, ok := item.Interface().(proto.Message)
+		v, ok := item.Interface().(proto2.Message)
 		if !ok {
 			return nil, fmt.Errorf("could not use %s as proto.Message", item.Kind())
 		}
-		a, err := ptypes.MarshalAny(v)
+		a, err := anypb.New(v)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/resolver/resolver_test.go
+++ b/backend/resolver/resolver_test.go
@@ -1,17 +1,17 @@
 package resolver
 
 import (
-	"github.com/lyft/clutch/backend/gateway/meta"
-	proto2 "google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
+	proto2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
 	k8sv1resolver "github.com/lyft/clutch/backend/api/resolver/k8s/v1"
 	resolverv1 "github.com/lyft/clutch/backend/api/resolver/v1"
+	"github.com/lyft/clutch/backend/gateway/meta"
 )
 
 // Check that our TypeURL function matches proto's interpretation of the URL.

--- a/backend/resolver/resolver_test.go
+++ b/backend/resolver/resolver_test.go
@@ -1,9 +1,11 @@
 package resolver
 
 import (
+	"github.com/lyft/clutch/backend/gateway/meta"
+	proto2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"testing"
 
-	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 
@@ -14,17 +16,17 @@ import (
 
 // Check that our TypeURL function matches proto's interpretation of the URL.
 func TestTypeURL(t *testing.T) {
-	u := TypeURL((*resolverv1.Schema)(nil))
+	u := meta.TypeURL((*resolverv1.Schema)(nil))
 
 	s := &resolverv1.Schema{}
-	a, _ := ptypes.MarshalAny(s)
+	a, _ := anypb.New(s)
 	assert.Equal(t, u, a.TypeUrl)
 	assert.Equal(t, u, "type.googleapis.com/clutch.resolver.v1.Schema")
 }
 
 func TestInputsToSchema(t *testing.T) {
 	tp := "type.googleapis.com/foo.v1.Bar"
-	m, err := InputsToSchemas(map[string][]descriptor.Message{
+	m, err := InputsToSchemas(map[string][]proto2.Message{
 		tp: {
 			(*k8sv1resolver.PodID)(nil),
 		},
@@ -32,7 +34,7 @@ func TestInputsToSchema(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, m, 1)
 	assert.Len(t, m[tp], 1)
-	assert.Equal(t, TypeURL((*k8sv1resolver.PodID)(nil)), m[tp][0].TypeUrl)
+	assert.Equal(t, meta.TypeURL((*k8sv1resolver.PodID)(nil)), m[tp][0].TypeUrl)
 	assert.NotEmpty(t, m[tp][0].Metadata.DisplayName)
 	assert.NotEmpty(t, m[tp][0].Fields)
 }

--- a/backend/resolver/resolver_test.go
+++ b/backend/resolver/resolver_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
-	proto2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
@@ -26,7 +26,7 @@ func TestTypeURL(t *testing.T) {
 
 func TestInputsToSchema(t *testing.T) {
 	tp := "type.googleapis.com/foo.v1.Bar"
-	m, err := InputsToSchemas(map[string][]proto2.Message{
+	m, err := InputsToSchemas(map[string][]proto.Message{
 		tp: {
 			(*k8sv1resolver.PodID)(nil),
 		},


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
We need to migrate away from deprecated APIs before upgrading to the next wave of golang proto modules or we'll start failing lint for use of deprecated functions.

### Testing Performed
Unit, local.