### PR TITLE
docs: add info on slack sink and custom slack overrides

### DIFF
--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -310,11 +310,11 @@ A custom Slack message can be created for a given `/service/method` using the av
 
 **Creating a Custom Slack Messages**
 
-The feature is powered by the Golang [Template](https://golang.org/pkg/text/template/) package. In the clutch-config, you can provide a template with the field names from the API request and/or response, which will be replaced with the field values at parse time. The template can also include Slack [`mrkdwn`](https://api.slack.com/reference/surfaces/formatting#basics) to add useful visual highlights to the custom message.
+The feature is powered by the Golang [`template`](https://golang.org/pkg/text/template/) package. In clutch-config, you can provide a template with the field names from the API request and/or response, which will be replaced with the field values at parse time. The template can also include Slack [`mrkdwn`](https://api.slack.com/reference/surfaces/formatting#basics) to add useful visual highlights to the custom message.
 
 Creating the template:
-- `.Request.key_name` to obtain data from the API request
-- `.Response.key_name` to obtain data from the API response
+- `.Request.<key_name>` to obtain data from the API request
+- `.Response.<key_name>` to obtain data from the API response
 - Clutch-specific [templating tokens](https://github.com/lyft/clutch/blob/0aa1c00b37513900c351be1106cc131498b1aad0/backend/gateway/config.go#L110-L122) in lieu of the standard Golang Template [Action](https://golang.org/pkg/text/template/#hdr-Actions) and [Variable](https://golang.org/pkg/text/template/#hdr-Variables) syntax
 - Any of the Golang Template [functions](https://golang.org/pkg/text/template/#hdr-Functions) can be used in the template
 

--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -270,7 +270,7 @@ Adding and customizing audit sinks lets you save or process infrastructure event
 #### Slack Sink
 By default, the Slack sink creates a formatted Slack message using a subset of information saved in an audit event. The default Slack message provides a summary that answers questions such as what operation was performed, who performed the operation, and what resources were operated on.
 
-< insert gif or picture >
+TODO: insert picture/gif
 
 The Slack sink requires your [Slack app’s](https://api.slack.com/start) bot token and the channel to post the messages. You can optionally provide filter rules to control what kinds of slack audits are sent to your channel.
 
@@ -296,12 +296,8 @@ services:
     typed_config:
       "@type": types.google.com/clutch.config.service.audit.v1.Config
       db_provider: clutch.service.db.postgres
-      filter:
-        denylist: true
-        rules:
-          - field: METHOD
-            text: Healthcheck
-      // highlight-next-line
+      // highlight-start
       sinks:
         - clutch.service.audit.sink.slack
+     // highlight-end
 ```

--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -306,7 +306,7 @@ services:
 
 A custom Slack message can be created for a given `/service/method` using the available metadata (the API request and response body) in an audit event. The custom message will then be appended to the default Slack message for a richer Slack audit.
 
-TODO: insert picture/gif
+<img style={ {border: "1px solid black"} } alt="slack audits" src="https://user-images.githubusercontent.com/39421794/112363388-d2458600-8cab-11eb-80d6-1324c5e5b64a.png" />
 
 **Creating a Custom Slack Messages**
 

--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -268,7 +268,7 @@ Clutch ships with a logging sink as a scaffold for your own, as well as a sink f
 Adding and customizing audit sinks lets you save or process infrastructure events however appropriate for your needs.
 
 #### Slack Sink
-By default, the Slack sink creates a formatted Slack message using a subset of information saved in an audit event. The default Slack message provides a summary that answers questions such as what operation was performed, who performed the operation, and what resources were operated on.
+By default, the Slack sink creates a formatted Slack message using a subset of information saved in an audit event. The default Slack message provides a summary, answering questions such as what operation was performed, who performed the operation, and what resources were operated on.
 
 <img style={ {border: "1px solid black"} } alt="slack audits" src="https://user-images.githubusercontent.com/39421794/112361590-f1431880-8ca9-11eb-9d65-a4a843b6b08c.gif" />
 
@@ -310,12 +310,12 @@ A custom Slack message can be created for a given `/service/method` using the av
 
 **Creating a Custom Slack Messages**
 
-The feature is powered by the Golang [Template](https://golang.org/pkg/text/template/) package. In the clutch-config, you can provide a template with the field names from the API request and/or response, which will be replaced with the values of the those fields at parse time. The template can also include Slack [`mrkdwn`](https://api.slack.com/reference/surfaces/formatting#basics) to add useful visual highlights to the custom message.
+The feature is powered by the Golang [Template](https://golang.org/pkg/text/template/) package. In the clutch-config, you can provide a template with the field names from the API request and/or response, which will be replaced with the field values at parse time. The template can also include Slack [`mrkdwn`](https://api.slack.com/reference/surfaces/formatting#basics) to add useful visual highlights to the custom message.
 
 Creating the template:
 - `.Request.key_name` to obtain data from the API request
 - `.Response.key_name` to obtain data from the API response
-- Clutch-specific [templating tokens](https://github.com/lyft/clutch/blob/0aa1c00b37513900c351be1106cc131498b1aad0/backend/gateway/config.go#L110-L122) in lieu of the standard Golang Template Action and Variable syntax
+- Clutch-specific [templating tokens](https://github.com/lyft/clutch/blob/0aa1c00b37513900c351be1106cc131498b1aad0/backend/gateway/config.go#L110-L122) in lieu of the standard Golang Template [Action](https://golang.org/pkg/text/template/#hdr-Actions) and [Variable](https://golang.org/pkg/text/template/#hdr-Variables) syntax
 - Any of the Golang Template [functions](https://golang.org/pkg/text/template/#hdr-Functions) can be used in the template
 
 Example Config:

--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -272,7 +272,7 @@ By default, the Slack sink creates a formatted Slack message using a subset of i
 
 TODO: insert picture/gif
 
-The Slack sink requires your [Slack app’s](https://api.slack.com/start) bot token and the channel to post the messages. You can optionally provide filter rules to control what kinds of slack audits are sent to your channel.
+The Slack sink requires your [Slack app’s](https://api.slack.com/start) bot token and the channel to post the messages. You can optionally provide filter rules to control what kinds of Slack audits are sent to the channel.
 
 Example Config:
 ```yaml title="backend/clutch-config.yaml"
@@ -304,20 +304,19 @@ services:
 
 **Custom Slack Messages**
 
-A custom slack message can be created for a given `/service/method` using the available metadata (the API request and response body) in an audit event. The custom message will then be appended to the default message for a richer slack audit.
+A custom Slack message can be created for a given `/service/method` using the available metadata (the API request and response body) in an audit event. The custom message will then be appended to the default Slack message for a richer Slack audit.
 
 TODO: insert picture/gif
 
-The feature is powered by the Golang [Template](https://golang.org/pkg/text/template/) package. In the clutch-config, you can provide a template with the field names from the API request and/or response, which will then be replaced by the values saved in the audit event metadata. The template can also include Slack [`mrkdwn`](https://api.slack.com/reference/surfaces/formatting#basics) for adding useful visual highlights to the custom message.
+**Creating a Custom Slack Messages**
 
-**Creating a Custom Messsage**
-- `.Request.<key>` to obtain data from the API request
-- `.Response.<key>` to obtain data from the API response
-- Any of the Golang Template [functions](https://golang.org/pkg/text/template/#hdr-Functions) can be used in the custom template
+The feature is powered by the Golang [Template](https://golang.org/pkg/text/template/) package. In the clutch-config, you can provide a template with the field names from the API request and/or response, which will be replaced with the values of the those fields at parse time. The template can also include Slack [`mrkdwn`](https://api.slack.com/reference/surfaces/formatting#basics) to add useful visual highlights to the custom message.
 
-- `[[ ]]` in lieu of the Golang Template action syntax ( `{{ }}`)
-- `$$` in lieu of the Golang Template variable syntax ( `$`)
-
+Creating the template:
+- `.Request.key_name` to obtain data from the API request
+- `.Response.key_name` to obtain data from the API response
+- Clutch-specific [templating tokens](https://github.com/lyft/clutch/blob/0aa1c00b37513900c351be1106cc131498b1aad0/backend/gateway/config.go#L110-L122) in lieu of the standard Golang Template Action and Variable syntax
+- Any of the Golang Template [functions](https://golang.org/pkg/text/template/#hdr-Functions) can be used in the template
 
 Example Config:
 ```yaml title="backend/clutch-config.yaml"

--- a/docs/advanced/security-auditing.md
+++ b/docs/advanced/security-auditing.md
@@ -270,7 +270,7 @@ Adding and customizing audit sinks lets you save or process infrastructure event
 #### Slack Sink
 By default, the Slack sink creates a formatted Slack message using a subset of information saved in an audit event. The default Slack message provides a summary that answers questions such as what operation was performed, who performed the operation, and what resources were operated on.
 
-TODO: insert picture/gif
+<img style={ {border: "1px solid black"} } alt="slack audits" src="https://user-images.githubusercontent.com/39421794/112361590-f1431880-8ca9-11eb-9d65-a4a843b6b08c.gif" />
 
 The Slack sink requires your [Slack app’s](https://api.slack.com/start) bot token and the channel to post the messages. You can optionally provide filter rules to control what kinds of Slack audits are sent to the channel.
 


### PR DESCRIPTION
### Description
PR adds docs on
* general overview of slack sink and an example config
* info on how to create a custom slack message and an example config

### Testing Performed
Deploy preview link: https://deploy-preview-1168--clutch-preview.netlify.app/docs/advanced/security-auditing#sinks