### PR TITLE
ci: make resilience owners of redisexperimentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,4 @@
 /backend/**/chaos/                                   @lyft/resilience
 /backend/cmd/migrate/migrations/*_experimentation_*  @lyft/resilience
 /frontend/api/src/                                   @lyft/resilience
-/frontend/workflows/experimentation/                 @lyft/resilience
-/frontend/workflows/serverexperimentation/           @lyft/resilience
+/frontend/workflows/*experimentation/                @lyft/resilience


### PR DESCRIPTION
### Description
New rule should ensure that Resilience is the owner of `redisexperimentation` frontend module/package that's being added to Clutch here https://github.com/lyft/clutch/pull/1427.

### Testing Performed
N/A

