### PR TITLE
tools: add esbuild to gateway fe linker

### DIFF
--- a/tools/frontend-gateway-linker.sh
+++ b/tools/frontend-gateway-linker.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
 # Packages should be added to this list if there can only be one of them present when using Clutch as a submodule.
 LINKED_PACKAGES=(
+  "esbuild"
   "react"
   "react-dom"
   "react-router"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add esbuild to LINKED_PACKAGES under frontend-gateway-linker.sh to fix a build issue I was having

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual