### PR TITLE
Hydrator advanced option sort

### DIFF
--- a/frontend/packages/core/src/Resolver/hydrator.tsx
+++ b/frontend/packages/core/src/Resolver/hydrator.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { clutch } from "@clutch-sh/api";
+import _ from "lodash";
 
 import Select from "../Input/select";
 import TextField from "../Input/text-field";

--- a/frontend/packages/core/src/Resolver/hydrator.tsx
+++ b/frontend/packages/core/src/Resolver/hydrator.tsx
@@ -63,17 +63,18 @@ const OptionField = (
   field: clutch.resolver.v1.IField,
   onChange: (e: ResolverChangeEvent) => void
 ): React.ReactElement => {
+  const sortedOptions = _.sortBy(field.metadata.optionField.options, o => o.displayName);
   React.useEffect(() => {
     onChange({
       target: {
         name: field.name,
-        value: field.metadata.optionField.options?.[0]?.stringValue,
+        value: sortedOptions?.[0]?.stringValue,
       },
       initialLoad: true,
     });
   }, []);
 
-  const options = _.sortBy(field.metadata.optionField.options, o => o.displayName).map(option => {
+  const options = sortedOptions.map(option => {
     return { label: option.displayName, value: option.stringValue };
   });
   const updateSelectedOption = (value: string) => {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add sorting functionality back to resolver advanced selects originally introduced in #1240.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
