### PR TITLE
experimentation: rename module to service

### DIFF
--- a/backend/service/chaos/experimentation/terminator/terminator.go
+++ b/backend/service/chaos/experimentation/terminator/terminator.go
@@ -18,7 +18,7 @@ import (
 	"github.com/lyft/clutch/backend/service/chaos/experimentation/experimentstore"
 )
 
-const Name = "clutch.module.chaos.experimentation.termination"
+const Name = "clutch.service.chaos.experimentation.termination"
 
 func TypeUrl(message proto.Message) string {
 	return "type.googleapis.com/" + string(message.ProtoReflect().Descriptor().FullName())


### PR DESCRIPTION

### Description
`terminator` is a service, not a module.

### Testing Performed
unit