### PR TITLE
frontend: remove styled components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,6 @@
     "react-is": "^16.8.0",
     "react-scripts": "^4.0.1",
     "sort-package-json": "^1.48.1",
-    "styled-components": "^5.1.1",
     "typescript": "^4.2.3",
     "webpack": "4.44.2"
   },

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -47,7 +47,6 @@
     "react-is": "^16.8.0",
     "react-router": "^6.0.0-beta",
     "react-router-dom": "^6.0.0-beta",
-    "styled-components": "^5.1.1",
     "superstruct": "~0.15.0",
     "yup": "^0.32.8"
   },

--- a/frontend/packages/core/src/AppLayout/feedback.tsx
+++ b/frontend/packages/core/src/AppLayout/feedback.tsx
@@ -1,22 +1,18 @@
 import React from "react";
+import styled from "@emotion/styled";
 import { Fab, Link } from "@material-ui/core";
 import ChatBubbleOutlineIcon from "@material-ui/icons/ChatBubbleOutline";
-import styled from "styled-components";
 
-const Button = styled(Fab)`
-  ${({ theme }) => `
-  position: fixed;
-  right: ${theme.spacing(2)}px;
-  bottom: ${theme.spacing(2)}px;
-  `}
-`;
+const Button = styled(Fab)({
+  position: "fixed",
+  right: "16px",
+  bottom: "16px",
+});
 
-const Icon = styled(ChatBubbleOutlineIcon)`
-  ${({ theme }) => `
-  margin: ${theme.spacing(1)}px;
-  color: ${theme.palette.secondary.main}
-  `}
-`;
+const Icon = styled(ChatBubbleOutlineIcon)({
+  margin: "8px",
+  color: "#2D3F50",
+});
 
 const FeedbackButton: React.FC<{}> = () => (
   // Hack because ButtonBaseProps can't take a component prop

--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -4,7 +4,6 @@ import { createMuiTheme, CssBaseline, MuiThemeProvider, ThemeOptions } from "@ma
 import { useTheme as useMuiTheme } from "@material-ui/core/styles";
 import type { PaletteOptions } from "@material-ui/core/styles/createPalette";
 import { StylesProvider } from "@material-ui/styles";
-import { ThemeProvider as StyledThemeProvider } from "styled-components";
 
 interface ClutchPalette extends PaletteOptions {
   accent: {
@@ -17,13 +16,6 @@ interface ClutchPalette extends PaletteOptions {
 
 interface ClutchTheme extends ThemeOptions {
   palette: ClutchPalette;
-}
-
-declare module "styled-components" {
-  export interface ClutchTheme // eslint-disable-line @typescript-eslint/no-shadow
-    extends ThemeOptions {
-    palette: ClutchPalette;
-  }
 }
 
 const WHITE = "#ffffff";
@@ -104,10 +96,8 @@ const Theme: React.FC<ThemeProps> = ({ children }) => {
   return (
     <MuiThemeProvider theme={theme()}>
       <EmotionThemeProvider theme={theme()}>
-        <StyledThemeProvider theme={theme()}>
-          <CssBaseline />
-          <StylesProvider injectFirst>{children}</StylesProvider>
-        </StyledThemeProvider>
+        <CssBaseline />
+        <StylesProvider injectFirst>{children}</StylesProvider>
       </EmotionThemeProvider>
     </MuiThemeProvider>
   );

--- a/frontend/packages/core/src/Feedback/hint.tsx
+++ b/frontend/packages/core/src/Feedback/hint.tsx
@@ -1,15 +1,13 @@
 import React from "react";
+import styled from "@emotion/styled";
 import { Popover, Typography } from "@material-ui/core";
 import HelpIcon from "@material-ui/icons/Help";
-import styled from "styled-components";
 
-const HelpIconContainer = styled.div`
-  ${({ theme }) => `
-  display: flex;
-  color: ${theme.palette.text.secondary};
-  padding: 5px;
-  `}
-`;
+const HelpIconContainer = styled.div({
+  display: "flex",
+  color: "#D7DADB",
+  padding: "5px",
+});
 
 const Hint: React.FC = ({ children }) => {
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);

--- a/frontend/packages/core/src/Feedback/warning.tsx
+++ b/frontend/packages/core/src/Feedback/warning.tsx
@@ -1,11 +1,11 @@
 import React from "react";
+import styled from "@emotion/styled";
 import { Snackbar } from "@material-ui/core";
 import { Alert as MuiAlert } from "@material-ui/lab";
-import styled from "styled-components";
 
-const Alert = styled(MuiAlert)`
-  margin: 5px;
-`;
+const Alert = styled(MuiAlert)({
+  margin: "5px",
+});
 
 export interface WarningProps {
   message: any;

--- a/frontend/packages/core/src/Input/radio-group.tsx
+++ b/frontend/packages/core/src/Input/radio-group.tsx
@@ -1,31 +1,29 @@
 import * as React from "react";
+import styled from "@emotion/styled";
 import {
   FormControl as MuiFormControl,
   FormControlLabel,
   FormLabel as MuiFormLabel,
   RadioGroup as MuiRadioGroup,
 } from "@material-ui/core";
-import styled from "styled-components";
 
 import Radio from "./radio";
 
-const FormLabel = styled(MuiFormLabel)`
-  ${({ theme }) => `
-  && {
-    color: ${theme.palette.text.primary};
-  }
-  font-weight: bold;
-  position: relative;
-  &.Mui-disabled {
-    opacity: 0.75;
-  }
-  `}
-`;
+const FormLabel = styled(MuiFormLabel)({
+  "&&": {
+    color: "#2D3F50",
+  },
+  fontWeight: "bold",
+  position: "relative",
+  "&.Mui-disabled": {
+    opacity: "0.75",
+  },
+});
 
-const FormControl = styled(MuiFormControl)`
-  margin: 16px 0;
-  min-width: fit-content;
-`;
+const FormControl = styled(MuiFormControl)({
+  margin: "16px 0",
+  minWidth: "fit-content",
+});
 
 interface RadioGroupOption {
   label: string;

--- a/frontend/packages/core/src/not-found.tsx
+++ b/frontend/packages/core/src/not-found.tsx
@@ -1,18 +1,16 @@
 import React from "react";
+import styled from "@emotion/styled";
 import { Grid, Typography } from "@material-ui/core";
 import ThumbDownIcon from "@material-ui/icons/ThumbDown";
-import styled from "styled-components";
 
 const Container = styled(Grid)`
   minheight: 80vh;
 `;
 
-const IconContainer = styled(Grid)`
-  ${({ theme }) => `
-  color: ${theme.palette.accent.main};
-  font-size: 7rem;
-  `}
-`;
+const IconContainer = styled(Grid)({
+  color: "#02acbe",
+  fontSize: "7rem",
+});
 
 const NotFound: React.FC<{}> = () => (
   <Container

--- a/frontend/packages/core/src/panel.tsx
+++ b/frontend/packages/core/src/panel.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "@emotion/styled";
 import {
   Accordion as MuiExpansionPanel,
   AccordionDetails,
@@ -6,7 +7,6 @@ import {
   Typography,
 } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import styled from "styled-components";
 
 const FullWidthExpansionPanel = styled(MuiExpansionPanel)`
   width: 100%;

--- a/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
@@ -4,73 +4,71 @@ exports[`Not Found component renders correctly 1`] = `
 "<Theme>
   <ThemeProvider theme={{...}}>
     <ThemeProvider theme={{...}}>
-      <Component theme={{...}}>
-        <WithStyles(CssBaseline)>
-          <CssBaseline classes={{...}} />
-        </WithStyles(CssBaseline)>
-        <StylesProvider injectFirst={true}>
-          <NotFound>
-            <Styled(WithStyles(ForwardRef(Grid))) container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\" style={{...}}>
-              <WithStyles(ForwardRef(Grid)) container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\" style={{...}} className=\\"sc-bdnylx jOPWCO\\">
-                <ForwardRef(Grid) classes={{...}} container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\" style={{...}} className=\\"sc-bdnylx jOPWCO\\">
-                  <div className=\\"MuiGrid-root sc-bdnylx jOPWCO MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center MuiGrid-justify-xs-center\\" style={{...}}>
-                    <Styled(WithStyles(ForwardRef(Grid))) item={true}>
-                      <WithStyles(ForwardRef(Grid)) item={true} className=\\"sc-gtssRu deUxmn\\">
-                        <ForwardRef(Grid) classes={{...}} item={true} className=\\"sc-gtssRu deUxmn\\">
-                          <div className=\\"MuiGrid-root sc-gtssRu deUxmn MuiGrid-item\\">
-                            <ForwardRef fontSize=\\"inherit\\">
-                              <WithStyles(ForwardRef(SvgIcon)) fontSize=\\"inherit\\">
-                                <ForwardRef(SvgIcon) classes={{...}} fontSize=\\"inherit\\">
-                                  <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" color={[undefined]} aria-hidden={true} role={[undefined]}>
-                                    <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
-                                  </svg>
-                                </ForwardRef(SvgIcon)>
-                              </WithStyles(ForwardRef(SvgIcon))>
-                            </ForwardRef>
-                          </div>
-                        </ForwardRef(Grid)>
-                      </WithStyles(ForwardRef(Grid))>
-                    </Styled(WithStyles(ForwardRef(Grid)))>
-                    <WithStyles(ForwardRef(Grid)) item={true}>
-                      <ForwardRef(Grid) classes={{...}} item={true}>
-                        <div className=\\"MuiGrid-root MuiGrid-item\\">
-                          <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
-                            <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
-                              <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
-                                <WithStyles(ForwardRef(Grid)) item={true}>
-                                  <ForwardRef(Grid) classes={{...}} item={true}>
-                                    <div className=\\"MuiGrid-root MuiGrid-item\\">
-                                      Whoops...
-                                    </div>
-                                  </ForwardRef(Grid)>
-                                </WithStyles(ForwardRef(Grid))>
-                                <WithStyles(ForwardRef(Grid)) item={true}>
-                                  <ForwardRef(Grid) classes={{...}} item={true}>
-                                    <div className=\\"MuiGrid-root MuiGrid-item\\">
-                                      Looks like you took a wrong turn
-                                    </div>
-                                  </ForwardRef(Grid)>
-                                </WithStyles(ForwardRef(Grid))>
-                              </h3>
-                            </ForwardRef(Typography)>
-                          </WithStyles(ForwardRef(Typography))>
-                          <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
-                            <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
-                              <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
-                                &lt; 404 Not Found &gt;
-                              </h6>
-                            </ForwardRef(Typography)>
-                          </WithStyles(ForwardRef(Typography))>
+      <WithStyles(CssBaseline)>
+        <CssBaseline classes={{...}} />
+      </WithStyles(CssBaseline)>
+      <StylesProvider injectFirst={true}>
+        <NotFound>
+          <Styled(WithStyles(ForwardRef(Grid))) container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\" style={{...}}>
+            <WithStyles(ForwardRef(Grid)) container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\" style={{...}} className=\\"css-1rc10fs\\">
+              <ForwardRef(Grid) classes={{...}} container={true} direction=\\"column\\" justify=\\"center\\" alignItems=\\"center\\" style={{...}} className=\\"css-1rc10fs\\">
+                <div className=\\"MuiGrid-root css-1rc10fs MuiGrid-container MuiGrid-direction-xs-column MuiGrid-align-items-xs-center MuiGrid-justify-xs-center\\" style={{...}}>
+                  <Styled(WithStyles(ForwardRef(Grid))) item={true}>
+                    <WithStyles(ForwardRef(Grid)) item={true} className=\\"css-sm4uoy\\">
+                      <ForwardRef(Grid) classes={{...}} item={true} className=\\"css-sm4uoy\\">
+                        <div className=\\"MuiGrid-root css-sm4uoy MuiGrid-item\\">
+                          <ForwardRef fontSize=\\"inherit\\">
+                            <WithStyles(ForwardRef(SvgIcon)) fontSize=\\"inherit\\">
+                              <ForwardRef(SvgIcon) classes={{...}} fontSize=\\"inherit\\">
+                                <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" focusable=\\"false\\" viewBox=\\"0 0 24 24\\" color={[undefined]} aria-hidden={true} role={[undefined]}>
+                                  <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
+                                </svg>
+                              </ForwardRef(SvgIcon)>
+                            </WithStyles(ForwardRef(SvgIcon))>
+                          </ForwardRef>
                         </div>
                       </ForwardRef(Grid)>
                     </WithStyles(ForwardRef(Grid))>
-                  </div>
-                </ForwardRef(Grid)>
-              </WithStyles(ForwardRef(Grid))>
-            </Styled(WithStyles(ForwardRef(Grid)))>
-          </NotFound>
-        </StylesProvider>
-      </Component>
+                  </Styled(WithStyles(ForwardRef(Grid)))>
+                  <WithStyles(ForwardRef(Grid)) item={true}>
+                    <ForwardRef(Grid) classes={{...}} item={true}>
+                      <div className=\\"MuiGrid-root MuiGrid-item\\">
+                        <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
+                          <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
+                            <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
+                              <WithStyles(ForwardRef(Grid)) item={true}>
+                                <ForwardRef(Grid) classes={{...}} item={true}>
+                                  <div className=\\"MuiGrid-root MuiGrid-item\\">
+                                    Whoops...
+                                  </div>
+                                </ForwardRef(Grid)>
+                              </WithStyles(ForwardRef(Grid))>
+                              <WithStyles(ForwardRef(Grid)) item={true}>
+                                <ForwardRef(Grid) classes={{...}} item={true}>
+                                  <div className=\\"MuiGrid-root MuiGrid-item\\">
+                                    Looks like you took a wrong turn
+                                  </div>
+                                </ForwardRef(Grid)>
+                              </WithStyles(ForwardRef(Grid))>
+                            </h3>
+                          </ForwardRef(Typography)>
+                        </WithStyles(ForwardRef(Typography))>
+                        <WithStyles(ForwardRef(Typography)) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
+                          <ForwardRef(Typography) classes={{...}} align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
+                            <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-colorTextPrimary MuiTypography-alignCenter\\">
+                              &lt; 404 Not Found &gt;
+                            </h6>
+                          </ForwardRef(Typography)>
+                        </WithStyles(ForwardRef(Typography))>
+                      </div>
+                    </ForwardRef(Grid)>
+                  </WithStyles(ForwardRef(Grid))>
+                </div>
+              </ForwardRef(Grid)>
+            </WithStyles(ForwardRef(Grid))>
+          </Styled(WithStyles(ForwardRef(Grid)))>
+        </NotFound>
+      </StylesProvider>
     </ThemeProvider>
   </ThemeProvider>
 </Theme>"

--- a/frontend/packages/tools/package.json
+++ b/frontend/packages/tools/package.json
@@ -27,7 +27,6 @@
     "@types/node": "^14.14.37",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^17.0.0",
-    "@types/styled-components": "^5.1.9",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "babel-eslint": "^10.0.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -149,7 +149,7 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.10.4":
+"@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
   integrity sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
@@ -1471,7 +1471,7 @@
     "@babel/parser" "^7.12.7"
     "@babel/types" "^7.12.7"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.1.tgz#941395e0c5cc86d5d3e75caa095d3924526f0c1e"
   integrity sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==
@@ -1712,7 +1712,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.6", "@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.6":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1805,12 +1805,12 @@
     "@emotion/serialize" "^1.0.0"
     "@emotion/utils" "^1.0.0"
 
-"@emotion/stylis@0.8.5", "@emotion/stylis@^0.8.4":
+"@emotion/stylis@0.8.5":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4", "@emotion/unitless@^0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -4305,14 +4305,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/hoist-non-react-statics@*":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -4593,15 +4585,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
-
-"@types/styled-components@^5.1.9":
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.9.tgz#00d3d84b501420521c4db727e3c195459f87a6cf"
-  integrity sha512-kbEG6YlwK8rucITpKEr6pA4Ho9KSQHUUOzZ9lY3va1mtcjvS3D0wDciFyHEiNHKLL/npZCKDQJqm0x44sPO9oA==
-  dependencies:
-    "@types/hoist-non-react-statics" "*"
-    "@types/react" "*"
-    csstype "^3.0.2"
 
 "@types/styled-jsx@^2.2.8":
   version "2.2.8"
@@ -6004,16 +5987,6 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-"babel-plugin-styled-components@>= 1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.11.1.tgz#5296a9e557d736c3186be079fff27c6665d63d76"
-  integrity sha512-YwrInHyKUk1PU3avIRdiLyCpM++18Rs1NgyMXEAQC33rIXs/vro0A+stf4sT0Gf22Got+xRWB8Cm0tw+qkRzBA==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.0.0"
-    "@babel/helper-module-imports" "^7.0.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.11"
-
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -6740,11 +6713,6 @@ camelcase@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
-
-camelize@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
-  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -7701,11 +7669,6 @@ css-box-model@^1.2.0:
   dependencies:
     tiny-invariant "^1.0.6"
 
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
-
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -7802,15 +7765,6 @@ css-select@^2.0.0:
     css-what "^3.2.1"
     domutils "^1.7.0"
     nth-check "^1.0.2"
-
-css-to-react-native@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
-  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -10994,7 +10948,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -19161,22 +19115,6 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-components@^5.1.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.0.tgz#6dcb5aa8a629c84b8d5ab34b7167e3e0c6f7ed74"
-  integrity sha512-9qE8Vgp8C5cpGAIdFaQVAl89Zgx1TDM4Yf4tlHbO9cPijtpSXTMLHy9lmP0lb+yImhgPFb1AmZ1qMUubmg3HLg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^0.8.8"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
-
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -19201,7 +19139,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==

--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -8,7 +8,6 @@ LINKED_PACKAGES=(
   "react-dom"
   "react-router"
   "react-router-dom"
-  "styled-components"
   "@emotion/react"
   "@emotion/styled"
   "@material-ui/styles"
@@ -19,7 +18,6 @@ LINKED_PACKAGES=(
   "@types/node"
   "@types/react"
   "@types/react-dom"
-  "@types/styled-components"
   "typescript"
 )
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Remove styled-components dependency now that we are fully using emotion.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
CI