### PR TITLE
data-layout: add flag to enable or disable hydration on useDataLayout()

### DIFF
--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -32,8 +32,8 @@ interface DataLayout {
  * Use a registered data layout.
  * 
  * If a hydrate function has been specified this and the layout's data has not been set and shouldHydrate is true this will 
- * populate it's data on the first invocation. If the layout has a cache key set to true and also has existing data 
- * hydrate will not be invoked.
+ * populate it's data on the first invocation. If the layout has a cache key set to true and also has existing data OR
+ * shouldHydrate is false, hydrate will not be invoked.
 
  * @param key The name of the layout registered with the manager.
  */

--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -24,22 +24,21 @@ interface DataLayout {
   displayValue: () => any;
   /** Loading state of the layout. This is true when data is being hydrated. */
   isLoading: boolean;
-  /** Error state of the layout. This will be a message containing the error encountered when trying to hydrate the lyaout. */
+  /** Error state of the layout. This will be a message containing the error encountered when trying to hydrate the layout. */
   error: ClutchError;
 }
 
 /**
  * Use a registered data layout.
  * 
- * If a hydrate function has been specified this and the layout's data has not been set this will populate it's data
- * on the first invocation. If the layout has a cache key set to true and also has existing data hydrate will not be invoked.
+ * If a hydrate function has been specified this and the layout's data has not been set and shouldHydrate is true this will 
+ * populate it's data on the first invocation. If the layout has a cache key set to true and also has existing data 
+ * hydrate will not be invoked.
 
  * @param key The name of the layout registered with the manager.
  */
-const useDataLayout = (key: string): DataLayout => {
+const useDataLayout = (key: string, shouldHydrate: boolean = true): DataLayout => {
   const manager = useManagerContext();
-
-  const options = { hydrate: true };
 
   if (!Object.keys(manager.state).includes(key)) {
     throw new Error(`Non-existant data layout key: ${key}`);
@@ -53,7 +52,7 @@ const useDataLayout = (key: string): DataLayout => {
 
   React.useEffect(() => {
     if (
-      options.hydrate !== undefined &&
+      shouldHydrate &&
       !(manager.state[key].cache && !_.isEmpty(manager.state[key].data))
     ) {
       manager.hydrate(key);

--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -51,10 +51,7 @@ const useDataLayout = (key: string, shouldHydrate: boolean = true): DataLayout =
   }, []);
 
   React.useEffect(() => {
-    if (
-      shouldHydrate &&
-      !(manager.state[key].cache && !_.isEmpty(manager.state[key].data))
-    ) {
+    if (shouldHydrate && !(manager.state[key].cache && !_.isEmpty(manager.state[key].data))) {
       manager.hydrate(key);
     }
   }, [key]);

--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -31,15 +31,16 @@ interface DataLayout {
 /**
  * Use a registered data layout.
  * 
- * If a hydrate function has been specified this and the layout's data has not been set and shouldHydrate is true this will 
+ * If a hydrate function has been specified this and the layout's data has not been set and hydrate is true this will 
  * populate it's data on the first invocation. If the layout has a cache key set to true and also has existing data OR
- * shouldHydrate is false, hydrate will not be invoked.
+ * hydrate is false, hydrate will not be invoked.
 
  * @param key The name of the layout registered with the manager.
- * @param shouldHydrate An option to not hydrate if we don't want to.
+ * @param opts An options object to allow for things like disabling hydration by default
  */
-const useDataLayout = (key: string, shouldHydrate: boolean = true): DataLayout => {
+const useDataLayout = (key: string, opts?: object): DataLayout => {
   const manager = useManagerContext();
+  const options = { hydrate: true, ...opts };
 
   if (!Object.keys(manager.state).includes(key)) {
     throw new Error(`Non-existant data layout key: ${key}`);
@@ -52,7 +53,7 @@ const useDataLayout = (key: string, shouldHydrate: boolean = true): DataLayout =
   }, []);
 
   React.useEffect(() => {
-    if (shouldHydrate && !(manager.state[key].cache && !_.isEmpty(manager.state[key].data))) {
+    if (options.hydrate && !(manager.state[key].cache && !_.isEmpty(manager.state[key].data))) {
       manager.hydrate(key);
     }
   }, [key]);

--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -36,6 +36,7 @@ interface DataLayout {
  * shouldHydrate is false, hydrate will not be invoked.
 
  * @param key The name of the layout registered with the manager.
+ * @param shouldHydrate An option to not hydrate if we don't want to.
  */
 const useDataLayout = (key: string, shouldHydrate: boolean = true): DataLayout => {
   const manager = useManagerContext();

--- a/frontend/packages/data-layout/src/layout.tsx
+++ b/frontend/packages/data-layout/src/layout.tsx
@@ -28,6 +28,10 @@ interface DataLayout {
   error: ClutchError;
 }
 
+interface UseDataLayoutOptions {
+  hydrate?: boolean;
+}
+
 /**
  * Use a registered data layout.
  * 
@@ -38,7 +42,7 @@ interface DataLayout {
  * @param key The name of the layout registered with the manager.
  * @param opts An options object to allow for things like disabling hydration by default
  */
-const useDataLayout = (key: string, opts?: object): DataLayout => {
+const useDataLayout = (key: string, opts?: UseDataLayoutOptions): DataLayout => {
   const manager = useManagerContext();
   const options = { hydrate: true, ...opts };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It is useful to be able to not hydrate by default when calling useDataLayout(k).  
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Tested for my use case and it works.  This is important if we have tables where we want to switch views on data and don't want to call hydrate everytime we switch tabs.

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
