### PR TITLE
frontend: enforce isolated modules

### DIFF
--- a/frontend/packages/core/src/Feedback/index.tsx
+++ b/frontend/packages/core/src/Feedback/index.tsx
@@ -1,7 +1,8 @@
 import { Alert } from "./alert";
 import Error from "./error";
 import Hint from "./hint";
-import { Note, NoteConfig, NotePanel } from "./note";
+import { Note, NotePanel } from "./note";
 import Warning from "./warning";
 
-export { Alert, Error, Hint, Note, NoteConfig, NotePanel, Warning };
+export type { NoteConfig } from "./note";
+export { Alert, Error, Hint, Note, NotePanel, Warning };

--- a/frontend/packages/core/src/Input/radio-group.tsx
+++ b/frontend/packages/core/src/Input/radio-group.tsx
@@ -32,7 +32,7 @@ interface RadioGroupOption {
   value?: string;
 }
 
-interface RadioGroupProps {
+export interface RadioGroupProps {
   defaultOption?: number;
   label?: string;
   disabled?: boolean;
@@ -95,4 +95,4 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
   );
 };
 
-export { RadioGroup, RadioGroupProps };
+export default RadioGroup;

--- a/frontend/packages/core/src/Input/stories/radio-group.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/radio-group.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { RadioGroupProps } from "../radio-group";
-import { RadioGroup } from "../radio-group";
+import RadioGroup from "../radio-group";
 
 export default {
   title: "Core/Input/RadioGroup",

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -1,21 +1,17 @@
 import { Grid } from "@material-ui/core";
 
-// @ts-ignore
-import { BaseWorkflowProps, WorkflowConfiguration } from "./AppProvider/workflow";
 import { CheckboxPanel } from "./Input/checkbox";
 import Form from "./Input/form";
-import { RadioGroup } from "./Input/radio-group";
+import RadioGroup from "./Input/radio-group";
 import { Select } from "./Input/select";
 import { TextField } from "./Input/text-field";
-// @ts-ignore
-import { ClutchError } from "./Network/errors";
 import { Accordion, AccordionDetails } from "./accordion";
 import ClutchApp from "./AppProvider";
-import { Button, ButtonGroup, ButtonProps, ClipboardButton } from "./button";
+import { Button, ButtonGroup, ClipboardButton } from "./button";
 import Confirmation from "./confirmation";
 import { useWizardContext, WizardContext } from "./Contexts";
 import { Dialog, DialogActions, DialogContent } from "./dialog";
-import { Alert, Error, Hint, Note, NoteConfig, NotePanel, Warning } from "./Feedback";
+import { Alert, Error, Hint, Note, NotePanel, Warning } from "./Feedback";
 import { AvatarIcon, StatusIcon } from "./icon";
 import { Link } from "./link";
 import Loadable from "./loading";
@@ -27,6 +23,11 @@ import { Step, Stepper } from "./stepper";
 import { Tab, Tabs } from "./tab";
 import { AccordionRow, MetadataTable, Table, TableCell, TableRow, TreeTable } from "./Table";
 
+export type { BaseWorkflowProps, WorkflowConfiguration } from "./AppProvider/workflow";
+export type { ButtonProps } from "./button";
+export type { NoteConfig } from "./Feedback";
+export type { ClutchError } from "./Network/errors";
+
 export {
   Accordion,
   AccordionDetails,
@@ -34,14 +35,11 @@ export {
   Alert,
   AvatarIcon,
   ClutchApp,
-  BaseWorkflowProps,
   Button,
   ButtonGroup,
-  ButtonProps,
   CheckboxPanel,
   client,
   ClipboardButton,
-  ClutchError,
   Confirmation,
   Dialog,
   DialogActions,
@@ -55,7 +53,6 @@ export {
   Loadable,
   MetadataTable,
   Note,
-  NoteConfig,
   NotePanel,
   Paper,
   RadioGroup,
@@ -74,5 +71,4 @@ export {
   useWizardContext,
   Warning,
   WizardContext,
-  WorkflowConfiguration,
 };

--- a/frontend/packages/data-layout/src/index.tsx
+++ b/frontend/packages/data-layout/src/index.tsx
@@ -1,7 +1,6 @@
 import { DataLayoutContext } from "./context";
 import useDataLayout from "./layout";
-import { useDataLayoutManager } from "./manager";
-// @ts-ignore
-import { ManagerLayout } from "./state";
+import useDataLayoutManager from "./manager";
 
-export { ManagerLayout, useDataLayout, useDataLayoutManager, DataLayoutContext };
+export type { ManagerLayout } from "./state";
+export { useDataLayout, useDataLayoutManager, DataLayoutContext };

--- a/frontend/packages/data-layout/src/manager.tsx
+++ b/frontend/packages/data-layout/src/manager.tsx
@@ -82,7 +82,7 @@ const hydrate = (key: string): Thunk<ManagerLayout, Action> => {
   };
 };
 
-interface DataManager {
+export interface DataManager {
   state: object;
   assign: (key: string, value: object) => void;
   hydrate: (key: string) => void;
@@ -127,4 +127,4 @@ const useDataLayoutManager = (layouts: ManagerLayout): DataManager => {
   };
 };
 
-export { DataManager, useDataLayoutManager };
+export default useDataLayoutManager;

--- a/frontend/packages/wizard/src/index.tsx
+++ b/frontend/packages/wizard/src/index.tsx
@@ -1,4 +1,5 @@
 import WizardStep from "./step";
-import Wizard, { WizardChild } from "./wizard";
+import Wizard from "./wizard";
 
-export { Wizard, WizardChild, WizardStep };
+export type { WizardChild } from "./wizard";
+export { Wizard, WizardStep };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,7 +16,10 @@
     },
     "preserveConstEnums": true,
     "target": "ES2018",
-    "types": ["jest", "node", "long"]
+    "types": ["jest", "node", "long"],
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "isolatedModules": true,
   },
   "exclude": [
     "node_modules",

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -4,7 +4,8 @@ import type { clutch as IClutch } from "@clutch-sh/api";
 import { BaseWorkflowProps, Button, ButtonGroup, client } from "@clutch-sh/core";
 
 import PageLayout from "./core/page-layout";
-import { Column, ListView } from "./list-view";
+import type { Column } from "./list-view";
+import ListView from "./list-view";
 
 interface ExperimentTypeLinkProps {
   displayName: string;

--- a/frontend/workflows/experimentation/src/list-view.tsx
+++ b/frontend/workflows/experimentation/src/list-view.tsx
@@ -101,7 +101,7 @@ const EnhancedTableHead: React.FC<EnhancedTableHeadProps> = ({
   );
 };
 
-interface Column {
+export interface Column {
   id: string;
   header: string;
   sortable?: boolean;
@@ -190,4 +190,4 @@ const ListView: React.FC<ListViewProps> = ({ columns, items, onRowSelection }) =
   );
 };
 
-export { Column, ListView };
+export default ListView;

--- a/frontend/workflows/serverexperimentation/src/form-fields.tsx
+++ b/frontend/workflows/serverexperimentation/src/form-fields.tsx
@@ -44,7 +44,7 @@ interface RadioGroupOption {
   value: string;
 }
 
-interface FormItem {
+export interface FormItem {
   name?: string;
   label: string;
   type: string;
@@ -132,4 +132,4 @@ const FormFields: React.FC<FormProps> = ({ state, items, register, errors }) => 
   );
 };
 
-export { FormFields, FormItem };
+export default FormFields;

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -16,7 +16,8 @@ import { PageLayout } from "@clutch-sh/experimentation";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
-import { FormFields, FormItem } from "./form-fields";
+import type { FormItem } from "./form-fields";
+import FormFields from "./form-fields";
 
 enum FaultType {
   ABORT = "Abort",

--- a/frontend/workflows/serverexperimentation/src/tests/experiment-details.test.tsx
+++ b/frontend/workflows/serverexperimentation/src/tests/experiment-details.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 
-import { FormFields } from "../form-fields";
+import FormFields from "../form-fields";
 import { ExperimentDetails } from "../start-experiment";
 
 jest.mock("react-router-dom", () => {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Enforce [isolated modules](https://www.typescriptlang.org/tsconfig#isolatedModules) as this is required by both esbuild and react-scripts.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
