### PR TITLE
experimentation: Adding stats for active faults

### DIFF
--- a/backend/module/chaos/serverexperimentation/xds/xds_cache.go
+++ b/backend/module/chaos/serverexperimentation/xds/xds_cache.go
@@ -80,10 +80,7 @@ func refreshCache(ctx context.Context, storer experimentstore.Storer, snapshotCa
 	}
 
 	// Create/Update experiments
-	activeFaults := 0
 	for cluster, experiments := range clusterFaultMap {
-		activeFaults += 1
-
 		resources := make(map[gcpTypes.ResponseType][]gcpTypes.ResourceWithTtl)
 
 		logger.Debugw("Injecting fault for cluster", "cluster", cluster)
@@ -104,7 +101,7 @@ func refreshCache(ctx context.Context, storer experimentstore.Storer, snapshotCa
 		}
 	}
 
-	scope.Gauge("active_faults").Update(float64(activeFaults))
+	scope.Gauge("active_faults").Update(float64(len(clusterFaultMap)))
 }
 
 func setSnapshot(resourceMap map[gcpTypes.ResponseType][]gcpTypes.ResourceWithTtl, cluster string, snapshotCache gcpCacheV3.SnapshotCache, logger *zap.SugaredLogger) error {

--- a/backend/module/chaos/serverexperimentation/xds/xds_cache.go
+++ b/backend/module/chaos/serverexperimentation/xds/xds_cache.go
@@ -136,11 +136,11 @@ func setSnapshot(resourceMap map[gcpTypes.ResponseType][]gcpTypes.ResourceWithTt
 	if isSnapshotEmpty {
 		scope.Tagged(map[string]string{
 			"cluster": cluster,
-		}).Counter("active_faults").Inc(-1)
+		}).Gauge("active_faults").Update(-1)
 	} else {
 		scope.Tagged(map[string]string{
 			"cluster": cluster,
-		}).Counter("active_faults").Inc(1)
+		}).Gauge("active_faults").Update(1)
 	}
 
 	return nil

--- a/backend/module/chaos/serverexperimentation/xds/xds_cache.go
+++ b/backend/module/chaos/serverexperimentation/xds/xds_cache.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/uber-go/tally"
-
 	gcpTypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	gcpCacheV3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/golang/protobuf/ptypes"

--- a/backend/module/chaos/serverexperimentation/xds/xds_cache_test.go
+++ b/backend/module/chaos/serverexperimentation/xds/xds_cache_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/tally"
-
 	gcpCoreV3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	gcpRoute "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	gcpFilterCommon "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/common/fault/v3"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Emitting stats when faults are injects and removed. This will help us set alarms when faults are on longer than expected. 

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
