### PR TITLE
frontend: datalayout - add overwrite flag option to hydrate

### DIFF
--- a/frontend/packages/data-layout/src/manager.tsx
+++ b/frontend/packages/data-layout/src/manager.tsx
@@ -31,7 +31,7 @@ const update = (key: string, value: object): Thunk<ManagerLayout, Action> => {
   };
 };
 
-const hydrate = (key: string): Thunk<ManagerLayout, Action> => {
+const hydrate = (key: string, overwrite: boolean = false): Thunk<ManagerLayout, Action> => {
   return (dispatch, getState) => {
     const state = getState();
     if (Object.keys(state[key]).includes("hydrator")) {
@@ -66,6 +66,7 @@ const hydrate = (key: string): Thunk<ManagerLayout, Action> => {
             payload: {
               key,
               result: state[key].transformResponse(result),
+              overwrite: overwrite,
             },
           });
         })
@@ -85,7 +86,7 @@ const hydrate = (key: string): Thunk<ManagerLayout, Action> => {
 export interface DataManager {
   state: object;
   assign: (key: string, value: object) => void;
-  hydrate: (key: string) => void;
+  hydrate: (key: string, overwrite?: boolean) => void;
   update: (key: string, value: object) => void;
   reset: () => void;
 }

--- a/frontend/packages/data-layout/src/state.tsx
+++ b/frontend/packages/data-layout/src/state.tsx
@@ -29,6 +29,7 @@ interface ActionPayload {
   value?: object;
   result?: object;
   error?: ClutchError;
+  overwrite?: boolean;
 }
 
 export interface Action {
@@ -52,7 +53,7 @@ const reducer = (state: ManagerLayout, action: Action): ManagerLayout => {
       const newDataIsArray = Array.isArray(newData);
       const existingDataIsArray = Array.isArray(existingData);
       let data: object;
-      if ((newDataIsArray && !existingDataIsArray) || (!newDataIsArray && existingDataIsArray)) {
+      if (((newDataIsArray && !existingDataIsArray) || (!newDataIsArray && existingDataIsArray)) || action.payload?.overwrite) {
         data = newData;
       } else if (newDataIsArray) {
         data = [...existingData, ...newData];


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It might be useful to be able to force an overwrite of data when hydrating.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
still need to add tests to state.test.tsx etc

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
