### PR TITLE
frontend: add network tests for success interceptor

### DIFF
--- a/frontend/packages/core/src/Network/index.ts
+++ b/frontend/packages/core/src/Network/index.ts
@@ -26,8 +26,6 @@ const successInterceptor = (response: AxiosResponse) => {
   // to prevent CORS issues from redirecting on the server.
   if (response?.data?.authUrl) {
     window.location = response.data.authUrl;
-    response.data.code = 401;
-    response.data.message = "Authentication Expired";
     const clutchError = {
       status: {
         code: 401,
@@ -92,4 +90,4 @@ const createClient = () => {
 
 const client = createClient();
 
-export { client, errorInterceptor };
+export { client, errorInterceptor, successInterceptor };

--- a/frontend/packages/core/src/Network/tests/index.test.ts
+++ b/frontend/packages/core/src/Network/tests/index.test.ts
@@ -17,11 +17,12 @@ describe("success interceptor", () => {
   describe("on auth url response data", () => {
     let response: () => AxiosResponse;
     beforeEach(() => {
-      response = () => successInterceptor({
-        data: {
-          authUrl: "https://clutch.sh/auth",
-        },
-      } as AxiosResponse);
+      response = () =>
+        successInterceptor({
+          data: {
+            authUrl: "https://clutch.sh/auth",
+          },
+        } as AxiosResponse);
     });
 
     it("redirects to provided url", () => {

--- a/frontend/packages/core/src/Network/tests/index.test.ts
+++ b/frontend/packages/core/src/Network/tests/index.test.ts
@@ -31,7 +31,7 @@ describe("success interceptor", () => {
     });
 
     it("throws a ClutchError", () => {
-      expect(response()).toThrow({
+      expect(() => response()).toThrow({
         message: "Authentication Expired",
         status: {
           code: 401,

--- a/frontend/packages/core/src/Network/tests/index.test.ts
+++ b/frontend/packages/core/src/Network/tests/index.test.ts
@@ -1,7 +1,45 @@
-import type { AxiosError } from "axios";
+import type { AxiosError, AxiosResponse } from "axios";
 
 import type { ClutchError } from "../errors";
-import { client, errorInterceptor } from "../index";
+import { client, errorInterceptor, successInterceptor } from "../index";
+
+describe("success interceptor", () => {
+  const { location } = window;
+
+  beforeAll(() => {
+    delete window.location;
+  });
+
+  afterAll(() => {
+    window.location = location;
+  });
+
+  describe("on auth url response data", () => {
+    let response: () => AxiosResponse;
+    beforeEach(() => {
+      response = () => successInterceptor({
+        data: {
+          authUrl: "https://clutch.sh/auth",
+        },
+      } as AxiosResponse);
+    });
+
+    it("redirects to provided url", () => {
+      expect(() => response()).toThrow();
+      expect(window.location).toBe("https://clutch.sh/auth");
+    });
+
+    it("throws a ClutchError", () => {
+      expect(response()).toThrow({
+        message: "Authentication Expired",
+        status: {
+          code: 401,
+          text: "Authentication Expired",
+        },
+      } as ClutchError);
+    });
+  });
+});
 
 describe("error interceptor", () => {
   describe("on axios error", () => {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Adds tests for the success interceptor on the network client.

Also removes the code and message set on the response data in the auth case as they won't be propagated due to the throw logic.
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
included