### PR TITLE
audit: tune deadline and unlock before sink occurs

### DIFF
--- a/backend/service/audit/setup.go
+++ b/backend/service/audit/setup.go
@@ -171,7 +171,7 @@ func (c *client) poll() {
 	ticker := time.NewTicker(time.Second * time.Duration(ran.Int64()+minTime))
 	for {
 		<-ticker.C
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
 
 		isLocked, err := c.storage.AttemptLock(ctx, lockID)
 		if err != nil {
@@ -179,11 +179,11 @@ func (c *client) poll() {
 		}
 
 		if isLocked {
-			readAndFanout(ctx)
 			_, err := c.storage.ReleaseLock(ctx, lockID)
 			if err != nil {
 				c.logger.Error("Error trying to release lock", zap.Error(err))
 			}
+			readAndFanout(ctx)
 		}
 
 		cancel()


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Unlocking the events lock before the sink(s) occur as this could take sometime, this is because at this point the audit table has already been updated other works are now safe to pick up items from the audit table.

Also increase the deadline to 30 seconds to give more time for the sink write.

> {"level":"error","ts":1623447335.3891637,"caller":"sql/sql.go:202","msg":"Unable to perform an advisory unlock","serviceName":"clutch.service.audit","error":"context deadline exceeded","stacktrace":"github.com/lyft/clutch/backend/service/audit/storage/sql.(*client).ReleaseLock\n\t/code/clutch-private/clutch/backend/service/audit/storage/sql/sql.go:202\ngithub.com/lyft/clutch/backend/service/audit.(*client).poll\n\t/code/clutch-private/clutch/backend/service/audit/setup.go:183"}