### PR TITLE
wizard: error fills width

### DIFF
--- a/frontend/packages/wizard/src/step.tsx
+++ b/frontend/packages/wizard/src/step.tsx
@@ -29,11 +29,9 @@ const WizardStep: React.FC<WizardStepProps> = ({ isLoading, error, children }) =
   if (showLoading) {
     return <Loadable isLoading={isLoading}>{children}</Loadable>;
   }
-  return hasError ? (
-    <Error subject={error} />
-  ) : (
+  return (
     <Grid container justify="center" direction="column" alignItems="stretch">
-      {children}
+      {hasError ? <Error subject={error} /> : children}
     </Grid>
   );
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Fill the container width with the error.

Before

![Screenshot from 2021-03-31 11-40-10](https://user-images.githubusercontent.com/4712430/113202976-0e8b6000-9231-11eb-91a5-232cd82f1b32.png)


After
![Screenshot from 2021-03-31 14-54-28](https://user-images.githubusercontent.com/4712430/113202989-11865080-9231-11eb-9127-89fa3d5b850d.png)


