### PR TITLE
k8s: add Kubernetes Dashboard workflow

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,6 +80,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-is": "^16.8.0",
+    "react-timeago": "^5.2.0",
     "react-scripts": "^4.0.1",
     "sort-package-json": "^1.48.1",
     "typescript": "^4.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,8 +80,8 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-is": "^16.8.0",
-    "react-timeago": "^5.2.0",
     "react-scripts": "^4.0.1",
+    "react-timeago": "^5.2.0",
     "sort-package-json": "^1.48.1",
     "typescript": "^4.2.3",
     "webpack": "4.44.2"

--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -57,5 +57,8 @@ module.exports = {
         resolverType: "clutch.k8s.v1.HPA",
       },
     },
+    kubeDashboard: {
+      trending: true,
+    },
   },
 };

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -26,9 +26,14 @@
     "@clutch-sh/core": "^1.0.0-beta",
     "@clutch-sh/data-layout": "^1.0.0-beta",
     "@clutch-sh/wizard": "^1.0.0-beta",
+    "@emotion/styled": "^11.1.5",
+    "@hookform/resolvers": "2.0.0-beta.3",
+    "@material-ui/icons": "^4.9.1",
     "lodash": "4.17.21",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
+    "react-hook-form": "^6.11.0",
+	"react-router-dom": "^6.0.0-beta",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -34,7 +34,8 @@
     "react-dom": "^16.8.0",
     "react-hook-form": "^6.11.0",
     "react-router-dom": "^6.0.0-beta",
-    "yup": "^0.32.8"
+    "yup": "^0.32.8",
+    "react-timeago": "^5.2.0"
   },
   "devDependencies": {
     "@clutch-sh/tools": "^1.0.0-beta"

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -33,7 +33,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-hook-form": "^6.11.0",
-	"react-router-dom": "^6.0.0-beta",
+    "react-router-dom": "^6.0.0-beta",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -2,6 +2,7 @@ import type { BaseWorkflowProps, NoteConfig, WorkflowConfiguration } from "@clut
 import type { WizardChild } from "@clutch-sh/wizard";
 
 import DeletePod from "./delete-pod";
+import KubeDashboard from "./k8s-dashboard";
 import ResizeHPA from "./resize-hpa";
 
 interface ResolverConfigProps {
@@ -39,6 +40,13 @@ const register = (): WorkflowConfiguration => {
         description: "Resize a horizontal autoscaler.",
         component: ResizeHPA,
         requiredConfigProps: ["resolverType"],
+      },
+      kubeDashboard: {
+        path: "dashboard",
+        displayName: "Kubernetes Dashboard",
+        description: "Dashboard for Kubernetes Resources.",
+        component: KubeDashboard,
+        requiredConfigProps: [],
       },
     },
   };

--- a/frontend/workflows/k8s/src/k8s-dash-header.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-header.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+const Category = styled.div({
+  fontWeight: 700,
+  fontSize: "12px",
+  lineHeight: "16px",
+  color: "rgba(13, 16, 48, 0.38)",
+  textTransform: "uppercase",
+  paddingBottom: "8px",
+});
+
+const HeaderText = styled.div({
+  fontWeight: 700,
+  fontSize: "26px",
+  lineHeight: "32px",
+  color: "#0D1030",
+});
+
+const K8sDashHeader = () => (
+  <div>
+    <Category>Kubernetes/</Category>
+    <HeaderText>Kubernetes Resource Dashboard</HeaderText>
+  </div>
+);
+
+export default K8sDashHeader;

