### PR TITLE
frontend: limit resize asg desired size to max

### DIFF
--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -76,7 +76,8 @@ const GroupDetails: React.FC<WizardChild> = () => {
               key: "size.desired",
               validation: number()
                 .integer()
-                .min(ref("Min Size") as Reference<number>),
+                .min(ref("Min Size") as Reference<number>)
+                .max(ref("Max Size") as Reference<number>),
             },
           },
           { name: "Availability Zone", value: group.zones },


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix validation of desired size field within resize ASG workflow to set a max less than or equal to the max size field.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-04-14 at 11 30 22 AM](https://user-images.githubusercontent.com/1004789/114761006-d564ec80-9d14-11eb-9d0f-3471637b90ed.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual