### PR TITLE
mux: forward X- headers

### DIFF
--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -187,11 +187,10 @@ func customResponseForwarder(ctx context.Context, w http.ResponseWriter, resp pr
 	return nil
 }
 
-// forward all X- headers and add the grpcgateway prefix
 func customHeaderMatcher(key string) (string, bool) {
 	key = textproto.CanonicalMIMEHeaderKey(key)
 	if strings.HasPrefix(key, xHeader) {
-		// don't want to prefix these headers as they are looked up by grpc's annotate context flow and added to the context
+		// exclude handling these headers as they are looked up by grpc's annotate context flow and added to the context
 		// metadata if they're not found
 		if key != xForwardedFor && key != xForwardedHost {
 			return runtime.MetadataPrefix + key, true

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -192,7 +192,7 @@ func customHeaderMatcher(key string) (string, bool) {
 	key = textproto.CanonicalMIMEHeaderKey(key)
 	if strings.HasPrefix(key, xHeader) {
 		// don't want to prefix these headers as they are looked up by grpc's annotate context flow and added to the context
-		// metadata if they're are not found
+		// metadata if they're not found
 		if key != xForwardedFor && key != xForwardedHost {
 			return runtime.MetadataPrefix + key, true
 		}

--- a/backend/gateway/mux/mux_test.go
+++ b/backend/gateway/mux/mux_test.go
@@ -74,7 +74,7 @@ func TestCustomMatcher(t *testing.T) {
 		expectedBool bool
 	}{
 		{key: "X-Foo-Bar", expectedKey: "grpcgateway-X-Foo-Bar", expectedBool: true},
-		// testing the default rule - a part of the X group
+		// testing the default rule - a part of the isPermanentHTTPHeader group
 		{key: "Cookie", expectedKey: "grpcgateway-Cookie", expectedBool: true},
 		// testing the default rule - has the Grpc-Metadata prefix
 		{key: "Grpc-Metadata-Foo", expectedKey: "Foo", expectedBool: true},

--- a/backend/gateway/mux/mux_test.go
+++ b/backend/gateway/mux/mux_test.go
@@ -66,3 +66,25 @@ func TestGetAssetProivderService(t *testing.T) {
 	_, err := getAssetProviderService(assetCfg)
 	assert.Error(t, err)
 }
+
+func TestCustomMatcher(t *testing.T) {
+	testCases := []struct {
+		key          string
+		expectedKey  string
+		expectedBool bool
+	}{
+		{key: "X-Foo-Bar", expectedKey: "grpcgateway-X-Foo-Bar", expectedBool: true},
+		// testing the default rule - a part of the X group
+		{key: "Cookie", expectedKey: "grpcgateway-Cookie", expectedBool: true},
+		// testing the default rule - has the Grpc-Metadata prefix
+		{key: "Grpc-Metadata-Foo", expectedKey: "Foo", expectedBool: true},
+		// doesn't match custom or default rules
+		{key: "Foo-Bar", expectedKey: "", expectedBool: false},
+	}
+
+	for _, test := range testCases {
+		result, ok := customMatcher(test.key)
+		assert.Equal(t, test.expectedKey, result)
+		assert.Equal(t, test.expectedBool, ok)
+	}
+}

--- a/backend/gateway/mux/mux_test.go
+++ b/backend/gateway/mux/mux_test.go
@@ -67,23 +67,57 @@ func TestGetAssetProivderService(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestCustomMatcher(t *testing.T) {
+func TestCustomHeaderMatcher(t *testing.T) {
 	testCases := []struct {
 		key          string
 		expectedKey  string
 		expectedBool bool
 	}{
-		{key: "X-Foo-Bar", expectedKey: "grpcgateway-X-Foo-Bar", expectedBool: true},
-		// testing the default rule - a part of the isPermanentHTTPHeader group
-		{key: "Cookie", expectedKey: "grpcgateway-Cookie", expectedBool: true},
-		// testing the default rule - has the Grpc-Metadata prefix
-		{key: "Grpc-Metadata-Foo", expectedKey: "Foo", expectedBool: true},
+		{
+			key:          "X-Foo-Bar",
+			expectedKey:  "grpcgateway-X-Foo-Bar",
+			expectedBool: true,
+		},
+		// testing that the headers get uppercased
+		{
+			key:          "x-foo-bar",
+			expectedKey:  "grpcgateway-X-Foo-Bar",
+			expectedBool: true,
+		},
+		// testing the default rule - isPermanentHTTPHeader group
+		{
+			key:          "Cookie",
+			expectedKey:  "grpcgateway-Cookie",
+			expectedBool: true,
+		},
+		// testing the default rule - Grpc-Metadata prefix
+		{
+			key:          "Grpc-Metadata-Foo",
+			expectedKey:  "Foo",
+			expectedBool: true,
+		},
+		// testing the prefix doesn't get applied and doesn't match default rule
+		{
+			key:          xForwardedFor,
+			expectedKey:  "",
+			expectedBool: false,
+		},
+		// testing the prefix doesn't get applied and doesn't match default rule
+		{
+			key:          xForwardedHost,
+			expectedKey:  "",
+			expectedBool: false,
+		},
 		// doesn't match custom or default rules
-		{key: "Foo-Bar", expectedKey: "", expectedBool: false},
+		{
+			key:          "Foo-Bar",
+			expectedKey:  "",
+			expectedBool: false,
+		},
 	}
 
 	for _, test := range testCases {
-		result, ok := customMatcher(test.key)
+		result, ok := customHeaderMatcher(test.key)
 		assert.Equal(t, test.expectedKey, result)
 		assert.Equal(t, test.expectedBool, ok)
 	}


### PR DESCRIPTION
### Description
Background:
By default, http request headers are passed to gRPC context via the [DefaultHeaderMatcher](https://github.com/grpc-ecosystem/grpc-gateway/blob/519e7f45f48e3e378e3341d076579f3ce52aa717/runtime/mux.go#L63-L74) rule. If the request headers don't meet certain preconditions, they are dropped.

Solution:
PR adds a custom header rule so that `X-` request headers are forwarded (and prefixed with `grpcgateway`). All other headers will be checked by the DefaultHeaderMatcher rule.

Use case for this change: 
For the slackbot work, we need to [verify](https://api.slack.com/authentication/verifying-requests-from-slack#verifying-requests-from-slack-using-signing-secrets__a-recipe-for-security__step-by-step-walk-through-for-validating-a-request) a request came from Slack by certain `X-` request headers sent in the request.

### Testing Performed
Unit test and locally with https://github.com/lyft/clutch/pull/1250