### PR TITLE
frontend: fix default table cell value in TableRow

### DIFF
--- a/frontend/packages/core/src/Table/stories/table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/table.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import type { TableProps } from "../table";
+import type { TableProps, TableRowProps } from "../table";
 import { Table, TableRow } from "../table";
 
 export default {
@@ -9,23 +9,48 @@ export default {
   component: Table,
 } as Meta;
 
-const Template = (props: TableProps) => (
+const Template = ({ row, ...props }: TableProps & { row: React.ReactElement }) => (
   <div style={{ maxHeight: "300px", display: "flex" }}>
     <Table headings={["Column 1", "Column 2"]} {...props}>
-      {[...Array(10)].map((_, index: number) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <TableRow key={index}>
-          <div>Value 1</div>
-          <div>Value 2</div>
-        </TableRow>
-      ))}
+      {[...Array(10)].map((_, index: number) => React.cloneElement(row, { key: index }))}
     </Table>
   </div>
 );
 
+const PrimaryTableRow = (props: TableRowProps) => (
+  <TableRow {...props}>
+    <div>Value 1</div>
+    <div>Value 2</div>
+  </TableRow>
+);
+
+const IncompleteTableRow = (props: TableRowProps) => {
+  let data;
+  return (
+    <TableRow {...props}>
+      <div>Value 1</div>
+      {data}
+    </TableRow>
+  );
+};
+
 export const Primary = Template.bind({});
+Primary.args = {
+  row: <PrimaryTableRow />,
+};
 
 export const StickyHeader = Template.bind({});
 StickyHeader.args = {
   stickyHeader: true,
+  row: <PrimaryTableRow />,
+};
+
+export const MissingCellValue = Template.bind({});
+MissingCellValue.args = {
+  row: <IncompleteTableRow />,
+};
+
+export const DefaultCellValue = Template.bind({});
+DefaultCellValue.args = {
+  row: <IncompleteTableRow defaultCellValue="null" />,
 };

--- a/frontend/packages/core/src/Table/stories/table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/table.stories.tsx
@@ -12,7 +12,10 @@ export default {
 const Template = ({ row, ...props }: TableProps & { row: React.ReactElement }) => (
   <div style={{ maxHeight: "300px", display: "flex" }}>
     <Table headings={["Column 1", "Column 2"]} {...props}>
-      {[...Array(10)].map((_, index: number) => React.cloneElement(row, { key: index }))}
+      {
+        // eslint-disable-next-line react/no-array-index-key
+        [...Array(10)].map((_, index: number) => React.cloneElement(row, { key: index }))
+      }
     </Table>
   </div>
 );

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -86,7 +86,9 @@ export const TableRow = ({ children = [], onClick, defaultCellValue }: TableRowP
   <StyledTableRow onClick={onClick}>
     {React.Children.map(children, (value, index) => (
       // eslint-disable-next-line react/no-array-index-key
-      <TableCell key={index}>{value === undefined ? defaultCellValue : value}</TableCell>
+      <TableCell key={index}>
+        {value === null && defaultCellValue !== undefined ? defaultCellValue : value}
+      </TableCell>
     ))}
   </StyledTableRow>
 );


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
The children being mapped will have a null value instead of undefined. This fixes the default cell value not appearing issue.

Also added a check to make sure that we only attempt to use the default cell value if it's set since the prop is optional.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
added stories
