### PR TITLE
frontend: add age column to deployments table

### DIFF
--- a/frontend/workflows/k8s/src/deployments-table.tsx
+++ b/frontend/workflows/k8s/src/deployments-table.tsx
@@ -3,7 +3,9 @@ import type { clutch as IClutch } from "@clutch-sh/api";
 import { Table, TableRow } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
+import TimeAgo from "react-timeago";
 import _ from "lodash";
+import { convertTime, timeFormatter } from "./pods-table"
 
 const DeploymentsContainer = styled.div({
   display: "flex",
@@ -25,6 +27,7 @@ const DeploymentTable = () => {
           "Replicas Ready",
           "Replicas Available",
           "Replicas Up-To-Date",
+		  "Age",
         ]}
       >
         {_.sortBy(deployments, [
@@ -38,6 +41,7 @@ const DeploymentTable = () => {
             {deployment.deploymentStatus?.readyReplicas}
             {deployment.deploymentStatus?.availableReplicas}
             {deployment.deploymentStatus?.updatedReplicas}
+			<TimeAgo date={convertTime(deployment.creationTimeMillis)} formatter={timeFormatter} />
           </TableRow>
         ))}
       </Table>

--- a/frontend/workflows/k8s/src/deployments-table.tsx
+++ b/frontend/workflows/k8s/src/deployments-table.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import TimeAgo from "react-timeago";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { Table, TableRow } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
-import TimeAgo from "react-timeago";
 import _ from "lodash";
-import { convertTime, timeFormatter } from "./pods-table"
+
+import { convertTime, timeFormatter } from "./pods-table";
 
 const DeploymentsContainer = styled.div({
   display: "flex",
@@ -27,7 +28,7 @@ const DeploymentTable = () => {
           "Replicas Ready",
           "Replicas Available",
           "Replicas Up-To-Date",
-		  "Age",
+          "Age",
         ]}
       >
         {_.sortBy(deployments, [
@@ -41,7 +42,7 @@ const DeploymentTable = () => {
             {deployment.deploymentStatus?.readyReplicas}
             {deployment.deploymentStatus?.availableReplicas}
             {deployment.deploymentStatus?.updatedReplicas}
-			<TimeAgo date={convertTime(deployment.creationTimeMillis)} formatter={timeFormatter} />
+            <TimeAgo date={convertTime(deployment.creationTimeMillis)} formatter={timeFormatter} />
           </TableRow>
         ))}
       </Table>

--- a/frontend/workflows/k8s/src/pods-table.tsx
+++ b/frontend/workflows/k8s/src/pods-table.tsx
@@ -106,4 +106,4 @@ const PodTable = () => {
   );
 };
 
-export default PodTable;
+export { PodTable as default, timeFormatter, convertTime };


### PR DESCRIPTION
### Description
This PR adds an AGE column to the deployments table which displays the amount of time that the application has been running.

### Testing Performed
local:
<img width="1569" alt="Screen Shot 2021-06-02 at 11 51 57 AM" src="https://user-images.githubusercontent.com/3858939/120536655-34e88b80-c399-11eb-93a7-804c1d12b9e4.png">
