### PR TITLE
datalayout: make new data take precedence over old data

### DIFF
--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -55,7 +55,7 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
       if ((newDataIsArray && !existingDataIsArray) || (!newDataIsArray && existingDataIsArray)) {
         data = newData;
       } else if (newDataIsArray) {
-        data = [...existingData, ...newData ];
+        data = [...existingData, ...newData];
       } else {
         data = { ...existingData, ...newData };
       }

--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -55,9 +55,9 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
       if ((newDataIsArray && !existingDataIsArray) || (!newDataIsArray && existingDataIsArray)) {
         data = newData;
       } else if (newDataIsArray) {
-        data = [...newData, ...existingData];
+        data = [...existingData, ...newData ];
       } else {
-        data = { ...newData, ...existingData };
+        data = { ...existingData, ...newData };
       }
       const update = {
         isLoading: false,

--- a/frontend/packages/data-layout/src/tests/state.test.tsx
+++ b/frontend/packages/data-layout/src/tests/state.test.tsx
@@ -13,7 +13,7 @@ describe("Manager State", () => {
           type: ManagerAction.HYDRATE_END,
           payload: { key: "layout", result: [{ hydrate: "value" }] },
         });
-        expect(state.layout.data).toEqual([{ hydrate: "value" }, { update: "value" }]);
+        expect(state.layout.data).toEqual([{ update: "value" }, { hydrate: "value" }]);
       });
 
       it("of objects", () => {
@@ -30,7 +30,7 @@ describe("Manager State", () => {
       });
     });
 
-    it("gives priority to existing data", () => {
+    it("gives priority to new data", () => {
       let state = {};
       state = reducer(state, {
         type: ManagerAction.SET,
@@ -40,7 +40,7 @@ describe("Manager State", () => {
         type: ManagerAction.HYDRATE_END,
         payload: { key: "layout", result: { update: "endingValue" } },
       });
-      expect(state.layout.data).toStrictEqual({ update: "initialValue" });
+      expect(state.layout.data).toStrictEqual({ update: "endingValue" });
     });
 
     describe("on type mismatch", () => {


### PR DESCRIPTION
### Description
In case of a conflict at the time of wizard state merge, make new data override the old data.

### Testing Performed
Manual testing (went through some wizard flows and verified that they work)