### PR TITLE
experimentation: use ClutchErrors for richer error info

### DIFF
--- a/frontend/workflows/experimentation/src/core/page-layout.tsx
+++ b/frontend/workflows/experimentation/src/core/page-layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Alert } from "@clutch-sh/core";
+import type { ClutchError } from "@clutch-sh/core";
+import { Error } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import { Container, Grid, Typography } from "@material-ui/core";
 
@@ -15,18 +16,18 @@ const Heading = styled(Typography)({
 
 interface PageLayoutProps {
   heading: string;
-  error?: any;
+  error?: ClutchError;
 }
 
 const PageLayout: React.FC<PageLayoutProps> = ({ heading, error, children }) => {
-  const hasError = error !== undefined && error !== "" && error !== null;
+  const hasError = error !== undefined && error !== null;
   return (
     <PageContainer>
       <Container>
         <Heading variant="h5">
           <strong>{heading}</strong>
         </Heading>
-        {hasError && <Alert severity="error">{error}</Alert>}
+        {hasError && <Error subject={error} />}
         <Grid>{children}</Grid>
       </Container>
     </PageContainer>

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -21,7 +21,7 @@ const ListExperiments: React.FC<ListExperimentsProps> = ({ heading, columns, lin
   const [experiments, setExperiments] = useState<
     IClutch.chaos.experimentation.v1.ListViewItem[] | undefined
   >(undefined);
-  const [error, setError] = useState(undefined);
+  const [error, setError] = useState<ClutchError | undefined>(undefined);
 
   const navigate = useNavigate();
 

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
+import type { ClutchError } from "@clutch-sh/core";
 import { BaseWorkflowProps, Button, ButtonGroup, client } from "@clutch-sh/core";
 
 import PageLayout from "./core/page-layout";
@@ -20,7 +21,7 @@ const ListExperiments: React.FC<ListExperimentsProps> = ({ heading, columns, lin
   const [experiments, setExperiments] = useState<
     IClutch.chaos.experimentation.v1.ListViewItem[] | undefined
   >(undefined);
-  const [error, setError] = useState("");
+  const [error, setError] = useState(undefined);
 
   const navigate = useNavigate();
 
@@ -34,8 +35,8 @@ const ListExperiments: React.FC<ListExperimentsProps> = ({ heading, columns, lin
       .then(response => {
         setExperiments(response?.data?.items || []);
       })
-      .catch(err => {
-        setError(err.response.statusText);
+      .catch((err: ClutchError) => {
+        setError(err);
       });
   }, []);
 

--- a/frontend/workflows/experimentation/src/tests/__snapshots__/list-experiments.test.tsx.snap
+++ b/frontend/workflows/experimentation/src/tests/__snapshots__/list-experiments.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`List Experiments workflow renders correctly 1`] = `
-"<PageLayout heading=\\"List Experiments\\" error=\\"\\">
+"<PageLayout heading=\\"List Experiments\\" error={[undefined]}>
   <ButtonGroup justify=\\"center\\" border=\\"bottom\\">
     <Button text=\\"button_1\\" onClick={[Function: onClick]} />
   </ButtonGroup>

--- a/frontend/workflows/experimentation/src/tests/__snapshots__/view-experiment-run.test.tsx.snap
+++ b/frontend/workflows/experimentation/src/tests/__snapshots__/view-experiment-run.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`View Experiment Run workflow renders correctly 1`] = `
-"<PageLayout heading={[undefined]} error=\\"\\">
+"<PageLayout heading={[undefined]} error={[undefined]}>
   <Styled(form) />
 </PageLayout>"
 `;

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -66,7 +66,7 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
     return [goBackButton, destructiveButton];
   }
 
-  if (experiment === undefined && error === "") {
+  if (experiment === undefined) {
     client
       .post("/v1/chaos/experimentation/getExperimentRunDetails", { id: runID })
       .then(response => {

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { clutch as IClutch } from "@clutch-sh/api";
+import type { ClutchError } from "@clutch-sh/core";
 import {
   BaseWorkflowProps,
   Button,
@@ -18,7 +19,7 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
   const [experiment, setExperiment] = useState<
     IClutch.chaos.experimentation.v1.ExperimentRunDetails | undefined
   >(undefined);
-  const [error, setError] = useState("");
+  const [error, setError] = useState(undefined);
 
   const { runID } = useParams();
   const navigate = useNavigate();
@@ -55,8 +56,8 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
             .then(() => {
               setExperiment(undefined);
             })
-            .catch(err => {
-              setError(err.response.statusText);
+            .catch((err: ClutchError) => {
+              setError(err);
             });
         }}
       />
@@ -71,8 +72,8 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
       .then(response => {
         setExperiment(response?.data?.runDetails);
       })
-      .catch(err => {
-        setError(err.response.statusText);
+      .catch((err: ClutchError) => {
+        setError(err);
       });
   }
 

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -19,7 +19,7 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
   const [experiment, setExperiment] = useState<
     IClutch.chaos.experimentation.v1.ExperimentRunDetails | undefined
   >(undefined);
-  const [error, setError] = useState(undefined);
+  const [error, setError] = useState<ClutchError | undefined>(undefined);
 
   const { runID } = useParams();
   const navigate = useNavigate();

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import type { BaseWorkflowProps } from "@clutch-sh/core";
+import type { BaseWorkflowProps, ClutchError } from "@clutch-sh/core";
 import {
   Button,
   ButtonGroup,
@@ -245,7 +245,7 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
     navigate(`/experimentation/run/${id}`);
   };
 
-  const handleOnCreatedExperimentFailure = (err: string) => {
+  const handleOnCreatedExperimentFailure = (err: ClutchError) => {
     setExperimentData(undefined);
     setError(err);
   };
@@ -320,8 +320,8 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
       .then(response => {
         handleOnCreatedExperiment(response?.data.experiment.id);
       })
-      .catch(err => {
-        handleOnCreatedExperimentFailure(err.response.statusText);
+      .catch((err: ClutchError) => {
+        handleOnCreatedExperimentFailure(err);
       });
   };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Modify the base experimentation components and experimentation workflows to use the new ClutchError object for richer error messages.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-03-19 at 4 07 36 PM](https://user-images.githubusercontent.com/1004789/111850334-3d1e4800-88cd-11eb-934e-4918f1cbe61b.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
