### PR TITLE
frontend: prevent wizard regressing past the first step

### DIFF
--- a/frontend/packages/wizard/src/state.tsx
+++ b/frontend/packages/wizard/src/state.tsx
@@ -20,7 +20,7 @@ const reducer = (state: StateProps, action: WizardAction): StateProps => {
     case WizardAction.BACK:
       return {
         ...state,
-        activeStep: state.activeStep - 1,
+        activeStep: state.activeStep > 0 ? state.activeStep - 1 : 0,
       };
     case WizardAction.RESET:
       return {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
If a workflow attempts to use `onBack` on the first step we should not update the index.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manul
