### PR TITLE
experimentation: speed up integration testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ yarn-install: yarn-ensure
 
 .PHONY: backend-integration-test
 backend-integration-test:
-	cd backend/internal/test/integration/xds && docker-compose up --abort-on-container-exit
+	cd backend/internal/test/integration/xds && docker-compose up --build --abort-on-container-exit
 
 .PHONY: frontend # Build production frontend assets.
 frontend: yarn-install

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ yarn-install: yarn-ensure
 
 .PHONY: backend-integration-test
 backend-integration-test:
-	cd backend/internal/test/integration/xds && ./do_integration_test.sh docker-compose up --build --abort-on-container-exit
+	cd backend/internal/test/integration/xds && ./do_integration_test.sh
 
 .PHONY: frontend # Build production frontend assets.
 frontend: yarn-install

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ yarn-install: yarn-ensure
 
 .PHONY: backend-integration-test
 backend-integration-test:
-	cd backend/internal/test/integration/xds && docker-compose up --build --abort-on-container-exit
+	cd backend/internal/test/integration/xds && ./do_integration_test.sh docker-compose up --build --abort-on-container-exit
 
 .PHONY: frontend # Build production frontend assets.
 frontend: yarn-install

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ yarn-install: yarn-ensure
 
 .PHONY: backend-integration-test
 backend-integration-test:
-	cd backend/internal/test/integration/xds && docker-compose up --build --abort-on-container-exit
+	cd backend/internal/test/integration/xds && docker-compose up --abort-on-container-exit
 
 .PHONY: frontend # Build production frontend assets.
 frontend: yarn-install

--- a/backend/internal/test/integration/xds/.gitignore
+++ b/backend/internal/test/integration/xds/.gitignore
@@ -1,2 +1,1 @@
-testrunner
-envoyconfiggen
+build/

--- a/backend/internal/test/integration/xds/.gitignore
+++ b/backend/internal/test/integration/xds/.gitignore
@@ -1,0 +1,2 @@
+testrunner
+envoyconfiggen

--- a/backend/internal/test/integration/xds/do_integration_test.sh
+++ b/backend/internal/test/integration/xds/do_integration_test.sh
@@ -2,6 +2,7 @@ target_dir="$(pwd)"
 
 export GOOS=linux
 export GOARCH=amd64
+export CGO_ENABLED=0
 
 pushd ../../../..
 	pushd internal/test/integration/xds/cmd/envoyconfiggen

--- a/backend/internal/test/integration/xds/do_integration_test.sh
+++ b/backend/internal/test/integration/xds/do_integration_test.sh
@@ -1,9 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# We expect this to be run from the directory containing the script.
 target_dir="$(pwd)"
 
+# Build the Go executable on the host system targeting linux. This is much faster
+# than naively building within the container setup since we get to share the host Go
+# caches.
 export GOOS=linux
 export GOARCH=amd64
 export CGO_ENABLED=0
 
+# Place the output binaries in $target_dir for use by the Dockerfiles.
 pushd ../../../..
 	pushd internal/test/integration/xds/cmd/envoyconfiggen
 	  go build -o $target_dir/envoyconfiggen main.go

--- a/backend/internal/test/integration/xds/do_integration_test.sh
+++ b/backend/internal/test/integration/xds/do_integration_test.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # We expect this to be run from the directory containing the script.
-target_dir="$(pwd)"
+mkdir -p build/
+target_dir="$(pwd)/build"
 
 # Build the Go executable on the host system targeting linux. This is much faster
 # than naively building within the container setup since we get to share the host Go

--- a/backend/internal/test/integration/xds/do_integration_test.sh
+++ b/backend/internal/test/integration/xds/do_integration_test.sh
@@ -1,0 +1,15 @@
+target_dir="$(pwd)"
+
+export GOOS=linux
+export GOARCH=amd64
+
+pushd ../../../..
+	pushd internal/test/integration/xds/cmd/envoyconfiggen
+	  go build -o $target_dir/envoyconfiggen main.go
+	popd
+	pushd module/chaos/serverexperimentation/xds
+		go test -tags integration_only -c -o $target_dir/testrunner
+	popd
+popd
+
+docker-compose up --build --abort-on-container-exit

--- a/backend/internal/test/integration/xds/docker-compose.yaml
+++ b/backend/internal/test/integration/xds/docker-compose.yaml
@@ -2,22 +2,17 @@ version: "3.9"
 
 services:
   envoy:
+    stop_grace_period: 0s
     build:
-      context: ../../../.. # backend root directory
-      dockerfile: internal/test/integration/xds/envoy.Dockerfile
-    volumes:
-    - ../../../..:/code
-    - ~/.cache/go-build:/root/.cache/go-build
-    - ~/go:/go
+      context: .
+      dockerfile: envoy.Dockerfile
     ports:
       - "10000:10000"
       - "9901:9901"
   test_runner:
