### PR TITLE
oidc: check token store for token revocation

### DIFF
--- a/backend/mock/service/authnmock/storage.go
+++ b/backend/mock/service/authnmock/storage.go
@@ -1,0 +1,42 @@
+package authnmock
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/oauth2"
+)
+
+type MockAuthnStorage struct {
+	// mapping from provider -> user -> token
+	Tokens map[string]map[string]*oauth2.Token
+}
+
+func (m MockAuthnStorage) Store(ctx context.Context, userID, provider string, token *oauth2.Token) error {
+	if _, ok := m.Tokens[provider]; !ok {
+		m.Tokens[provider] = make(map[string]*oauth2.Token)
+	}
+
+	m.Tokens[provider][userID] = token
+
+	return nil
+}
+
+func (m MockAuthnStorage) Read(ctx context.Context, userID, provider string) (*oauth2.Token, error) {
+	if _, ok := m.Tokens[provider]; !ok {
+		return nil, errors.New("token not found")
+	}
+
+	token, ok := m.Tokens[provider][userID]
+	if !ok {
+		return nil, errors.New("token not found")
+	}
+
+	return token, nil
+}
+
+func NewMockStorage() *MockAuthnStorage {
+	return &MockAuthnStorage{
+		Tokens: map[string]map[string]*oauth2.Token{},
+	}
+}

--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -184,17 +184,6 @@ func (p *OIDCProvider) Verify(ctx context.Context, rawToken string) (*Claims, er
 		return nil, err
 	}
 
-	// If the token doesn't exist in the token storage anymore, it must have been revoked.
-	// Fail verification in this case.
-	// TODO(perf): Cache the lookup result in-memory for min(60, timeToExpiry) to prevent
-	// hitting the DB on each request. This should also cache whether we didn't find a token.
-	if p.tokenStorage != nil {
-		token, err := p.tokenStorage.Read(ctx, claims.Subject, clutchProvider)
-		if token == nil {
-			return nil, err
-		}
-	}
-
 	if err := claims.Valid(); err != nil {
 		return nil, err
 	}

--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -175,6 +175,15 @@ func (p *OIDCProvider) Verify(ctx context.Context, rawToken string) (*Claims, er
 		return nil, err
 	}
 
+	// If the token doesn't exist in the token storage anymore, it must have been revoked.
+	// Fail verification in this case.
+	if p.tokenStorage != nil {
+		token, err := p.tokenStorage.Read(ctx, claims.Subject, p.providerAlias)
+		if token == nil {
+			return nil, err
+		}
+	}
+
 	if err := claims.Valid(); err != nil {
 		return nil, err
 	}

--- a/backend/service/authn/oidc_test.go
+++ b/backend/service/authn/oidc_test.go
@@ -129,7 +129,7 @@ oidc:
 	mockStorage := authnmock.NewMockStorage()
 
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, mockprovider.Client())
-	
+
 	p, err := NewOIDCProvider(ctx, cfg, mockStorage)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)

--- a/backend/service/authn/oidc_test.go
+++ b/backend/service/authn/oidc_test.go
@@ -150,7 +150,7 @@ oidc:
 	assert.NotNil(t, providerToken)
 
 	// Check the store to make sure we recorded the clutch issued token.
-	clutchToken, err := mockStorage.Read(context.Background(), "user@example.com", clutchProviderName)
+	clutchToken, err := mockStorage.Read(context.Background(), "user@example.com", clutchProvider)
 	assert.NoError(t, err)
 	assert.NotNil(t, clutchToken)
 
@@ -163,7 +163,7 @@ oidc:
 
 	// Revoke all the tokens for clutch, leaving the provider token. This verifies that we explicitly
 	// check for the existence of the clutch issued token in the database.
-	delete(mockStorage.Tokens, clutchProviderName)
+	delete(mockStorage.Tokens, clutchProvider)
 
 	// Verification should now fail.
 	c, err = p.Verify(context.Background(), token.AccessToken)

--- a/backend/service/authn/oidc_test.go
+++ b/backend/service/authn/oidc_test.go
@@ -161,12 +161,5 @@ oidc:
 	assert.NotNil(t, c)
 	assert.Equal(t, email, c.Subject)
 
-	// Revoke all the tokens for clutch, leaving the provider token. This verifies that we explicitly
-	// check for the existence of the clutch issued token in the database.
-	delete(mockStorage.Tokens, clutchProvider)
-
-	// Verification should now fail.
-	c, err = p.Verify(context.Background(), token.AccessToken)
-	assert.Error(t, err)
-	assert.Nil(t, c)
+	// TODO(snowp): Delete clutch issued token and verify that we are no longer valid.
 }


### PR DESCRIPTION
### Description
Supports token revocation by checking the token storage to see if the token is still valid.
We expect tokens to be present in the store unless they have been revoked, so
checking for existence here is sufficient for revocation purposes.

No mechanism to actually revoke the token is added, just the logic for failing verification
when the token is revoked. 

### Testing Performed
Added unit test coverage

### GitHub Issue
#1116 

