### PR TITLE
topology cache: deduplicate batch inserts

### DIFF
--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -105,7 +105,7 @@ func (c *client) startTopologyCache(ctx context.Context) {
 // Notably a flush will happen every 30 seconds, ensuring all items make it into cache even if the
 // configured BatchInsertSize is not met.
 func (c *client) processTopologyObjectChannel(ctx context.Context, objs <-chan *topologyv1.UpdateCacheRequest, service string) {
-	var batchInsert []*topologyv1.Resource
+	var batchInsert = make(map[string]*topologyv1.Resource)
 	queueDepth := c.scope.Tagged(map[string]string{
 		"service": service,
 	}).SubScope("cache").Gauge("object_channel.queue_depth")
@@ -121,7 +121,7 @@ func (c *client) processTopologyObjectChannel(ctx context.Context, objs <-chan *
 
 			switch obj.Action {
 			case topologyv1.UpdateCacheRequest_CREATE_OR_UPDATE:
-				batchInsert = append(batchInsert, obj.Resource)
+				batchInsert[obj.Resource.Id] = obj.Resource
 			case topologyv1.UpdateCacheRequest_DELETE:
 				if err := c.deleteCache(ctx, obj.Resource.Id, obj.Resource.Pb.TypeUrl); err != nil {
 					c.log.Error("Error deleting cache", zap.Error(err))
@@ -131,23 +131,33 @@ func (c *client) processTopologyObjectChannel(ctx context.Context, objs <-chan *
 			}
 
 			if len(batchInsert) >= c.batchInsertSize {
-				if err := c.setCache(ctx, batchInsert); err != nil {
+				batch := convertBatchInsertToSlice(batchInsert)
+				if err := c.setCache(ctx, batch); err != nil {
 					c.log.Error("Error setting cache", zap.Error(err))
 				}
-				batchInsert = batchInsert[:0]
+				batchInsert = make(map[string]*topologyv1.Resource)
 			}
 		// TODO (mcutalo): There is a possibility that this code will never be reached.
 		// If deletes happen at a faster interval than the flush timer (which is configurable via batchInsertFlush),
 		// insert items would be stuck in the batch until the BatchInsertSize is reached.
 		case <-time.After(c.batchInsertFlush):
 			if len(batchInsert) > 0 {
-				if err := c.setCache(ctx, batchInsert); err != nil {
+				batch := convertBatchInsertToSlice(batchInsert)
+				if err := c.setCache(ctx, batch); err != nil {
 					c.log.Error("Error setting cache", zap.Error(err))
 				}
-				batchInsert = batchInsert[:0]
+				batchInsert = make(map[string]*topologyv1.Resource)
 			}
 		}
 	}
+}
+
+func convertBatchInsertToSlice(batch map[string]*topologyv1.Resource) []*topologyv1.Resource {
+	var batchInsert []*topologyv1.Resource
+	for _, resource := range batch {
+		batchInsert = append(batchInsert, resource)
+	}
+	return batchInsert
 }
 
 func (c *client) prepareBulkCacheInsert(obj []*topologyv1.Resource) ([]interface{}, string) {

--- a/backend/service/topology/cache_test.go
+++ b/backend/service/topology/cache_test.go
@@ -153,6 +153,47 @@ func BenchmarkPrepareBulkCacheInsert(b *testing.B) {
 	}
 }
 
+func TestConvertBatchInsertToSlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		id             string
+		input          []*topologyv1.Resource
+		expectedLength int
+	}{
+		{
+			id:             "1",
+			input:          generatePrepareBulkCacheInsertInput(1),
+			expectedLength: 1,
+		},
+		{
+			id:             "10",
+			input:          generatePrepareBulkCacheInsertInput(10),
+			expectedLength: 10,
+		},
+		{
+			id:             "100",
+			input:          generatePrepareBulkCacheInsertInput(100),
+			expectedLength: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.id, func(t *testing.T) {
+			t.Parallel()
+
+			resources := make(map[string]*topologyv1.Resource)
+			for _, v := range tt.input {
+				resources[v.Id] = v
+			}
+
+			actaul := convertBatchInsertToSlice(resources)
+			assert.Equal(t, tt.expectedLength, len(actaul))
+		})
+	}
+}
+
 func generatePrepareBulkCacheInsertInput(count int) []*topologyv1.Resource {
 	results := []*topologyv1.Resource{}
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

It was possible to batch insert multiple entries of the same item which is not possible with postgres and results in the error below. With this PR I changed the `batchInserts` to a map which removes the possibility for duplicates while also updating the cache with the latest entry assuming that items coming over the channel are received in chronological order which I think its safe to assume for a single resource.

> {"level":"error","ts":1617985716.6457253,"caller":"topology/cache.go:135","msg":"Error setting cache","serviceName":"clutch.service.topology","error":"pq: ON CONFLICT DO UPDATE command cannot affect row a second time","stacktrace":"github.com/lyft/clutch/backend/service/topology.(*client).processTopologyObjectChannel\n\t/code/clutch-private/clutch/backend/service/topology/cache.go:135"}

This also shows a slight improve in areas during benchmarking but i think overall about the same perf, the previous benchmark can be found [here](https://github.com/lyft/clutch/pull/1154#discussion_r605280940).
```
goos: darwin
goarch: amd64
pkg: github.com/lyft/clutch/backend/service/topology
cpu: Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz
BenchmarkPrepareBulkCacheInsert-8   	      33	  32537305 ns/op	12094080 B/op	  309784 allocs/op
PASS
ok  	github.com/lyft/clutch/backend/service/topology	1.138s
```

### Testing Performed
Local / Unit.
