### PR TITLE
frontend: use grpc code as status text in errors

### DIFF
--- a/frontend/packages/core/src/Network/errors.ts
+++ b/frontend/packages/core/src/Network/errors.ts
@@ -1,6 +1,7 @@
 import type { clutch as IClutch } from "@clutch-sh/api";
 import type { AxiosError } from "axios";
 
+import { grpcCodeToText } from "./grpc";
 import type { HttpStatus } from "./index";
 
 interface Details {
@@ -263,7 +264,7 @@ const grpcResponseToError = (clientError: AxiosError): ClutchError => {
     message: data.message,
     status: {
       code: clientError.response.status,
-      text: clientError.response.statusText,
+      text: grpcCodeToText(data.code),
     } as HttpStatus,
   } as ClutchError;
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Translate the gRPC code into text for the error components status text.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual