### PR TITLE
frontend: enclose error to prevent spacing injection from parent

### DIFF
--- a/frontend/packages/core/src/Feedback/error/index.tsx
+++ b/frontend/packages/core/src/Feedback/error/index.tsx
@@ -76,7 +76,7 @@ const Error = ({ subject: error, onRetry }: ErrorProps) => {
     }).length > 0;
 
   return (
-    <>
+    <div>
       <ErrorAlert
         severity="error"
         title={error.status.text}
@@ -94,7 +94,7 @@ const Error = ({ subject: error, onRetry }: ErrorProps) => {
         </ErrorSummaryContainer>
       </ErrorAlert>
       {hasDetails && <ErrorDetails error={error} />}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
…m parent

<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This prevents any parent from injecting padding/margin into the error component and messing up the alignment of components.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-03-30 at 3 36 44 PM](https://user-images.githubusercontent.com/1004789/113065438-c0f9ef00-916d-11eb-8f53-cec83b730869.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual