### PR TITLE
frontend: use Code component for workflow error details

### DIFF
--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -4,6 +4,7 @@ import LaunchIcon from "@material-ui/icons/Launch";
 import { Alert } from "@material-ui/lab";
 
 import { Dialog, DialogContent } from "../dialog";
+import Code from "../text";
 
 export interface BaseWorkflowProps {
   heading: string;
@@ -109,10 +110,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
         <Grid container direction="column" justify="center" alignItems="center">
           <Dialog onClose={this.onDetailsClose} open={showDetails} title="Stack Trace">
             <DialogContent>
-              {errorInfo?.componentStack?.split("\n").map((i, key) => {
-                /* eslint-disable-next-line react/no-array-index-key */
-                return <div key={key}>{i}</div>;
-              })}
+              <Code>{errorInfo?.componentStack || "Could not determine stack trace"}</Code>
             </DialogContent>
           </Dialog>
           <Alert


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Swap out custom dialog for the new Code component when rendering error details (usually the stack trace) from a workflow failing to load.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-03-19 at 5 18 02 PM](https://user-images.githubusercontent.com/1004789/111853273-85426800-88d7-11eb-9ad2-1919e6952b0d.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
