### PR TITLE
frontend: add stateful set table to kubernetes dashboard

### DIFF
--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -5,6 +5,7 @@ import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout"
 import styled from "@emotion/styled";
 import AppsIcon from "@material-ui/icons/Apps";
 import CropFreeIcon from "@material-ui/icons/CropFree";
+import DnsOutlinedIcon from "@material-ui/icons/DnsOutlined";
 import LoopOutlinedIcon from "@material-ui/icons/LoopOutlined";
 
 import type { WorkflowProps } from ".";
@@ -13,6 +14,7 @@ import DeploymentTable from "./deployments-table";
 import K8sDashHeader from "./k8s-dash-header";
 import K8sDashSearch from "./k8s-dash-search";
 import PodTable from "./pods-table";
+import StatefulSetTable from "./stateful-sets-table";
 
 const Container = styled.div({
   flex: 1,
@@ -134,6 +136,29 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
           });
       },
     },
+    statefulSetListData: {
+      deps: ["inputData"],
+      hydrator: inputData => {
+        return client
+          .post("/v1/k8s/listStatefulSets", {
+            ...defaultRequestData(inputData),
+            options: {
+              labels: {},
+            },
+          } as IClutch.k8s.v1.IListStatefulSetsRequest)
+          .then(response => {
+            return response?.data;
+          })
+          .catch((err: ClutchError) => {
+            setError(existingError => {
+              if (existingError === undefined) {
+                return err;
+              }
+              return existingError;
+            });
+          });
+      },
+    },
   };
   const dataLayoutManager = useDataLayoutManager(dataLayout);
 
@@ -142,6 +167,7 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
     dataLayoutManager.hydrate("podListData");
     dataLayoutManager.hydrate("deploymentListData");
     dataLayoutManager.hydrate("cronListData");
+    dataLayoutManager.hydrate("statefulSetListData");
     setError(undefined);
   };
 
@@ -169,6 +195,9 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
                 </Tab>
                 <Tab startAdornment={<LoopOutlinedIcon />} label="Cron Jobs">
                   <CronTable />
+                </Tab>
+                <Tab startAdornment={<DnsOutlinedIcon />} label="Stateful Sets">
+                  <StatefulSetTable />
                 </Tab>
               </Tabs>
             </Paper>

--- a/frontend/workflows/k8s/src/stateful-sets-table.tsx
+++ b/frontend/workflows/k8s/src/stateful-sets-table.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { Table, TableRow } from "@clutch-sh/core";
+import { useDataLayout } from "@clutch-sh/data-layout";
+import styled from "@emotion/styled";
+import _ from "lodash";
+
+const StatefulSetsContainer = styled.div({
+  display: "flex",
+  maxHeight: "50vh",
+});
+
+const StatefulSetTable = () => {
+  const statefulSetListData = useDataLayout("statefulSetListData", { hydrate: false });
+  const statefulSets = statefulSetListData.displayValue()
+    ?.statefulSets as IClutch.k8s.v1.StatefulSet[];
+
+  return (
+    <StatefulSetsContainer>
+      <Table stickyHeader actionsColumn headings={["Name", "Cluster"]}>
+        {_.sortBy(statefulSets, [
+          o => {
+            return o.name;
+          },
+        ]).map(statefulSet => (
+          <TableRow key={statefulSet.name} defaultCellValue="nil">
+            {statefulSet.name}
+            {statefulSet.cluster}
+          </TableRow>
+        ))}
+      </Table>
+    </StatefulSetsContainer>
+  );
+};
+
+export default StatefulSetTable;


### PR DESCRIPTION
### Description
This PR adds a stateful sets table to the Kubernetes dashboard which lists the stateful sets in a given namespace

### Testing Performed
local
<img width="1569" alt="Screen Shot 2021-06-03 at 9 32 43 PM" src="https://user-images.githubusercontent.com/3858939/120746391-f0054780-c4b3-11eb-8942-e8998dc39fa5.png">


### TODOs
- Add current replicas, desired replicas, age, etc as columns in this table
