### PR TITLE
k8s: add values to ListConfigMaps mock

### DIFF
--- a/backend/mock/service/k8smock/k8smock.go
+++ b/backend/mock/service/k8smock/k8smock.go
@@ -252,6 +252,20 @@ func (s *svc) ListConfigMaps(_ context.Context, clientset, cluster, namespace st
 			Labels:      listOptions.Labels,
 			Annotations: map[string]string{"Key": "value"},
 		},
+		&k8sv1.ConfigMap{
+			Cluster:     "fake-cluster-name",
+			Namespace:   namespace,
+			Name:        "foo-bar",
+			Labels:      listOptions.Labels,
+			Annotations: map[string]string{"Key": "value"},
+		},
+		&k8sv1.ConfigMap{
+			Cluster:     "fake-cluster-name",
+			Namespace:   namespace,
+			Name:        "stuff-things",
+			Labels:      listOptions.Labels,
+			Annotations: map[string]string{"Key": "value"},
+		},
 	}
 	return configMaps, nil
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add some more test values to the k8s mock for listing config maps.  Note this will break clutch-private tests temporarily when it is merged. 
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
tests still pass since this doesn't affect anything.
### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
