### PR TITLE
frontend: fix spacing in workflow default error message

### DIFF
--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -88,7 +88,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     const { error, errorInfo, showDetails } = this.state;
 
     const defaultErrorMsg = (
-      <>Failed to load{workflow.displayName} workflow. Please contact the developer</>
+      <>Failed to load {workflow.displayName} workflow. Please contact the developer</>
     );
     if (error) {
       let message = defaultErrorMsg;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes the format of the default error message for workflows

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual