### PR TITLE
backend: stop signal captures to topo context on shutdown

### DIFF
--- a/backend/service/topology/topology.go
+++ b/backend/service/topology/topology.go
@@ -106,6 +106,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 		<-sigc
 		c.log.Info("Caught shutdown signal, shutting down topology caching and releasing advisory lock")
 		ctxCancelFunc()
+		signal.Stop(sigc)
 	}()
 
 	c.log.Info("Topology caching is enabled")


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Upon shutdown via one of the captured system calls the topocache would continue to capture signals preventing the main thread from exiting.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