-    image: golang:1.16.0
-    volumes:
-    - ../../../..:/code
-    - ~/.cache/go-build:/root/.cache/go-build
-    - ~/go:/go
-    command: sh -c 'cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only'
+    build:
+      context: .
+      dockerfile: testrunner.Dockerfile
+    command: /testrunner
     ports:
       - "9000:9000"

--- a/backend/internal/test/integration/xds/docker-compose.yaml
+++ b/backend/internal/test/integration/xds/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     volumes:
     - ../../../..:/code
     - ~/.cache/go-build:/root/.cache/go-build
+    - ~/go:/root/go
     ports:
       - "10000:10000"
       - "9901:9901"
@@ -16,6 +17,7 @@ services:
     volumes:
     - ../../../..:/code
     - ~/.cache/go-build:/root/.cache/go-build
+    - ~/go:/root/go
     command: sh -c 'cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only'
     ports:
       - "9000:9000"

--- a/backend/internal/test/integration/xds/docker-compose.yaml
+++ b/backend/internal/test/integration/xds/docker-compose.yaml
@@ -13,6 +13,5 @@ services:
     build:
       context: .
       dockerfile: testrunner.Dockerfile
-    command: /testrunner
     ports:
       - "9000:9000"

--- a/backend/internal/test/integration/xds/docker-compose.yaml
+++ b/backend/internal/test/integration/xds/docker-compose.yaml
@@ -5,13 +5,15 @@ services:
     build:
       context: ../../../.. # backend root directory
       dockerfile: internal/test/integration/xds/envoy.Dockerfile
+    volumes:
+    - ../../../..:/code
     ports:
       - "10000:10000"
       - "9901:9901"
   test_runner:
-    build:
-      context: ../../../.. # backend root directory
-      dockerfile: internal/test/integration/xds/testrunner.Dockerfile
-    command: /testrunner
+    image: golang:1.16.0
+    volumes:
+    - ../../../..:/code
+    command: sh -c 'cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only'
     ports:
       - "9000:9000"

--- a/backend/internal/test/integration/xds/docker-compose.yaml
+++ b/backend/internal/test/integration/xds/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
     - ../../../..:/code
     - ~/.cache/go-build:/root/.cache/go-build
-    - ~/go:/root/go
+    - ~/go:/go
     ports:
       - "10000:10000"
       - "9901:9901"
@@ -17,7 +17,7 @@ services:
     volumes:
     - ../../../..:/code
     - ~/.cache/go-build:/root/.cache/go-build
-    - ~/go:/root/go
+    - ~/go:/go
     command: sh -c 'cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only'
     ports:
       - "9000:9000"

--- a/backend/internal/test/integration/xds/docker-compose.yaml
+++ b/backend/internal/test/integration/xds/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       dockerfile: internal/test/integration/xds/envoy.Dockerfile
     volumes:
     - ../../../..:/code
+    - ~/.cache/go-build:~/.cache/go-build
     ports:
       - "10000:10000"
       - "9901:9901"
@@ -14,6 +15,7 @@ services:
     image: golang:1.16.0
     volumes:
     - ../../../..:/code
+    - ~/.cache/go-build:~/.cache/go-build
     command: sh -c 'cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only'
     ports:
       - "9000:9000"

--- a/backend/internal/test/integration/xds/docker-compose.yaml
+++ b/backend/internal/test/integration/xds/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: internal/test/integration/xds/envoy.Dockerfile
     volumes:
     - ../../../..:/code
-    - ~/.cache/go-build:~/.cache/go-build
+    - ~/.cache/go-build:/root/.cache/go-build
     ports:
       - "10000:10000"
       - "9901:9901"
@@ -15,7 +15,7 @@ services:
     image: golang:1.16.0
     volumes:
     - ../../../..:/code
-    - ~/.cache/go-build:~/.cache/go-build
+    - ~/.cache/go-build:/root/.cache/go-build
     command: sh -c 'cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only'
     ports:
       - "9000:9000"

--- a/backend/internal/test/integration/xds/envoy.Dockerfile
+++ b/backend/internal/test/integration/xds/envoy.Dockerfile
@@ -4,4 +4,6 @@ FROM envoyproxy/envoy:v1.17.1 as envoy
 FROM golang:1.16.0
 COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
 
-ENTRYPOINT bash -c '/usr/local/bin/envoy -c $(go run /code/internal/test/integration/xds/cmd/envoyconfiggen)'
+ENV GO111MODULE=on
+
+ENTRYPOINT bash -c '/usr/local/bin/envoy --config-yaml "$(cd /code/internal/test/integration/xds/cmd/envoyconfiggen && go run main.go)"'

--- a/backend/internal/test/integration/xds/envoy.Dockerfile
+++ b/backend/internal/test/integration/xds/envoy.Dockerfile
@@ -1,8 +1,6 @@
-FROM golang:1.16.0 AS build
+FROM envoyproxy/envoy-alpine:v1.17.1
+
 COPY envoyconfiggen /envoyconfiggen
 RUN /envoyconfiggen > /config.json
-
-FROM envoyproxy/envoy:v1.17.1
-COPY --from=build /config.json /config.json
 
 ENTRYPOINT /usr/local/bin/envoy -c /config.json

