### PR TITLE
frontend: support origin navigation in workflows

### DIFF
--- a/frontend/packages/core/src/Contexts/wizard-context.tsx
+++ b/frontend/packages/core/src/Contexts/wizard-context.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export interface ContextProps {
   displayWarnings: (warnings: string[]) => void;
-  onBack: () => void;
+  onBack: (params?: { toOrigin?: boolean }) => void;
   onSubmit: () => void;
   setOnSubmit: (f: (...args: any[]) => void) => void;
   setIsLoading: (isLoading: boolean) => void;

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { Button, ButtonGroup, Step, Stepper, Warning, WizardContext } from "@clutch-sh/core";
 import type { ManagerLayout } from "@clutch-sh/data-layout";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
@@ -58,6 +58,9 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
   const [globalWarnings, setGlobalWarnings] = React.useState<string[]>([]);
   const dataLayoutManager = useDataLayoutManager(dataLayout);
   const [, setSearchParams] = useSearchParams();
+  const locationState = useLocation().state as { origin?: string; autosubmit?: boolean };
+  const navigate = useNavigate();
+  const [origin] = React.useState(locationState?.origin);
 
   const updateStepData = (stepName: string, data: object) => {
     setWizardStepData(prevState => {
@@ -89,10 +92,14 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
       displayWarnings: (warnings: string[]) => {
         setGlobalWarnings(warnings);
       },
-      onBack: () => {
+      onBack: (params: { toOrigin: boolean }) => {
         setGlobalWarnings([]);
         setSearchParams({});
-        dispatch(WizardAction.BACK);
+        if (params?.toOrigin && origin) {
+          navigate(origin);
+        } else {
+          dispatch(WizardAction.BACK);
+        }
       },
     };
   };
@@ -106,6 +113,7 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
   const steps = filteredChildren.map((child: WizardChildren) => {
     const isLoading = wizardStepData[child.type.name]?.isLoading || false;
     const hasError = wizardStepData[child.type.name]?.hasError;
+
     return (
       <>
         <DataLayoutContext.Provider value={dataLayoutManager}>
@@ -124,6 +132,9 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
                   dataLayoutManager.reset();
                   setSearchParams({});
                   dispatch(WizardAction.RESET);
+                  if (origin) {
+                    navigate(origin);
+                  }
                 }}
               />
             </ButtonGroup>

--- a/frontend/workflows/ec2/src/reboot-instance.tsx
+++ b/frontend/workflows/ec2/src/reboot-instance.tsx
@@ -54,7 +54,7 @@ const InstanceDetails: React.FC<WizardChild> = () => {
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
       <MetadataTable data={data} />
       <ButtonGroup>
-        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Back" variant="neutral" onClick={() => onBack()} />
         <Button text="Reboot" variant="destructive" onClick={onSubmit} />
       </ButtonGroup>
     </WizardStep>

--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -84,7 +84,7 @@ const GroupDetails: React.FC<WizardChild> = () => {
         ]}
       />
       <ButtonGroup>
-        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Back" variant="neutral" onClick={() => onBack()} />
         <Button text="Resize" variant="destructive" onClick={onSubmit} />
       </ButtonGroup>
     </WizardStep>

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -66,7 +66,7 @@ const InstanceDetails: React.FC<WizardChild> = () => {
         </Accordion>
       )}
       <ButtonGroup>
-        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Back" variant="neutral" onClick={() => onBack()} />
         <Button text="Terminate" variant="destructive" onClick={onSubmit} />
       </ButtonGroup>
     </WizardStep>

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -5,8 +5,11 @@ import {
   ButtonGroup,
   client,
   Confirmation,
+  FeatureOff,
+  FeatureOn,
   MetadataTable,
   Resolver,
+  SimpleFeatureFlag,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
@@ -50,7 +53,14 @@ const PodDetails: React.FC<WizardChild> = () => {
         ]}
       />
       <ButtonGroup>
-        <Button text="Back" variant="neutral" onClick={() => onBack({ toOrigin: true })} />
+        <SimpleFeatureFlag feature="k8sDashOrigin">
+          <FeatureOn>
+            <Button text="Back" variant="neutral" onClick={() => onBack({ toOrigin: true })} />
+          </FeatureOn>
+          <FeatureOff>
+            <Button text="Back" variant="neutral" onClick={() => onBack()} />
+          </FeatureOff>
+        </SimpleFeatureFlag>
         <Button text="Delete" variant="destructive" onClick={onSubmit} />
       </ButtonGroup>
     </WizardStep>

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -50,7 +50,7 @@ const PodDetails: React.FC<WizardChild> = () => {
         ]}
       />
       <ButtonGroup>
-        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Back" variant="neutral" onClick={() => onBack({ toOrigin: true })} />
         <Button text="Delete" variant="destructive" onClick={onSubmit} />
       </ButtonGroup>
     </WizardStep>

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -109,7 +109,7 @@ const HPADetails: React.FC<WizardChild> = () => {
         </Accordion>
       )}
       <ButtonGroup>
-        <Button text="Back" variant="neutral" onClick={onBack} />
+        <Button text="Back" variant="neutral" onClick={() => onBack()} />
         <Button text="Resize" variant="destructive" onClick={onSubmit} />
       </ButtonGroup>
     </WizardStep>

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -104,7 +104,7 @@ const StreamDetails: React.FC<WizardChild> = () => {
         ]}
       />
       <ButtonGroup>
-        <Button text="Back" onClick={onBack} />
+        <Button text="Back" onClick={() => onBack()} />
         <Button text="Update" variant="destructive" onClick={onSubmit} />
       </ButtonGroup>
     </WizardStep>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add ability to navigate back to origin of workflows when one is set. This is useful for workflows that depend on other workflows (e.g. k8s dashboard -> delete pod) when either navigating backward or restarting the workflow users should be directed back to the place they started.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![origin](https://user-images.githubusercontent.com/1004789/121733643-99e26680-caa8-11eb-930e-d7e2cbd4fd67.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual