### PR TITLE
frontend: add more fields to stateful table

### DIFF
--- a/frontend/workflows/k8s/src/stateful-sets-table.tsx
+++ b/frontend/workflows/k8s/src/stateful-sets-table.tsx
@@ -17,7 +17,11 @@ const StatefulSetTable = () => {
 
   return (
     <StatefulSetsContainer>
-      <Table stickyHeader actionsColumn headings={["Name", "Cluster"]}>
+      <Table
+        stickyHeader
+        actionsColumn
+        headings={["Name", "Cluster", "Replicas Desired", "Replicas Ready", "Replicas Up-To-Date"]}
+      >
         {_.sortBy(statefulSets, [
           o => {
             return o.name;
@@ -26,6 +30,9 @@ const StatefulSetTable = () => {
           <TableRow key={statefulSet.name} defaultCellValue="nil">
             {statefulSet.name}
             {statefulSet.cluster}
+            {statefulSet.status?.replicas}
+            {statefulSet.status?.readyReplicas}
+            {statefulSet.status?.updatedReplicas}
           </TableRow>
         ))}
       </Table>


### PR DESCRIPTION
### Description
This PR adds the desired replicas, available replicas & updated replicas to the stateful sets table

### Testing Performed
local
![Screen Shot 2021-06-08 at 11 33 13 AM](https://user-images.githubusercontent.com/3858939/121239600-4aa0f980-c84e-11eb-9af3-e95fbcba0d1a.png)
