### PR TITLE
frontend: sort workflow groups

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -13,6 +13,7 @@ import {
   Popper as MuiPopper,
   Typography,
 } from "@material-ui/core";
+import _ from "lodash";
 
 import { useAppContext } from "../Contexts";
 
@@ -223,6 +224,7 @@ const Drawer: React.FC = () => {
     <DrawerPanel data-qa="drawer" variant="permanent">
       {sortedGroupings(workflows).map(grouping => {
         const value = routesByGrouping(workflows)[grouping];
+        const sortedWorkflows = _.sortBy(value.workflows, w => w.displayName);
         return (
           <Group
             key={grouping}
@@ -231,7 +233,7 @@ const Drawer: React.FC = () => {
             updateOpenGroup={updateOpenGroup}
             closeGroup={() => setOpenGroup("")}
           >
-            {value.workflows.map(workflow => (
+            {sortedWorkflows.map(workflow => (
               <Link
                 key={workflow.path.replace("/", "")}
                 to={workflow.path}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Sort workflow groups when displayed in the drawer menu.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-04-02 at 4 27 49 PM](https://user-images.githubusercontent.com/1004789/113461176-63b1a800-93d0-11eb-9455-ac2748984993.png)


### Testing Performed
<!-- Describe how you tested this change below. -->
manual
