### PR TITLE
experimentation: Adding `Chaos` in server experimentation UI

### DIFF
--- a/frontend/workflows/serverexperimentation/src/index.tsx
+++ b/frontend/workflows/serverexperimentation/src/index.tsx
@@ -9,7 +9,7 @@ const register = (): WorkflowConfiguration => {
       contactUrl: "mailto:hello@clutch.sh",
     },
     path: "server-experimentation",
-    group: "Experimentation",
+    group: "Chaos Experimentation",
     displayName: "Server Fault Injection",
     routes: {
       startExperiment: {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
To be more explicit and avoid any confusion with the name Experimentation, this PR adds Chaos before Experimentation in Server experiments.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
