### PR TITLE
datalayout: avoid shared ref to data object in initial state

### DIFF
--- a/frontend/packages/data-layout/.eslintrc.js
+++ b/frontend/packages/data-layout/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
         "import/no-extraneous-dependencies": [
           "error",
           {
-            devDependencies: ["*.config.js"],
+            devDependencies: ["*.config.js", "**/*.test.tsx"],
             packageDir: [__dirname, path.join(__dirname, "../tools")],
           },
         ],

--- a/frontend/packages/data-layout/package.json
+++ b/frontend/packages/data-layout/package.json
@@ -32,7 +32,8 @@
     "react-hook-thunk-reducer": "^0.2.1"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^1.0.0-beta"
+    "@clutch-sh/tools": "^1.0.0-beta",
+    "react-test-renderer": "^17.0.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/frontend/packages/data-layout/src/manager.tsx
+++ b/frontend/packages/data-layout/src/manager.tsx
@@ -99,7 +99,7 @@ const defaultState = (layouts: ManagerLayout) => {
   const initializedLayouts = {};
   Object.keys(layouts).forEach(key => {
     const layout = layouts[key];
-    initializedLayouts[key] = initialLayoutStepState;
+    initializedLayouts[key] = _.cloneDeep(initialLayoutStepState);
     if (layout?.hydrator !== undefined) {
       initializedLayouts[key] = {
         ...initializedLayouts[key],

--- a/frontend/packages/data-layout/src/manager.tsx
+++ b/frontend/packages/data-layout/src/manager.tsx
@@ -93,13 +93,13 @@ export interface DataManager {
 const defaultTransform = (data: object): object => data;
 const defaultErrorTransform = (err: any): ClutchError => err;
 
-const initialLayoutStepState = { data: {}, isLoading: true, error: null };
+const initialLayoutStepState = () => ({ data: {}, isLoading: true, error: null });
 
 const defaultState = (layouts: ManagerLayout) => {
   const initializedLayouts = {};
   Object.keys(layouts).forEach(key => {
     const layout = layouts[key];
-    initializedLayouts[key] = _.cloneDeep(initialLayoutStepState);
+    initializedLayouts[key] = initialLayoutStepState();
     if (layout?.hydrator !== undefined) {
       initializedLayouts[key] = {
         ...initializedLayouts[key],

--- a/frontend/packages/data-layout/src/tests/manager.test.tsx
+++ b/frontend/packages/data-layout/src/tests/manager.test.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import renderer from "react-test-renderer";
+
+import useDataLayoutManager from "../manager";
+
+describe("Manager Default State", () => {
+  it("does not share an initial state reference", () => {
+    let manager;
+
+    const TestComponent = () => {
+      manager = useDataLayoutManager({
+        a: {},
+        b: {},
+      });
+
+      return null;
+    };
+
+    renderer.create(<TestComponent />);
+
+    manager.state.a.data = { foo: "bar" };
+    expect(manager.state.b.data).toEqual({});
+  });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -17584,7 +17584,7 @@ react-syntax-highlighter@^13.5.0, react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@^17.0.0:
+react-test-renderer@^17.0.0, react-test-renderer@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
   integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Changes the initial state dict to come from a function so each key's initial state cannot end up sharing the same reference to another key's initial state.

### Testing Performed
Manual & unit test.

### TODO
- [x] Unit test.