### PR TITLE
frontend: add startAdornment to Tab

### DIFF
--- a/frontend/packages/core/src/stories/tab.stories.tsx
+++ b/frontend/packages/core/src/stories/tab.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import EmojiPeopleOutlinedIcon from "@material-ui/icons/EmojiPeopleOutlined";
 import type { Meta } from "@storybook/react";
 
 import type { TabProps } from "../tab";
@@ -21,6 +22,12 @@ Primary.args = {
 
 export const Selected = Template.bind({});
 Selected.args = {
-  label: "Tab 1",
+  ...Primary.args,
   selected: true,
+};
+
+export const StartAdornment = Template.bind({});
+StartAdornment.args = {
+  ...Primary.args,
+  startAdornment: <EmojiPeopleOutlinedIcon />,
 };

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -36,6 +36,9 @@ const StyledTab = styled(MuiTab)({
     color: "rgba(13, 16, 48, 0.6)",
     backgroundColor: "#DBDBE0",
   },
+  ".MuiTab-wrapper": {
+    margin: "auto",
+  },
 });
 
 const StyledTabs = styled(TabList)({
@@ -47,9 +50,10 @@ const StyledTabs = styled(TabList)({
 
 export interface TabProps extends Pick<MuiTabProps, "label" | "selected" | "value" | "onClick"> {
   children?: React.ReactNode;
+  startAdornment?: React.ReactNode;
 }
 
-export const Tab = ({ onClick, ...props }: TabProps) => {
+export const Tab = ({ onClick, label, startAdornment, ...props }: TabProps) => {
   const tabProps = { ...props };
   delete tabProps.children;
   const onClickMiddleware = (e: any) => {
@@ -58,7 +62,16 @@ export const Tab = ({ onClick, ...props }: TabProps) => {
       onClick(e);
     }
   };
-  return <StyledTab color="primary" onClick={onClickMiddleware} {...tabProps} />;
+  let finalLabel = label;
+  if (startAdornment !== undefined) {
+    finalLabel = (
+      <div style={{ display: "flex" }}>
+        <span style={{ marginRight: "7px" }}>{startAdornment}</span>
+        {label}
+      </div>
+    );
+  }
+  return <StyledTab color="primary" onClick={onClickMiddleware} label={finalLabel} {...tabProps} />;
 };
 
 const TabPanel = styled(MuiTabPanel)({


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add `startAdornment` prop to Tab component.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-03-24 at 1 57 38 PM](https://user-images.githubusercontent.com/1004789/112382610-4c284000-8ca9-11eb-8ff4-fcab93293167.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual and storybook