### PR TITLE
tools: add vscode settings for proto paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "protoc": {
       "options": [
-          "--proto_path=api" // support proto imports when opening vscode from the root or using workspaces
+          "--proto_path=api"
       ]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "protoc": {
+      "options": [
+          "--proto_path=api" // support proto imports when opening vscode from the root or using workspaces
+      ]
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,11 @@
 {
   "protoc": {
-      "options": [
-          "--proto_path=api"
-      ]
+    "path": "${workspaceRoot}/build/bin/protoc-v3.14.0",
+    "options": [
+      "--proto_path=build/bin/protoc-v3.14.0-include",
+      "--proto_path=api",
+      "--proto_path=build/bin/googleapis-d4cd8d96ed6eb5dd7c997aab68a1d6bb0825090c",
+      "--proto_path=${env.GOPATH}/pkg/mod/github.com/envoyproxy/protoc-gen-validate@v0.6.1"
+    ]
   }
 }

--- a/api/.vscode/settings.json
+++ b/api/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "protoc": {
+    "path": "../build/bin/protoc-v3.14.0",
+    "options": [
+      "--proto_path=../build/bin/protoc-v3.14.0-include",
+      "--proto_path=.",
+      "--proto_path=../build/bin/googleapis-d4cd8d96ed6eb5dd7c997aab68a1d6bb0825090c",
+      "--proto_path=${env.GOPATH}/pkg/mod/github.com/envoyproxy/protoc-gen-validate@v0.6.1"
+    ]
+  }
+}

--- a/tools/compile-protos.sh
+++ b/tools/compile-protos.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+########
+# Note: When updating any of these versions be sure to also
+# update the corresponding version in .vscode/settings.json
+# and api/.vscode/settings.json
+########
+
 # https://github.com/protocolbuffers/protobuf/releases
 PROTOC_RELEASE=3.14.0
 PROTO_ZIP_RELEASE_MD5_LINUX=cef4dc2f438e44e5d1af64ba4f9dbaa6


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
This allows proto paths to resolve correctly when opening code from the root directory or via workspaces

Note these paths must be at the root of the project for those who open vscode at the root and within the workspace for those who use vscode workspaces.

### Testing Performed
manual