### PR TITLE
frontend: add cronjob table to kubernetes dashboard

### DIFF
--- a/frontend/workflows/k8s/src/crons-table.tsx
+++ b/frontend/workflows/k8s/src/crons-table.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { Table, TableRow } from "@clutch-sh/core";
+import { useDataLayout } from "@clutch-sh/data-layout";
+import styled from "@emotion/styled";
+import _ from "lodash";
+
+const CronsContainer = styled.div({
+  display: "flex",
+  maxHeight: "50vh",
+});
+
+const CronTable = () => {
+  const cronListData = useDataLayout("cronListData", { hydrate: false });
+  const crons = cronListData.displayValue()?.cronJobs as IClutch.k8s.v1.CronJob[];
+
+  return (
+    <CronsContainer>
+      <Table
+        stickyHeader
+        actionsColumn
+        headings={["Name", "Cluster", "Schedule", "Suspend", "Active Jobs", "Concurrency Policy"]}
+      >
+        {_.sortBy(crons, [
+          o => {
+            return o.name;
+          },
+        ]).map(cron => (
+          <TableRow key={cron.name} defaultCellValue="nil">
+            {cron.name}
+            {cron.cluster}
+            {cron.schedule}
+            {cron.suspend}
+            {cron.numActiveJobs}
+            {cron.concurrencyPolicy}
+          </TableRow>
+        ))}
+      </Table>
+    </CronsContainer>
+  );
+};
+
+export default CronTable;

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -5,8 +5,10 @@ import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout"
 import styled from "@emotion/styled";
 import AppsIcon from "@material-ui/icons/Apps";
 import CropFreeIcon from "@material-ui/icons/CropFree";
+import LoopOutlinedIcon from "@material-ui/icons/LoopOutlined";
 
 import type { WorkflowProps } from ".";
+import CronTable from "./crons-table";
 import DeploymentTable from "./deployments-table";
 import K8sDashHeader from "./k8s-dash-header";
 import K8sDashSearch from "./k8s-dash-search";
@@ -109,6 +111,29 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
           });
       },
     },
+    cronListData: {
+      deps: ["inputData"],
+      hydrator: inputData => {
+        return client
+          .post("/v1/k8s/listCronJobs", {
+            ...defaultRequestData(inputData),
+            options: {
+              labels: {},
+            },
+          } as IClutch.k8s.v1.IListCronJobsRequest)
+          .then(response => {
+            return response?.data;
+          })
+          .catch((err: ClutchError) => {
+            setError(existingError => {
+              if (existingError === undefined) {
+                return err;
+              }
+              return existingError;
+            });
+          });
+      },
+    },
   };
   const dataLayoutManager = useDataLayoutManager(dataLayout);
 
@@ -116,6 +141,7 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
     dataLayoutManager.assign("inputData", { namespace, clientset });
     dataLayoutManager.hydrate("podListData");
     dataLayoutManager.hydrate("deploymentListData");
+    dataLayoutManager.hydrate("cronListData");
     setError(undefined);
   };
 
@@ -140,6 +166,9 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
                 </Tab>
                 <Tab startAdornment={<CropFreeIcon />} label="Deployments">
                   <DeploymentTable />
+                </Tab>
+                <Tab startAdornment={<LoopOutlinedIcon />} label="Cron Jobs">
+                  <CronTable />
                 </Tab>
               </Tabs>
             </Paper>


### PR DESCRIPTION
### Description
This PR adds a cronjob overview table to the kubernetes dashboard where users can view a list of cronjobs running per namespace along with some metadata.

### Testing Performed
Local:
<img width="1569" alt="Screen Shot 2021-06-02 at 2 20 28 PM" src="https://user-images.githubusercontent.com/3858939/120554047-20fb5480-c3ae-11eb-8999-2484df56121f.png">
