### PR TITLE
authnz: explicitly list allowed authn methods

### DIFF
--- a/backend/middleware/authn/authn.go
+++ b/backend/middleware/authn/authn.go
@@ -28,7 +28,8 @@ const Name = "clutch.middleware.authn"
 // List of method patterns that should not be blocked by authn.
 // TODO(maybe): convert this to an API annotation or make configurable on the middleware.
 var allowlist = []string{
-	"/clutch.authn.v1.AuthnAPI/*",
+	"/clutch.authn.v1.AuthnAPI/Callback",
+	"/clutch.authn.v1.AuthnAPI/Login",
 	"/clutch.healthcheck.v1.HealthcheckAPI/*",
 }
 

--- a/backend/middleware/authn/authn.go
+++ b/backend/middleware/authn/authn.go
@@ -25,14 +25,6 @@ import (
 
 const Name = "clutch.middleware.authn"
 
-// List of method patterns that should not be blocked by authn.
-// TODO(maybe): convert this to an API annotation or make configurable on the middleware.
-var allowlist = []string{
-	"/clutch.authn.v1.AuthnAPI/Callback",
-	"/clutch.authn.v1.AuthnAPI/Login",
-	"/clutch.healthcheck.v1.HealthcheckAPI/*",
-}
-
 func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (middleware.Middleware, error) {
 	svc, ok := service.Registry["clutch.service.authn"]
 	if !ok {
@@ -62,7 +54,7 @@ func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 
 		// Determine if it's on the allow list.
 		checkRequired := true
-		for _, allow := range allowlist {
+		for _, allow := range authn.AlwaysAllowedMethods {
 			if middleware.MatchMethodOrResource(allow, info.FullMethod) {
 				checkRequired = false
 				break

--- a/backend/middleware/authz/authz.go
+++ b/backend/middleware/authz/authz.go
@@ -29,7 +29,8 @@ const Name = "clutch.middleware.authz"
 // List of method patterns that should never go through the authz engine.
 // TODO(maybe): convert this to an API annotation or make configurable on the authz middleware.
 var allowlist = []string{
-	"/clutch.authn.v1.AuthnAPI/*",
+	"/clutch.authn.v1.AuthnAPI/Callback",
+	"/clutch.authn.v1.AuthnAPI/Login",
 	"/clutch.healthcheck.v1.HealthcheckAPI/*",
 }
 

--- a/backend/middleware/authz/authz.go
+++ b/backend/middleware/authz/authz.go
@@ -26,14 +26,6 @@ import (
 
 const Name = "clutch.middleware.authz"
 
-// List of method patterns that should never go through the authz engine.
-// TODO(maybe): convert this to an API annotation or make configurable on the authz middleware.
-var allowlist = []string{
-	"/clutch.authn.v1.AuthnAPI/Callback",
-	"/clutch.authn.v1.AuthnAPI/Login",
-	"/clutch.healthcheck.v1.HealthcheckAPI/*",
-}
-
 func New(cfg *anypb.Any, logger *zap.Logger, scope tally.Scope) (middleware.Middleware, error) {
 	svc, ok := service.Registry["clutch.service.authz"]
 	if !ok {
@@ -68,7 +60,7 @@ func (m *mid) evaluate(ctx context.Context, r *authzv1.CheckRequest) error {
 func (m *mid) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 		// Never interfere with allowlisted flows.
-		for _, allow := range allowlist {
+		for _, allow := range authn.AlwaysAllowedMethods {
 			if middleware.MatchMethodOrResource(allow, info.FullMethod) {
 				return handler(ctx, req)
 			}

--- a/backend/middleware/authz/authz_test.go
+++ b/backend/middleware/authz/authz_test.go
@@ -49,7 +49,7 @@ func TestNoClaims(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestWhitelist(t *testing.T) {
+func TestAllowlist(t *testing.T) {
 	s := &svcMock{}
 	m, _ := newWithMock(s)
 	interceptor := m.UnaryInterceptor()
@@ -57,7 +57,7 @@ func TestWhitelist(t *testing.T) {
 	ctx := context.Background()
 
 	req := &healthcheckv1.HealthcheckRequest{}
-	info := &grpc.UnaryServerInfo{FullMethod: "/clutch.authn.v1.AuthnAPI/FooBar"}
+	info := &grpc.UnaryServerInfo{FullMethod: "/clutch.authn.v1.AuthnAPI/Callback"}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return &healthcheckv1.HealthcheckResponse{}, nil
 	}

--- a/backend/service/authn/authn.go
+++ b/backend/service/authn/authn.go
@@ -20,6 +20,14 @@ import (
 
 const Name = "clutch.service.authn"
 
+// AlwaysAllowedMethods is a list of method patterns that are always open and not blocked by authn or authz.
+// TODO(maybe): convert this to an API annotation or make configurable on the middleware that use the list.
+var AlwaysAllowedMethods = []string{
+	"/clutch.authn.v1.AuthnAPI/Callback",
+	"/clutch.authn.v1.AuthnAPI/Login",
+	"/clutch.healthcheck.v1.HealthcheckAPI/*",
+}
+
 func New(cfg *anypb.Any, logger *zap.Logger, scope tally.Scope) (service.Service, error) {
 	config := &authnv1.Config{}
 	if err := cfg.UnmarshalTo(config); err != nil {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Be explicit about the authn methods that are always open and move the list to a common palce.

### Testing Performed
CI