### PR TITLE
frontend: reset data layout data on restart

### DIFF
--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -7,6 +7,7 @@ enum ManagerAction {
   HYDRATE_END,
   SET,
   UPDATE,
+  RESET,
 }
 
 export interface ManagerLayout {
@@ -36,6 +37,7 @@ export interface Action {
 
 const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
   const layoutKey = action?.payload?.key;
+  const stateClone = { ...state };
 
   switch (action.type) {
     case ManagerAction.HYDRATE_START:
@@ -84,6 +86,16 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
           ...action.payload?.value,
         },
       };
+    case ManagerAction.RESET:
+      Object.keys(state).forEach(key => {
+        stateClone[key] = {
+          ...state[key],
+          data: {},
+          isLoading: true,
+          error: null,
+        };
+      });
+      return stateClone;
     default:
       throw new Error(`Unknown data manager action: ${action.type}`);
   }

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -103,7 +103,13 @@ const Wizard = ({ heading, dataLayout, children }: WizardProps) => {
         <Grid container justify="center">
           {((state.activeStep === lastStepIndex && !isLoading && isMultistep) || hasError) && (
             <ButtonGroup>
-              <Button text="Start Over" onClick={() => dispatch(WizardAction.RESET)} />
+              <Button
+                text="Start Over"
+                onClick={() => {
+                  dataLayoutManager.reset();
+                  dispatch(WizardAction.RESET);
+                }}
+              />
             </ButtonGroup>
           )}
         </Grid>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Clear data layout when restarting workflows.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![restartDL](https://user-images.githubusercontent.com/1004789/111741492-d4d75400-8843-11eb-80d3-fa550c2f5bc7.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
