### PR TITLE
frontend: inherit width in form component

### DIFF
--- a/frontend/packages/core/src/Input/form.tsx
+++ b/frontend/packages/core/src/Input/form.tsx
@@ -4,6 +4,7 @@ const Form = styled.form({
   "> *": {
     margin: "8px 0",
   },
+  width: inherit,
 });
 
 export default Form;

--- a/frontend/packages/core/src/Input/form.tsx
+++ b/frontend/packages/core/src/Input/form.tsx
@@ -4,7 +4,7 @@ const Form = styled.form({
   "> *": {
     margin: "8px 0",
   },
-  width: inherit,
+  width: "inherit",
 });
 
 export default Form;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Inherit form width from parent components to prevent resizing any of the form children.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
