### PR TITLE
experimentation: display termination reason

### DIFF
--- a/backend/service/chaos/experimentation/experimentstore/experiment_run.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run.go
@@ -106,18 +106,18 @@ func (er *ExperimentRun) CreateProperties(now time.Time) ([]*experimentationv1.P
 				Value: cancellationTimeTimestamp,
 			})
 		}
-
-		terminationReason := "Unknown"
-		if er.TerminationReason != "" {
-			terminationReason = er.TerminationReason
-		}
-
-		properties = append(properties, &experimentationv1.Property{
-			Id:    "termination_reason",
-			Label: "Termination Reason",
-			Value: &experimentationv1.Property_StringValue{StringValue: terminationReason},
-		})
 	}
+
+	terminationReason := "N/A"
+	if er.TerminationReason != "" {
+		terminationReason = er.TerminationReason
+	}
+
+	properties = append(properties, &experimentationv1.Property{
+		Id:    "termination_reason",
+		Label: "Termination Reason",
+		Value: &experimentationv1.Property_StringValue{StringValue: terminationReason},
+	})
 
 	return properties, nil
 }

--- a/backend/service/chaos/experimentation/experimentstore/experiment_run.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run.go
@@ -108,16 +108,18 @@ func (er *ExperimentRun) CreateProperties(now time.Time) ([]*experimentationv1.P
 		}
 	}
 
-	terminationReason := "N/A"
-	if er.TerminationReason != "" {
-		terminationReason = er.TerminationReason
-	}
+	if status == experimentationv1.Experiment_STATUS_CANCELED || status == experimentationv1.Experiment_STATUS_COMPLETED {
+		terminationReason := "N/A"
+		if er.TerminationReason != "" {
+			terminationReason = er.TerminationReason
+		}
 
-	properties = append(properties, &experimentationv1.Property{
-		Id:    "termination_reason",
-		Label: "Termination Reason",
-		Value: &experimentationv1.Property_StringValue{StringValue: terminationReason},
-	})
+		properties = append(properties, &experimentationv1.Property{
+			Id:    "termination_reason",
+			Label: "Termination Reason",
+			Value: &experimentationv1.Property_StringValue{StringValue: terminationReason},
+		})
+	}
 
 	return properties, nil
 }

--- a/backend/service/chaos/experimentation/experimentstore/experiment_run.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run.go
@@ -27,7 +27,7 @@ func (er *ExperimentRun) Status(now time.Time) experimentationv1.Experiment_Stat
 	} else {
 		if now.Before(er.StartTime) {
 			return experimentationv1.Experiment_STATUS_SCHEDULED
-		} else if now.After(er.StartTime) && (er.EndTime == nil || now.Before(*er.EndTime)) {
+		} else if (now.Equal(er.StartTime) || now.After(er.StartTime)) && (er.EndTime == nil || now.Before(*er.EndTime)) {
 			return experimentationv1.Experiment_STATUS_RUNNING
 		}
 		return experimentationv1.Experiment_STATUS_COMPLETED

--- a/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
@@ -122,6 +122,10 @@ func TestExperimentRunProperties(t *testing.T) {
 				"run_creation_time",
 				"start_time",
 				"end_time",
+				"termination_reason",
+			},
+			expectedPropertyValues: map[string]string{
+				"termination_reason": "N/A",
 			},
 		},
 		{
@@ -137,6 +141,10 @@ func TestExperimentRunProperties(t *testing.T) {
 				"run_creation_time",
 				"start_time",
 				"end_time",
+				"termination_reason",
+			},
+			expectedPropertyValues: map[string]string{
+				"termination_reason": "N/A",
 			},
 		},
 		{
@@ -156,7 +164,7 @@ func TestExperimentRunProperties(t *testing.T) {
 				"termination_reason",
 			},
 			expectedPropertyValues: map[string]string{
-				"termination_reason": "Unknown",
+				"termination_reason": "N/A",
 			},
 		},
 		{
@@ -176,7 +184,7 @@ func TestExperimentRunProperties(t *testing.T) {
 				"termination_reason",
 			},
 			expectedPropertyValues: map[string]string{
-				"termination_reason": "Unknown",
+				"termination_reason": "N/A",
 			},
 		},
 		{

--- a/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
@@ -114,7 +114,7 @@ func TestExperimentRunProperties(t *testing.T) {
 			endTime:           &future,
 			cancellationTime:  nil,
 			creationTime:      now,
-			now:               past,
+			now:               now,
 			terminationReason: "foo",
 			expectedPropertyIds: []string{
 				"run_identifier",
@@ -129,7 +129,7 @@ func TestExperimentRunProperties(t *testing.T) {
 			endTime:           nil,
 			cancellationTime:  nil,
 			creationTime:      now,
-			now:               future,
+			now:               now,
 			terminationReason: "",
 			expectedPropertyIds: []string{
 				"run_identifier",

--- a/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
@@ -114,18 +114,14 @@ func TestExperimentRunProperties(t *testing.T) {
 			endTime:           &future,
 			cancellationTime:  nil,
 			creationTime:      now,
-			now:               now,
-			terminationReason: "",
+			now:               past,
+			terminationReason: "foo",
 			expectedPropertyIds: []string{
 				"run_identifier",
 				"status",
 				"run_creation_time",
 				"start_time",
 				"end_time",
-				"termination_reason",
-			},
-			expectedPropertyValues: map[string]string{
-				"termination_reason": "N/A",
 			},
 		},
 		{
@@ -133,7 +129,7 @@ func TestExperimentRunProperties(t *testing.T) {
 			endTime:           nil,
 			cancellationTime:  nil,
 			creationTime:      now,
-			now:               now,
+			now:               past,
 			terminationReason: "",
 			expectedPropertyIds: []string{
 				"run_identifier",
@@ -141,10 +137,6 @@ func TestExperimentRunProperties(t *testing.T) {
 				"run_creation_time",
 				"start_time",
 				"end_time",
-				"termination_reason",
-			},
-			expectedPropertyValues: map[string]string{
-				"termination_reason": "N/A",
 			},
 		},
 		{

--- a/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run_test.go
@@ -129,7 +129,7 @@ func TestExperimentRunProperties(t *testing.T) {
 			endTime:           nil,
 			cancellationTime:  nil,
 			creationTime:      now,
-			now:               past,
+			now:               future,
 			terminationReason: "",
 			expectedPropertyIds: []string{
 				"run_identifier",

--- a/backend/service/chaos/experimentation/experimentstore/experiment_test.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_test.go
@@ -30,6 +30,12 @@ func TestExperimentRunConfigToExperiment(t *testing.T) {
 			expectedStatus: experimentationv1.Experiment_STATUS_RUNNING,
 		},
 		{
+			startTime:      now,
+			endTime:        nil,
+			now:            now,
+			expectedStatus: experimentationv1.Experiment_STATUS_RUNNING,
+		},
+		{
 			startTime:      past,
 			endTime:        &future,
 			now:            now,


### PR DESCRIPTION
### Description

1. Display `termination reason` when an experiment is `canceled` or `completed`. Previously we were displaying the termination reason only for `canceled` experiment but this did not cover the case when an experiment was started without a specified end date and terminated by automated experiment termination later on (in this case, the final status of terminated experiment was `completed`.
2. Fix experiment status computation for corner case when current time equal to start time. Previously experiments like that returned `completed` status, after the changes they return `running` status.


### Testing Performed
Unit tests and manual testing.
