### PR TITLE
data-layout: hydrateAll()

### DIFF
--- a/frontend/packages/data-layout/src/manager.tsx
+++ b/frontend/packages/data-layout/src/manager.tsx
@@ -82,12 +82,21 @@ const hydrate = (key: string): Thunk<ManagerLayout, Action> => {
   };
 };
 
+const hydrateAll = () => {
+  return getState => {
+    const state = getState();
+    Object.keys(state).forEach(key => {
+      hydrate(key);
+    });
+  };
+};
 export interface DataManager {
   state: object;
   assign: (key: string, value: object) => void;
   hydrate: (key: string) => void;
   update: (key: string, value: object) => void;
   reset: () => void;
+  hydrateAll: () => void;
 }
 
 const defaultTransform = (data: object): object => data;
@@ -124,6 +133,7 @@ const useDataLayoutManager = (layouts: ManagerLayout): DataManager => {
     hydrate: key => dispatch(hydrate(key)),
     update: (key, value) => dispatch(update(key, value)),
     reset: () => dispatch(reset()),
+    hydrateAll: () => dispatch(hydrateAll()),
   };
 };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add a hydrateAll() func to the manager that allows one to hydrate on all the keys, rather than having to call hydrate() on each individual one

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
still testing
### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
