### PR TITLE
frontend: fix eslintrc resolver paths

### DIFF
--- a/frontend/packages/tools/.eslintrc.js
+++ b/frontend/packages/tools/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     "import/resolver": {
       node: {
         extensions: [".js", ".jsx", ".ts", ".tsx"],
-        paths: ["src", "dist"],
+        paths: ["**/src", "**/dist"],
       },
     },
     "import/parsers": {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes eslintrc resolver paths to account for nested directories.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manually in a gateway