### PR TITLE
frontend: allow for configurable popper id

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -118,7 +118,7 @@ const Group = ({ heading, open = false, updateOpenGroup, closeGroup, children }:
       >
         <Avatar>{heading.charAt(0)}</Avatar>
         <GroupHeading align="center">{heading}</GroupHeading>
-        <Popper open={open} onClickAway={closeGroup} anchorRef={anchorRef}>
+        <Popper open={open} onClickAway={closeGroup} anchorRef={anchorRef} id="workflow-options">
           {children}
         </Popper>
       </GroupListItem>

--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -91,6 +91,7 @@ export interface PopperProps
   open: boolean;
   anchorRef: React.MutableRefObject<HTMLElement>;
   children?: React.ReactElement<PopperItemProps> | React.ReactElement<PopperItemProps>[];
+  id?: string;
 }
 const Popper = ({
   open,
@@ -98,18 +99,19 @@ const Popper = ({
   onClickAway,
   placement = "right-start",
   children,
+  id,
 }: PopperProps) => (
-  <Collapse in={open} timeout="auto" unmountOnExit>
-    <StyledPopper open={open} anchorEl={anchorRef.current} transition placement={placement}>
-      <Paper>
-        <ClickAwayListener onClickAway={onClickAway}>
-          <List component="div" disablePadding id="workflow-options">
-            {children}
-          </List>
-        </ClickAwayListener>
-      </Paper>
-    </StyledPopper>
-  </Collapse>
+  // <Collapse in={open} timeout="auto" unmountOnExit>
+  <StyledPopper open={open} anchorEl={anchorRef.current} transition placement={placement}>
+    <Paper>
+      <ClickAwayListener onClickAway={onClickAway}>
+        <List component="div" disablePadding id={id}>
+          {children}
+        </List>
+      </ClickAwayListener>
+    </Paper>
+  </StyledPopper>
+  // </Collapse>
 );
 
 export { Popper, PopperItem };

--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -101,17 +101,17 @@ const Popper = ({
   children,
   id,
 }: PopperProps) => (
-  // <Collapse in={open} timeout="auto" unmountOnExit>
-  <StyledPopper open={open} anchorEl={anchorRef.current} transition placement={placement}>
-    <Paper>
-      <ClickAwayListener onClickAway={onClickAway}>
-        <List component="div" disablePadding id={id}>
-          {children}
-        </List>
-      </ClickAwayListener>
-    </Paper>
-  </StyledPopper>
-  // </Collapse>
+  <Collapse in={open} timeout="auto" unmountOnExit>
+    <StyledPopper open={open} anchorEl={anchorRef.current} transition placement={placement}>
+      <Paper>
+        <ClickAwayListener onClickAway={onClickAway}>
+          <List component="div" disablePadding id={id}>
+            {children}
+          </List>
+        </ClickAwayListener>
+      </Paper>
+    </StyledPopper>
+  </Collapse>
 );
 
 export { Popper, PopperItem };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Move hard-coded ID out of popper and allow it to be passed in as a prop

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual