### PR TITLE
oidc: check token store when validating tokens

### DIFF
--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -184,19 +184,19 @@ func (p *OIDCProvider) Verify(ctx context.Context, rawToken string) (*Claims, er
 		return nil, err
 	}
 
+	if err := claims.Valid(); err != nil {
+		return nil, err
+	}
+
 	// If the token doesn't exist in the token storage anymore, it must have been revoked.
 	// Fail verification in this case.
 	// TODO(perf): Cache the lookup result in-memory for min(60, timeToExpiry) to prevent
 	// hitting the DB on each request. This should also cache whether we didn't find a token.
 	if p.tokenStorage != nil {
-		token, err := p.tokenStorage.Read(ctx, claims.Subject, clutchProvider)
-		if token == nil {
+		_, err := p.tokenStorage.Read(ctx, claims.Subject, clutchProvider)
+		if err != nil {
 			return nil, err
 		}
-	}
-
-	if err := claims.Valid(); err != nil {
-		return nil, err
 	}
 
 	return claims, nil

--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -184,6 +184,17 @@ func (p *OIDCProvider) Verify(ctx context.Context, rawToken string) (*Claims, er
 		return nil, err
 	}
 
+	// If the token doesn't exist in the token storage anymore, it must have been revoked.
+	// Fail verification in this case.
+	// TODO(perf): Cache the lookup result in-memory for min(60, timeToExpiry) to prevent
+	// hitting the DB on each request. This should also cache whether we didn't find a token.
+	if p.tokenStorage != nil {
+		token, err := p.tokenStorage.Read(ctx, claims.Subject, clutchProvider)
+		if token == nil {
+			return nil, err
+		}
+	}
+
 	if err := claims.Valid(); err != nil {
 		return nil, err
 	}

--- a/backend/service/authn/oidc_test.go
+++ b/backend/service/authn/oidc_test.go
@@ -161,5 +161,12 @@ oidc:
 	assert.NotNil(t, c)
 	assert.Equal(t, email, c.Subject)
 
-	// TODO(snowp): Delete clutch issued token and verify that we are no longer valid.
+	// Revoke all the tokens for clutch, leaving the provider token. This verifies that we explicitly
+	// check for the existence of the clutch issued token in the database.
+	delete(mockStorage.Tokens, clutchProvider)
+
+	// Verification should now fail.
+	c, err = p.Verify(context.Background(), token.AccessToken)
+	assert.Error(t, err)
+	assert.Nil(t, c)
 }


### PR DESCRIPTION
Adds the write part of the token revocation logic introduced in #1157
