### PR TITLE
frontend: resolver - add prop to override / disable autocomplete at the workflow level

### DIFF
--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -54,6 +54,10 @@ interface ResolverProps {
    *  API module to resolve lookups against.
    * */
   apiPackage?: object;
+  /**
+   *  enableAutocomplete bool is used to enable/disable autocomplete at the workflow level rather than the schema level.
+   */
+  enableAutocomplete?: boolean;
 }
 
 const Resolver: React.FC<ResolverProps> = ({
@@ -62,6 +66,7 @@ const Resolver: React.FC<ResolverProps> = ({
   onResolve,
   variant = "dual",
   apiPackage,
+  enableAutocomplete = "true",
 }) => {
   const [state, dispatch] = useResolverState();
   const { displayWarnings } = useWizardContext();
@@ -116,6 +121,7 @@ const Resolver: React.FC<ResolverProps> = ({
                   setSearchParams({ q: data.query });
                   submitHandler(data);
                 }}
+                enableAutocomplete={enableAutocomplete}
               />
             </>
           )}

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -66,7 +66,7 @@ const Resolver: React.FC<ResolverProps> = ({
   onResolve,
   variant = "dual",
   apiPackage,
-  enableAutocomplete = "true",
+  enableAutocomplete = true,
 }) => {
   const [state, dispatch] = useResolverState();
   const { displayWarnings } = useWizardContext();

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -48,7 +48,12 @@ const autoComplete = async (type: string, search: string): Promise<any> => {
   return { results: response?.data?.results || [] };
 };
 
-const QueryResolver: React.FC<QueryResolverProps> = ({ inputType, schemas, submitHandler, enableAutocomplete = true }) => {
+const QueryResolver: React.FC<QueryResolverProps> = ({
+  inputType,
+  schemas,
+  submitHandler,
+  enableAutocomplete = true,
+}) => {
   const validation = useForm({
     mode: "onSubmit",
     reValidateMode: "onSubmit",
@@ -68,7 +73,8 @@ const QueryResolver: React.FC<QueryResolverProps> = ({ inputType, schemas, submi
   // If there is at least 1 schema that has the ability to autocomplete we will enable it.
   // enableAutocomplete's default value is true.  We only use it (set it to false) when we want to override and disable autocomplete at the workflow level rather than the schema level.
   const isAutoCompleteEnabled =
-    (schemas.filter(schema => schema?.metadata?.search?.autocompleteEnabled === true).length >= 1) && enableAutocomplete;
+    schemas.filter(schema => schema?.metadata?.search?.autocompleteEnabled === true).length >= 1 &&
+    enableAutocomplete;
 
   const error = validation.errors?.query;
   return (

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -30,6 +30,7 @@ interface QueryResolverProps {
   inputType: string;
   schemas: clutch.resolver.v1.Schema[];
   submitHandler: any;
+  enableAutocomplete?: boolean;
 }
 
 const autoComplete = async (type: string, search: string): Promise<any> => {
@@ -47,7 +48,7 @@ const autoComplete = async (type: string, search: string): Promise<any> => {
   return { results: response?.data?.results || [] };
 };
 
-const QueryResolver: React.FC<QueryResolverProps> = ({ inputType, schemas, submitHandler }) => {
+const QueryResolver: React.FC<QueryResolverProps> = ({ inputType, schemas, submitHandler, enableAutocomplete = true }) => {
   const validation = useForm({
     mode: "onSubmit",
     reValidateMode: "onSubmit",
@@ -65,8 +66,9 @@ const QueryResolver: React.FC<QueryResolverProps> = ({ inputType, schemas, submi
   };
 
   // If there is at least 1 schema that has the ability to autocomplete we will enable it.
+  // enableAutocomplete's default value is true.  We only use it (set it to false) when we want to override and disable autocomplete at the workflow level rather than the schema level.
   const isAutoCompleteEnabled =
-    schemas.filter(schema => schema?.metadata?.search?.autocompleteEnabled === true).length >= 1;
+    (schemas.filter(schema => schema?.metadata?.search?.autocompleteEnabled === true).length >= 1) && enableAutocomplete;
 
   const error = validation.errors?.query;
   return (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It would be convenient to have the ability to turn off autocomplete at the workflow rather than just the schema level.
Once this PR is in then we can pass a prop via the config file to the ResolverChild to turn off autocomplete for a given workflow.
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
