### PR TITLE
meta: update pattern value extraction to allow empty string

### DIFF
--- a/backend/gateway/meta/meta.go
+++ b/backend/gateway/meta/meta.go
@@ -198,13 +198,6 @@ func ExtractPatternValuesFromString(pb proto.Message, value string) (map[string]
 		return result, false, nil
 	}
 
-	// Check that all of the fields have values
-	for _, value := range result {
-		if len(value) == 0 {
-			return result, false, nil
-		}
-	}
-
 	return result, true, nil
 }
 

--- a/backend/gateway/meta/meta_test.go
+++ b/backend/gateway/meta/meta_test.go
@@ -220,6 +220,16 @@ func TestExtractProtoPatternsValues(t *testing.T) {
 			expect:      "",
 			shouldError: true,
 		},
+		{
+			id: "pod",
+			pb: &k8sapiv1.Pod{
+				Cluster:   "foo",
+				Namespace: "",
+				Name:      "cat",
+			},
+			expect:      "foo//cat",
+			shouldError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -286,6 +296,17 @@ func TestPatternValueMapping(t *testing.T) {
 				"cluster":   "mycluster",
 				"namespace": "mynamespace",
 				"name":      "deploymentname",
+			},
+			ok: true,
+		},
+		{
+			id:     "k8s pod",
+			pb:     &k8sapiv1.Pod{},
+			search: "mycluster//podID",
+			result: map[string]string{
+				"cluster":   "mycluster",
+				"namespace": "",
+				"name":      "podID",
 			},
 			ok: true,
 		},


### PR DESCRIPTION
### Description
The `ExtractPatternValuesFromString` method does not allow fields to have empty string as a valid value. This PR updates the method to allow pattern values to be an empty string .

This enables us to input a search query with one of the fields as an empty string e.g now for the pod delete flow a user can input `<clientset>//<pod-id>` as a valid query to search for a podID in all namespaces in a particular clientset
### Testing Performed
local
![ezgif com-gif-maker (27)](https://user-images.githubusercontent.com/3858939/114796237-4e7c3800-9d45-11eb-8a9d-ebfccab05b56.gif)


### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
