### PR TITLE
k8s cache: fix cache panic on shutdown

### DIFF
--- a/backend/service/k8s/cache.go
+++ b/backend/service/k8s/cache.go
@@ -91,7 +91,6 @@ func (s *svc) startInformers(ctx context.Context, clusterName string, cs Context
 	<-ctx.Done()
 	s.log.Info("Shutting down the kubernetes cache informers")
 	close(stop)
-	close(s.topologyObjectChan)
 	s.topologyInformerLock.Release(topologyInformerLockId)
 }
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

Previously I was closing `s.topologyObjectChan` for every cluster that I was watching which resulted in the error below. Moved the channel close up so its not invoked more than once.

```
panic: close of closed channel

goroutine 221 [running]:
github.com/lyft/clutch/backend/service/k8s.(*svc).startInformers(0xc000070440, 0x46e0ff8, 0xc000070bc0, 0xc00131d1f0, 0x8, 0x4712d48, 0xc001715170, 0x68c61714000)
	/code/clutch-private/clutch/backend/service/k8s/cache.go:94 +0x868
created by github.com/lyft/clutch/backend/service/k8s.(*svc).StartTopologyCaching
	/code/clutch-private/clutch/backend/service/k8s/cache.go:45 +0x1af
```

### Tests
Locally.

```
INFO	topology/topology.go:107	Caught shutdown signal, shutting down topology caching and releasing advisory lock	{"serviceName": "clutch.service.topology"}
INFO	k8s/cache.go:99	Shutting down the kubernetes cache informers	{"serviceName": "clutch.service.k8s"}
INFO	k8s/cache.go:50	Shutting down the kubernetes topo cache channel	{"serviceName": "clutch.service.k8s"}
````