### PR TITLE
authn: allow empty refresh tokens in database

### DIFF
--- a/backend/service/authn/storage.go
+++ b/backend/service/authn/storage.go
@@ -63,7 +63,7 @@ func (s *storage) Store(ctx context.Context, userID, provider string, t *oauth2.
 	if t == nil {
 		return status.Errorf(codes.InvalidArgument, "token provided for storage was nil")
 	} else if userID == "" || provider == "" || t.AccessToken == "" {
-		return status.Errorf(codes.InvalidArgument, "userID '%s' or provider '%s' were blank", userID, provider)
+		return status.Errorf(codes.InvalidArgument, "userID '%s', provider '%s', or access token were blank", userID, provider)
 	}
 
 	at, err := s.crypto.Encrypt([]byte(t.AccessToken))


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Previously an error would occur if a credential did not have a refresh token, causing exchange or other token read/write operations to fail.

### Testing Performed
Unit

### GitHub Issue

Fixes #1177

### TODOs
- [x] unit