### PR TITLE
authn: read tokens through the provider for refresh

### DIFF
--- a/backend/mock/service/authnmock/oidcprovider.go
+++ b/backend/mock/service/authnmock/oidcprovider.go
@@ -78,7 +78,7 @@ func (m *MockOIDCProviderServer) handle(w http.ResponseWriter, r *http.Request) 
 			panic(err)
 		}
 
-		fmt.Fprintf(w, `{"token_type":"bearer","access_token":"AAAAAAAAAAAA", "id_token": "%s"}`, tok)
+		fmt.Fprintf(w, `{"token_type":"bearer","access_token":"AAAAAAAAAAAA","refresh_token":"REFRESH","id_token":"%s"}`, tok)
 	case "/oauth2/v1/keys":
 		jwk := jose.JSONWebKey{KeyID: "foo", Key: m.key.Public()}
 		jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}}

--- a/backend/module/authn/authn.go
+++ b/backend/module/authn/authn.go
@@ -30,9 +30,9 @@ func New(*any.Any, *zap.Logger, tally.Scope) (module.Module, error) {
 		return nil, errors.New("unable to get authn service")
 	}
 
-	p, ok := svc.(authn.IssuerProviderReader)
+	p, ok := svc.(authn.Service)
 	if !ok {
-		return nil, errors.New("authn service was not the correct type (is not a IssuerProviderReader)")
+		return nil, errors.New("authn service was not the correct type")
 	}
 
 	return &mod{

--- a/backend/module/authn/authn.go
+++ b/backend/module/authn/authn.go
@@ -30,9 +30,9 @@ func New(*any.Any, *zap.Logger, tally.Scope) (module.Module, error) {
 		return nil, errors.New("unable to get authn service")
 	}
 
-	p, ok := svc.(authn.IssuerProvider)
+	p, ok := svc.(authn.IssuerProviderReader)
 	if !ok {
-		return nil, errors.New("authn service was not the correct type (is not a IssuerProvider)")
+		return nil, errors.New("authn service was not the correct type (is not a IssuerProviderReader)")
 	}
 
 	return &mod{

--- a/backend/service/authn/authn.go
+++ b/backend/service/authn/authn.go
@@ -69,7 +69,8 @@ type Issuer interface {
 	CreateToken(ctx context.Context, subject string, tokenType authnmodulev1.CreateTokenRequest_TokenType, expiry *time.Duration) (token *oauth2.Token, err error)
 }
 
-type IssuerProvider interface {
+type IssuerProviderReader interface {
 	Issuer
 	Provider
+	TokenReader // Read calls are proxied through the IssuerProvider so the token can be refreshed if needed.
 }

--- a/backend/service/authn/authn.go
+++ b/backend/service/authn/authn.go
@@ -69,8 +69,21 @@ type Issuer interface {
 	CreateToken(ctx context.Context, subject string, tokenType authnmodulev1.CreateTokenRequest_TokenType, expiry *time.Duration) (token *oauth2.Token, err error)
 }
 
-type IssuerProviderReader interface {
+type Service interface {
 	Issuer
 	Provider
 	TokenReader // Read calls are proxied through the IssuerProvider so the token can be refreshed if needed.
+}
+
+type TokenReader interface {
+	Read(ctx context.Context, userID, provider string) (*oauth2.Token, error)
+}
+
+type TokenStorer interface {
+	Store(ctx context.Context, userID, provider string, token *oauth2.Token) error
+}
+
+type Storage interface {
+	TokenReader
+	TokenStorer
 }

--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -263,6 +263,10 @@ func (p *OIDCProvider) Read(ctx context.Context, userID, provider string) (*oaut
 		return t, nil
 	}
 
+	if t.RefreshToken == "" {
+		return nil, status.Error(codes.Unauthenticated, "the token has expired and no refresh token is present")
+	}
+
 	// If invalid, attempt refresh.
 	newToken, err := p.oauth2.TokenSource(ctx, t).Token()
 	if err != nil {

--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -248,8 +248,8 @@ func (p *OIDCProvider) Read(ctx context.Context, userID, provider string) (*oaut
 		return nil, status.Error(codes.Internal, "token read attempted but storage is not configured")
 	}
 
-	if provider == clutchProvider {
-		return nil, status.Error(codes.Internal, "only tokens from third-party providers should be read")
+	if provider != p.providerAlias {
+		return nil, status.Errorf(codes.InvalidArgument, "provider '%s' cannot read '%s' tokens", p.providerAlias, provider)
 	}
 
 	// Get token from storage.

--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -9,9 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"

--- a/backend/service/authn/oidc.go
+++ b/backend/service/authn/oidc.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	authnmodulev1 "github.com/lyft/clutch/backend/api/authn/v1"
 	authnv1 "github.com/lyft/clutch/backend/api/config/service/authn/v1"
@@ -275,7 +278,6 @@ func (p *OIDCProvider) Read(ctx context.Context, userID, provider string) (*oaut
 	}
 
 	return newToken, nil
-
 }
 
 func NewOIDCProvider(ctx context.Context, config *authnv1.Config, tokenStorage Storage) (Provider, error) {

--- a/backend/service/authn/storage.go
+++ b/backend/service/authn/storage.go
@@ -28,15 +28,6 @@ func NewStorage(cfg *anypb.Any, logger *zap.Logger, scope tally.Scope) (service.
 	return newStorage(c)
 }
 
-type TokenReader interface {
-	Read(ctx context.Context, userID, provider string) (*oauth2.Token, error)
-}
-
-type Storage interface {
-	TokenReader
-	Store(ctx context.Context, userID, provider string, token *oauth2.Token) error
-}
-
 type storage struct {
 	crypto *cryptographer
 	repo   *repository

--- a/backend/service/authn/storage.go
+++ b/backend/service/authn/storage.go
@@ -28,9 +28,13 @@ func NewStorage(cfg *anypb.Any, logger *zap.Logger, scope tally.Scope) (service.
 	return newStorage(c)
 }
 
-type Storage interface {
-	Store(ctx context.Context, userID, provider string, token *oauth2.Token) error
+type TokenReader interface {
 	Read(ctx context.Context, userID, provider string) (*oauth2.Token, error)
+}
+
+type Storage interface {
+	TokenReader
+	Store(ctx context.Context, userID, provider string, token *oauth2.Token) error
 }
 
 type storage struct {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Third-party token reads can now take place through the provider so they can be refreshed if needed.

### Testing Performed
TODO

### TODOs

- [x] Tests
- [x] Try to figure out some cleaner refactoring of the provider impl