--- a/frontend/workflows/k8s/src/k8s-dash-search.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-search.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { Form, FormRow, IconButton, Paper, TextField } from "@clutch-sh/core";
+import { useDataLayout } from "@clutch-sh/data-layout";
+import styled from "@emotion/styled";
+import { yupResolver } from "@hookform/resolvers/yup";
+import SearchIcon from "@material-ui/icons/Search";
+import * as yup from "yup";
+
+const Container = styled.div({
+  margin: "32px 0",
+});
+
+const schema = yup.object().shape({
+  namespace: yup.string().required("Namespace is required"),
+  clientset: yup.string().required("Clientset is required"),
+});
+
+const K8sDashSearch = ({ onSubmit }) => {
+  const { errors, handleSubmit, register } = useForm({
+    mode: "onChange",
+    reValidateMode: "onChange",
+    resolver: yupResolver(schema),
+  });
+  const inputData = useDataLayout("inputData");
+  const podListData = useDataLayout("podListData");
+
+  const submitHandler = v => {
+    inputData.updateData("namespace", v.namespace);
+    inputData.updateData("clientset", v.clientset);
+    podListData.hydrate();
+    onSubmit();
+  };
+
+  return (
+    <Container>
+      <Paper>
+        <Form onSubmit={handleSubmit(submitHandler)}>
+          <FormRow>
+            <TextField
+              defaultValue={inputData.displayValue()?.namespace}
+              placeholder="Namespace"
+              name="namespace"
+              error={!!errors?.namespace}
+              helperText={errors?.namespace?.message}
+              inputRef={register}
+            />
+            <TextField
+              defaultValue={inputData.displayValue()?.clientset}
+              placeholder="Clientset"
+              name="clientset"
+              error={!!errors?.clientset}
+              helperText={errors?.clientset?.message}
+              inputRef={register}
+            />
+            <IconButton type="submit">
+              <SearchIcon />
+            </IconButton>
+          </FormRow>
+        </Form>
+      </Paper>
+    </Container>
+  );
+};
+
+export default K8sDashSearch;

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { client, ClutchError, Error, Paper, Tab, Tabs } from "@clutch-sh/core";
+import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
+import styled from "@emotion/styled";
+import AppsIcon from "@material-ui/icons/Apps";
+
+import type { WorkflowProps } from ".";
+import K8sDashHeader from "./k8s-dash-header";
+import K8sDashSearch from "./k8s-dash-search";
+import PodTable from "./pods-table";
+
+const Container = styled.div({
+  flex: 1,
+  margin: "32px",
+  display: "flex",
+  flexDirection: "column",
+  "> *:first-child": {
+    margin: "0",
+  },
+});
+
+const Content = styled.div({
+  margin: "32px 0",
+});
+
+const PlaceholderTitle = styled.div({
+  paddingBottom: "16px",
+  fontWeight: 700,
+  fontSize: "22px",
+  lineHeight: "28px",
+  color: "0D1030",
+});
+
+const PlaceholderText = styled.div({
+  fontWeight: 400,
+  fontSize: "16px",
+  lineHeight: "22px",
+  color: "rgba(13, 16, 48, 0.6)",
+});
+
+const Placeholder = () => (
+  <Paper>
+    <div style={{ margin: "32px", textAlign: "center" }}>
+      <PlaceholderTitle>There is nothing to display here</PlaceholderTitle>
+      <PlaceholderText>Please enter a namespace and clientset to proceed.</PlaceholderText>
+    </div>
+  </Paper>
+);
+
+const defaultRequestData = inputData => {
+  // passing an empty cluster name to enforce fanout to all clusters
+  return {
+    clientset: inputData.clientset,
+    cluster: inputData.clientset,
+    namespace: inputData.namespace,
+  };
+};
+
+const KubeDashboard: React.FC<WorkflowProps> = () => {
+  const [hasInputData, setHasInputData] = React.useState(false);
+  const [error, setError] = React.useState<ClutchError | undefined>(undefined);
+
+  const dataLayout = {
+    inputData: {},
+    podListData: {
+      deps: ["inputData"],
+      hydrator: inputData => {
+        return client
+          .post("/v1/k8s/listPods", {
+            ...defaultRequestData(inputData),
+            options: {
+              labels: {},
+            },
+          } as IClutch.k8s.v1.IListPodsRequest)
+          .then(response => {
+            return response?.data;
+          })
+          .catch((err: ClutchError) => {
+            setError(existingError => {
+              if (existingError === undefined) {
+                return err;
+              }
+              return existingError;
+            });
+          });
+      },
+    },
+  };
+  const dataLayoutManager = useDataLayoutManager(dataLayout);
+
+  const clearData = () => {
+    setError(undefined);
+    dataLayoutManager.reset();
+    const { inputData } = dataLayoutManager.state as any;
+    setHasInputData(inputData?.data?.namespace !== undefined);
+  };
+
+  return (
+    <DataLayoutContext.Provider value={dataLayoutManager}>
+      <Container>
+        <K8sDashHeader />
+        <K8sDashSearch onSubmit={() => clearData()} />
+        <Content>
+          {error !== undefined ? (
+            <Error subject={error} />
+          ) : !hasInputData ? (
+            <Placeholder />
+          ) : (
+            <Paper>
+              <Tabs variant="fullWidth">
+                <Tab startAdornment={<AppsIcon />} label="Pods">
+                  <PodTable />
+                </Tab>
+              </Tabs>
+            </Paper>
+          )}
+        </Content>
+      </Container>
+    </DataLayoutContext.Provider>
+  );
+};
+
+export default KubeDashboard;

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -49,7 +49,6 @@ const Placeholder = () => (
 );
 
 const defaultRequestData = inputData => {
-  // passing an empty cluster name to enforce fanout to all clusters
   return {
     clientset: inputData.clientset,
     cluster: inputData.clientset,
@@ -58,7 +57,6 @@ const defaultRequestData = inputData => {
 };
 
 const KubeDashboard: React.FC<WorkflowProps> = () => {
-  const [hasInputData, setHasInputData] = React.useState(false);
   const [error, setError] = React.useState<ClutchError | undefined>(undefined);
 
   const dataLayout = {
@@ -89,22 +87,24 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
   };
   const dataLayoutManager = useDataLayoutManager(dataLayout);
 
-  const clearData = () => {
+  const handleSubmit = (namespace, clientset) => {
+    dataLayoutManager.assign("inputData", { namespace, clientset });
+    dataLayoutManager.hydrate("podListData");
     setError(undefined);
-    dataLayoutManager.reset();
-    const { inputData } = dataLayoutManager.state as any;
-    setHasInputData(inputData?.data?.namespace !== undefined);
   };
+
+  const state = dataLayoutManager.state as any;
+  const hasData = state.inputData?.data?.namespace;
 
   return (
     <DataLayoutContext.Provider value={dataLayoutManager}>
       <Container>
         <K8sDashHeader />
-        <K8sDashSearch onSubmit={() => clearData()} />
+        <K8sDashSearch onSubmit={(namespace, clientset) => handleSubmit(namespace, clientset)} />
         <Content>
           {error !== undefined ? (
             <Error subject={error} />
-          ) : !hasInputData ? (
+          ) : !hasData ? (
             <Placeholder />
           ) : (
             <Paper>

--- a/frontend/workflows/k8s/src/pods-table.tsx
+++ b/frontend/workflows/k8s/src/pods-table.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { Table, TableRow, TableRowAction, TableRowActions } from "@clutch-sh/core";
+import { useDataLayout } from "@clutch-sh/data-layout";
+import styled from "@emotion/styled";
+import DeleteIcon from "@material-ui/icons/Delete";
+import _ from "lodash";
+
+const PodsContainer = styled.div({
+  display: "flex",
+  maxHeight: "50vh",
+});
+const getReadyCountString = containers => {
+  const readyCount = containers.filter(cont => cont.ready).length;
+  return `${readyCount.toString()}/${containers?.length?.toString()}`;
+};
+
+const getRestartCountString = containers => {
+  const restartCount = containers.reduce((a, b) => a + b.restartCount, 0);
+  return restartCount.toString();
+};
+
+const PodTable = () => {
+  const podListData = useDataLayout("podListData");
+  const pods = podListData.displayValue()?.pods as IClutch.k8s.v1.Pod[];
+  const navigate = useNavigate();
+
+  return (
+    <PodsContainer>
+      <Table
+        stickyHeader
+        actionsColumn
+        headings={[
+          "Name",
+          "Facet",
+          "Cluster",
+          "Containers Ready",
+          "Restart",
+          "Node IP",
+          "Pod IP",
+          "State",
+          "SHA",
+        ]}
+      >
+        {_.sortBy(pods, [
+          o => {
+            return o.name;
+          },
+        ]).map(pod => (
+          <TableRow key={pod.name} defaultCellValue="nil">
+            {pod.name}
+            {pod.labels?.facet}
+            {pod.cluster}
+            {getReadyCountString(pod.containers)}
+            {getRestartCountString(pod.containers)}
+            {pod.nodeIp}
+            {pod.podIp}
+            {pod.status}
+            {pod.labels?.version}
+            <TableRowActions>
+              <TableRowAction
+                icon={<DeleteIcon />}
+                onClick={() =>
+                  navigate(`/k8s/pod/delete?q=${pod.cluster}/${pod.namespace}/${pod.name}`)
+                }
+              >
+                Delete
+              </TableRowAction>
+            </TableRowActions>
+          </TableRow>
+        ))}
+      </Table>
+    </PodsContainer>
+  );
+};
+
+export default PodTable;

--- a/frontend/workflows/k8s/src/pods-table.tsx
+++ b/frontend/workflows/k8s/src/pods-table.tsx
@@ -33,7 +33,6 @@ const PodTable = () => {
         actionsColumn
         headings={[
           "Name",
-          "Facet",
           "Cluster",
           "Containers Ready",
           "Restart",
@@ -50,7 +49,6 @@ const PodTable = () => {
         ]).map(pod => (
           <TableRow key={pod.name} defaultCellValue="nil">
             {pod.name}
-            {pod.labels?.facet}
             {pod.cluster}
             {getReadyCountString(pod.containers)}
             {getRestartCountString(pod.containers)}

--- a/frontend/workflows/k8s/src/pods-table.tsx
+++ b/frontend/workflows/k8s/src/pods-table.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import TimeAgo from "react-timeago";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Table, TableRow, TableRowAction, TableRowActions } from "@clutch-sh/core";
+import { Chip, Table, TableRow, TableRowAction, TableRowActions } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -11,6 +12,7 @@ const PodsContainer = styled.div({
   display: "flex",
   maxHeight: "50vh",
 });
+
 const getReadyCountString = containers => {
   const readyCount = containers.filter(cont => cont.ready).length;
   return `${readyCount.toString()}/${containers?.length?.toString()}`;
@@ -21,8 +23,37 @@ const getRestartCountString = containers => {
   return restartCount.toString();
 };
 
+const getPodChipState = (status: string) => {
+  switch (true) {
+    case status.includes("Error") ||
+      status.includes("BackOff") ||
+      status.includes("Evicted") ||
+      status.includes("Terminating"):
+      return "error";
+    case status.includes("Running"):
+      return "active";
+    case status.includes("Init") || status.includes("Initializing") || status.includes("Pending"):
+      return "pending";
+    case status.includes("Completed"):
+      return "success";
+    default:
+      return "neutral";
+  }
+};
+
+const convertTime = timeStampMillis => {
+  return parseInt(timeStampMillis, 10);
+};
+
+const timeFormatter = (value, unit, suffix) => {
+  if (suffix === "ago") {
+    return `${value}${unit.charAt(0)}`;
+  }
+  return `${value}${unit.charAt(0)} ${suffix}`;
+};
+
 const PodTable = () => {
-  const podListData = useDataLayout("podListData");
+  const podListData = useDataLayout("podListData", { hydrate: false });
   const pods = podListData.displayValue()?.pods as IClutch.k8s.v1.Pod[];
   const navigate = useNavigate();
 
@@ -40,6 +71,7 @@ const PodTable = () => {
           "Pod IP",
           "State",
           "SHA",
+          "Age",
         ]}
       >
         {_.sortBy(pods, [
@@ -54,8 +86,9 @@ const PodTable = () => {
             {getRestartCountString(pod.containers)}
             {pod.nodeIp}
             {pod.podIp}
-            {pod.status}
+            <Chip variant={getPodChipState(pod.status)} label={pod.status} />
             {pod.labels?.version}
+            <TimeAgo date={convertTime(pod.startTimeMillis)} formatter={timeFormatter} />
             <TableRowActions>
               <TableRowAction
                 icon={<DeleteIcon />}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -324,6 +324,13 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
+"@babel/helper-module-imports@^7.12.13":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
+  dependencies:
+    "@babel/types" "^7.13.12"
+
 "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.7.0":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
@@ -760,6 +767,13 @@
   integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-jsx@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz#044fb81ebad6698fe62c478875575bcbb9b70f15"
+  integrity sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
@@ -1444,7 +1458,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.13.17":
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.13.17":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
@@ -1660,6 +1674,24 @@
     source-map "^0.5.7"
     stylis "^4.0.3"
 
+"@emotion/babel-plugin@^11.3.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz#3a16850ba04d8d9651f07f3fb674b3436a4fb9d7"
+  integrity sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
+    "@babel/runtime" "^7.13.10"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.2"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "^4.0.3"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -1733,10 +1765,22 @@
   dependencies:
     "@emotion/memoize" "^0.7.4"
 
+"@emotion/is-prop-valid@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz#29ef6be1e946fb4739f9707def860f316f668cde"
+  integrity sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+
 "@emotion/memoize@0.7.4", "@emotion/memoize@^0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/react@^11.0.0":
   version "11.0.0"
@@ -1766,6 +1810,17 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0.tgz#1a61f4f037cf39995c97fc80ebe99abc7b191ca9"
   integrity sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/serialize@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
+  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
   dependencies:
     "@emotion/hash" "^0.8.0"
     "@emotion/memoize" "^0.7.4"
@@ -1810,6 +1865,17 @@
     "@emotion/babel-plugin" "^11.0.0"
     "@emotion/is-prop-valid" "^1.0.0"
     "@emotion/serialize" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+
+"@emotion/styled@^11.1.5":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
+  integrity sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/babel-plugin" "^11.3.0"
+    "@emotion/is-prop-valid" "^1.1.0"
+    "@emotion/serialize" "^1.0.2"
     "@emotion/utils" "^1.0.0"
 
 "@emotion/stylis@0.8.5":
@@ -1857,6 +1923,21 @@
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
   integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
+"@eslint/eslintrc@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.1.tgz#442763b88cecbe3ee0ec7ca6d6dd6168550cbf14"
+  integrity sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -9755,6 +9836,49 @@ eslint@^7.24.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+eslint@^7.26.0:
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.26.0.tgz#d416fdcdcb3236cd8f282065312813f8c13982f6"
+  integrity sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.1"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.21"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.4"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -17593,6 +17717,13 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-timeago@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-timeago/-/react-timeago-5.3.0.tgz#00f6776bfe48b922beec570a36449a3f5c253c73"
+  integrity sha512-+SUGRu+elNozCMpp9mNPUqarS0AK+sjzicVK0tjUifxMcb3+6lU5vxM9rOh+/uBcOhnTyNYe9JLvbU/NVySFOQ==
+  dependencies:
+    eslint "^7.26.0"
 
 react-transition-group@^4.0.0, react-transition-group@^4.4.0:
   version "4.4.1"


### PR DESCRIPTION
### Description
This PR adds a new workflow for the Kubernetes Dashboard which serves as an overview of all the Kubernetes resources running in the cluster. This PR adds a Pods list table which displays pods in a given namespace in a clientset and allows the user to perform a delete operation on a pod from the dashboard

### Testing Performed
Local 
![ezgif com-gif-maker (48)](https://user-images.githubusercontent.com/3858939/119041675-c1438900-b96b-11eb-89dc-e8588ee0bd06.gif)



### TODOs
- Add more resource tables to this dashboard. Tables for Deployments, CronJobs, StatefulSets and Jobs coming soon!