--- a/backend/internal/test/integration/xds/envoy.Dockerfile
+++ b/backend/internal/test/integration/xds/envoy.Dockerfile
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine:v1.17.1
 
-COPY envoyconfiggen /envoyconfiggen
+COPY build/envoyconfiggen /envoyconfiggen
 RUN /envoyconfiggen > /config.json
 
 ENTRYPOINT /usr/local/bin/envoy -c /config.json

--- a/backend/internal/test/integration/xds/envoy.Dockerfile
+++ b/backend/internal/test/integration/xds/envoy.Dockerfile
@@ -1,9 +1,8 @@
+FROM golang:1.16.0 AS build
+COPY envoyconfiggen /envoyconfiggen
+RUN /envoyconfiggen > /config.json
 
-FROM envoyproxy/envoy-alpine:v1.17.1 as envoy
+FROM envoyproxy/envoy:v1.17.1
+COPY --from=build /config.json /config.json
 
-FROM golang:1.16.0
-COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
-
-ENV GO111MODULE=on
-
-ENTRYPOINT bash -c '/usr/local/bin/envoy --config-yaml "$(cd /code/internal/test/integration/xds/cmd/envoyconfiggen && go run main.go)"'
+ENTRYPOINT /usr/local/bin/envoy -c /config.json

--- a/backend/internal/test/integration/xds/envoy.Dockerfile
+++ b/backend/internal/test/integration/xds/envoy.Dockerfile
@@ -1,9 +1,7 @@
-FROM golang:1.16.0 AS build
-COPY . /code
-RUN cd /code/internal/test/integration/xds/cmd/envoyconfiggen && go build -o /tmp/generate_config
-RUN /tmp/generate_config > /config.json
 
-FROM envoyproxy/envoy:v1.17.1
-COPY --from=build /config.json /config.json
+FROM envoyproxy/envoy:v1.17.1 as envoy
 
-ENTRYPOINT /usr/local/bin/envoy -c /config.json
+FROM golang:1.16.0
+COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
+
+ENTRYPOINT bash -c '/usr/local/bin/envoy -c $(go run /code/internal/test/integration/xds/cmd/envoyconfiggen)'

--- a/backend/internal/test/integration/xds/envoy.Dockerfile
+++ b/backend/internal/test/integration/xds/envoy.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM envoyproxy/envoy:v1.17.1 as envoy
+FROM envoyproxy/envoy-alpine:v1.17.1 as envoy
 
 FROM golang:1.16.0
 COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy

--- a/backend/internal/test/integration/xds/testrunner.Dockerfile
+++ b/backend/internal/test/integration/xds/testrunner.Dockerfile
@@ -1,6 +1,3 @@
 FROM golang:1.16.0
 
-COPY . /code
-
-RUN cd /code/module/chaos/serverexperimentation/xds && find . -type f -name "*_test.go" ! -name "*_integration_test.go" -exec rm {} \;
-RUN cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only -c -o /testrunner
+ENTRYPOINT cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only -c -o /testrunner

--- a/backend/internal/test/integration/xds/testrunner.Dockerfile
+++ b/backend/internal/test/integration/xds/testrunner.Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.16.0
+FROM scratch
 
 ADD testrunner /testrunner

--- a/backend/internal/test/integration/xds/testrunner.Dockerfile
+++ b/backend/internal/test/integration/xds/testrunner.Dockerfile
@@ -1,3 +1,3 @@
-FROM scratch
+FROM alpine
 
 ADD testrunner /testrunner

--- a/backend/internal/test/integration/xds/testrunner.Dockerfile
+++ b/backend/internal/test/integration/xds/testrunner.Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
 
-ADD testrunner /testrunner
+ADD build/testrunner /testrunner
 
 ENTRYPOINT /testrunner

--- a/backend/internal/test/integration/xds/testrunner.Dockerfile
+++ b/backend/internal/test/integration/xds/testrunner.Dockerfile
@@ -1,3 +1,5 @@
 FROM alpine
 
 ADD testrunner /testrunner
+
+ENTRYPOINT /testrunner

--- a/backend/internal/test/integration/xds/testrunner.Dockerfile
+++ b/backend/internal/test/integration/xds/testrunner.Dockerfile
@@ -1,3 +1,3 @@
 FROM golang:1.16.0
 
-ENTRYPOINT cd /code/module/chaos/serverexperimentation/xds && go test -tags integration_only -c -o /testrunner
+ADD testrunner /testrunner


### PR DESCRIPTION
Cuts down the time to run integration tests in several ways:
1) build the Go binaries on the host system, allowing for reuse of cached artifacts (build, go mod, etc.)
2) use smaller Docker containers. We go from needing to pull golang and envoyproxy/envoy to pulling alpine and envoyproxy/envoy-alpine, which results in substantially shorter download times
3) set the grace period of the envoy container to 0, this issues a KILL immediately instead of waiting for up to 10s for envoy to handle a TERM