### PR TITLE
k8s: add deployments table to Kubernetes dashboard

### DIFF
--- a/frontend/workflows/k8s/src/deployments-table.tsx
+++ b/frontend/workflows/k8s/src/deployments-table.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { Table, TableRow } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
@@ -11,15 +10,9 @@ const DeploymentsContainer = styled.div({
   maxHeight: "50vh",
 });
 
-const getReadyCountString = containers => {
-  const readyCount = containers.filter(cont => cont.ready).length;
-  return `${readyCount.toString()}/${containers?.length?.toString()}`;
-};
-
 const DeploymentTable = () => {
   const deploymentListData = useDataLayout("deploymentListData", { hydrate: false });
   const deployments = deploymentListData.displayValue()?.deployments as IClutch.k8s.v1.Deployment[];
-  const navigate = useNavigate();
 
   return (
     <DeploymentsContainer>

--- a/frontend/workflows/k8s/src/deployments-table.tsx
+++ b/frontend/workflows/k8s/src/deployments-table.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { Table, TableRow } from "@clutch-sh/core";
+import { useDataLayout } from "@clutch-sh/data-layout";
+import styled from "@emotion/styled";
+import _ from "lodash";
+
+const DeploymentsContainer = styled.div({
+  display: "flex",
+  maxHeight: "50vh",
+});
+
+const getReadyCountString = containers => {
+  const readyCount = containers.filter(cont => cont.ready).length;
+  return `${readyCount.toString()}/${containers?.length?.toString()}`;
+};
+
+const DeploymentTable = () => {
+  const deploymentListData = useDataLayout("deploymentListData", { hydrate: false });
+  const deployments = deploymentListData.displayValue()?.deployments as IClutch.k8s.v1.Deployment[];
+  const navigate = useNavigate();
+
+  return (
+    <DeploymentsContainer>
+      <Table
+        stickyHeader
+        actionsColumn
+        headings={[
+          "Name",
+          "Cluster",
+          "Replicas Ready",
+          "Replicas Available",
+          "Replicas Up-To-Date",
+        ]}
+      >
+        {_.sortBy(deployments, [
+          o => {
+            return o.name;
+          },
+        ]).map(deployment => (
+          <TableRow key={deployment.name} defaultCellValue="nil">
+            {deployment.name}
+            {deployment.cluster}
+            {deployment.deploymentStatus?.readyReplicas}
+            {deployment.deploymentStatus?.availableReplicas}
+            {deployment.deploymentStatus?.updatedReplicas}
+          </TableRow>
+        ))}
+      </Table>
+    </DeploymentsContainer>
+  );
+};
+
+export default DeploymentTable;

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -7,10 +7,10 @@ import AppsIcon from "@material-ui/icons/Apps";
 import CropFreeIcon from "@material-ui/icons/CropFree";
 
 import type { WorkflowProps } from ".";
+import DeploymentTable from "./deployments-table";
 import K8sDashHeader from "./k8s-dash-header";
 import K8sDashSearch from "./k8s-dash-search";
 import PodTable from "./pods-table";
-import DeploymentTable from "./deployments-table";
 
 const Container = styled.div({
   flex: 1,
@@ -108,7 +108,7 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
             });
           });
       },
-	},
+    },
   };
   const dataLayoutManager = useDataLayoutManager(dataLayout);
 
@@ -138,7 +138,7 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
                 <Tab startAdornment={<AppsIcon />} label="Pods">
                   <PodTable />
                 </Tab>
-				<Tab startAdornment={<CropFreeIcon />} label="Deployments">
+                <Tab startAdornment={<CropFreeIcon />} label="Deployments">
                   <DeploymentTable />
                 </Tab>
               </Tabs>

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -4,11 +4,13 @@ import { client, ClutchError, Error, Paper, Tab, Tabs } from "@clutch-sh/core";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
 import AppsIcon from "@material-ui/icons/Apps";
+import CropFreeIcon from "@material-ui/icons/CropFree";
 
 import type { WorkflowProps } from ".";
 import K8sDashHeader from "./k8s-dash-header";
 import K8sDashSearch from "./k8s-dash-search";
 import PodTable from "./pods-table";
+import DeploymentTable from "./deployments-table";
 
 const Container = styled.div({
   flex: 1,
@@ -84,12 +86,36 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
           });
       },
     },
+    deploymentListData: {
+      deps: ["inputData"],
+      hydrator: inputData => {
+        return client
+          .post("/v1/k8s/listDeployments", {
+            ...defaultRequestData(inputData),
+            options: {
+              labels: {},
+            },
+          } as IClutch.k8s.v1.IListDeploymentsRequest)
+          .then(response => {
+            return response?.data;
+          })
+          .catch((err: ClutchError) => {
+            setError(existingError => {
+              if (existingError === undefined) {
+                return err;
+              }
+              return existingError;
+            });
+          });
+      },
+	},
   };
   const dataLayoutManager = useDataLayoutManager(dataLayout);
 
   const handleSubmit = (namespace, clientset) => {
     dataLayoutManager.assign("inputData", { namespace, clientset });
     dataLayoutManager.hydrate("podListData");
+    dataLayoutManager.hydrate("deploymentListData");
     setError(undefined);
   };
 
@@ -111,6 +137,9 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
               <Tabs variant="fullWidth">
                 <Tab startAdornment={<AppsIcon />} label="Pods">
                   <PodTable />
+                </Tab>
+				<Tab startAdornment={<CropFreeIcon />} label="Deployments">
+                  <DeploymentTable />
                 </Tab>
               </Tabs>
             </Paper>


### PR DESCRIPTION
### Description
This PR adds a new Deployments table to the Kubernetes Dashboard which displays a list of deployments and its meta data. The data displayed per deployment maps to the output of `kubectl get deployment`

### Testing Performed
local
![ezgif com-gif-maker (49)](https://user-images.githubusercontent.com/3858939/119531417-bd7f8000-bd38-11eb-8386-cbf6e3f2736c.gif)


### TODOs
- Add ability to delete deployments in deployment table
- Add age field to the deployment table