### PR TITLE
wizard: call toArray on steps to filter nulls

### DIFF
--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -97,10 +97,13 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
     };
   };
 
-  const lastStepIndex = React.Children.count(children) - 1;
+  // toArray will exclude any null Children.
+  const filteredChildren = React.Children.toArray(children);
+
+  const lastStepIndex = filteredChildren.length - 1;
   // If our wizard only has 1 step, it doesn't make sense to put a restart button
   const isMultistep = lastStepIndex > 0;
-  const steps = React.Children.map(children, (child: WizardChildren) => {
+  const steps = filteredChildren.map((child: WizardChildren) => {
     const isLoading = wizardStepData[child.type.name]?.isLoading || false;
     const hasError = wizardStepData[child.type.name]?.hasError;
     return (
@@ -146,7 +149,7 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
         {heading && <Heading>{heading}</Heading>}
         <Grid item>
           <Stepper activeStep={state.activeStep}>
-            {React.Children.map(children, (child: WizardChildren) => {
+            {filteredChildren.map((child: WizardChildren) => {
               const { name } = child.props;
               const hasError = wizardStepData[child.type.name]?.hasError;
               return <Step key={name} label={name} error={hasError} />;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
If there was an optional step e.g.
```jsx
{fooStepEnabled && <FooStep />}
<BarStep />
```
 one of the children would be null.

Calling toArray removes null children per https://github.com/facebook/react/issues/4867#issuecomment-413975155

Demo: https://codesandbox.io/s/nice-northcutt-mu0kk?file=/src/App.js

### Testing Performed
Manual, CI.