### PR TITLE
frontend: set lower bound on select default index

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -201,9 +201,7 @@ const Select = ({
   options,
   onChange,
 }: SelectProps) => {
-  const [defaultIdx] = React.useState(
-    defaultOption < options.length && defaultOption > 0 ? defaultOption : 0
-  );
+  const defaultIdx = defaultOption < options.length && defaultOption > 0 ? defaultOption : 0;
   const [selectedIdx, setSelectedIdx] = React.useState(defaultIdx);
 
   React.useEffect(() => {

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -201,12 +201,16 @@ const Select = ({
   options,
   onChange,
 }: SelectProps) => {
-  if (options?.length === undefined || options?.length === 0) {
-    return null;
-  }
-
-  const defaultIdx = defaultOption < options.length ? defaultOption : 0;
+  const [defaultIdx] = React.useState(
+    defaultOption < options.length && defaultOption > 0 ? defaultOption : 0
+  );
   const [selectedIdx, setSelectedIdx] = React.useState(defaultIdx);
+
+  React.useEffect(() => {
+    if (options.length !== 0) {
+      onChange && onChange(options[selectedIdx]?.value || options[selectedIdx].label);
+    }
+  }, []);
 
   const updateSelectedOption = (event: React.ChangeEvent<{ name?: string; value: string }>) => {
     const { value } = event.target;
@@ -215,9 +219,9 @@ const Select = ({
     onChange && onChange(value);
   };
 
-  React.useEffect(() => {
-    onChange && onChange(options[selectedIdx]?.value || options[selectedIdx].label);
-  }, []);
+  if (options.length === 0) {
+    return null;
+  }
 
   return (
     <StyledFormControl key={name} fullWidth disabled={disabled} error={error}>

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -224,9 +224,10 @@ const Select = ({
   }
 
   return (
-    <StyledFormControl key={name} fullWidth disabled={disabled} error={error}>
+    <StyledFormControl id={name} key={name} fullWidth disabled={disabled} error={error}>
       {label && <StyledInputLabel>{label}</StyledInputLabel>}
       <StyledSelect
+        id={`${name}-select`}
         value={options[selectedIdx]?.value || options[selectedIdx].label}
         onChange={updateSelectedOption}
       >

--- a/frontend/packages/core/src/Input/tests/select.test.tsx
+++ b/frontend/packages/core/src/Input/tests/select.test.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import Select from "../select";
+
+describe("Select", () => {
+  describe("default option", () => {
+    it("has lower bound", () => {
+      const component = shallow(
+        <Select name="foobar" defaultOption={-1} options={[{ label: "foo" }, { label: "bar" }]} />
+      );
+      expect(component.find("#foobar")).toHaveLength(1);
+      expect(component.find("#foobar-select").props().value).toEqual("foo");
+    });
+
+    it("has upper bound", () => {
+      const component = shallow(
+        <Select name="foobar" defaultOption={2} options={[{ label: "foo" }]} />
+      );
+      expect(component.find("#foobar")).toHaveLength(1);
+      expect(component.find("#foobar-select").props().value).toEqual("foo");
+    });
+  });
+});


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add a lower bound on default option index.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual and unit
