### PR TITLE
resolver: add project to core resolver

### DIFF
--- a/backend/resolver/core/core.go
+++ b/backend/resolver/core/core.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	envoyv1 "github.com/lyft/clutch/backend/api/core/envoy/v1"
+	projectv1 "github.com/lyft/clutch/backend/api/core/project/v1"
 	resolverv1 "github.com/lyft/clutch/backend/api/resolver/v1"
 	"github.com/lyft/clutch/backend/gateway/meta"
 	"github.com/lyft/clutch/backend/resolver"
@@ -22,9 +23,11 @@ import (
 var Name = "clutch.resolver.core"
 
 var typeURLEnvoyCluster = meta.TypeURL((*envoyv1.Cluster)(nil))
+var typeURLProject = meta.TypeURL((*projectv1.Project)(nil))
 
 var typeSchemas = resolver.TypeURLToSchemaMessagesMap{
 	typeURLEnvoyCluster: {},
+	typeURLProject:      {},
 }
 
 func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (resolver.Resolver, error) {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Adding `Project` to the core resolver, currently this enables autocomplete for this resource.

### Testing Performed
Locally.

```
curl --location --request POST 'http://localhost:8080/v1/resolver/autocomplete' \
--header 'Content-Type: application/json' \
--data-raw '{
  "want": "type.googleapis.com/clutch.core.project.v1.Project",
  "search": "clutch"
}'

{"results":[{"id":"clutch","label":""}]}
```
