### PR TITLE
project selector: don't add project that already exists

### DIFF
--- a/frontend/workflows/projectSelector/src/hello-world.tsx
+++ b/frontend/workflows/projectSelector/src/hello-world.tsx
@@ -90,7 +90,7 @@ const selectorReducer = (state: State, action: Action): State => {
         (project: string) => !(project in state[action.payload.group])
       );
       if (uniqueCustomProjects.length === 0) {
-        return { ...state };
+        return state;
       }
       return {
         ...state,
@@ -102,13 +102,14 @@ const selectorReducer = (state: State, action: Action): State => {
         },
       };
     }
-    case "REMOVE_PROJECTS":
+    case "REMOVE_PROJECTS": {
       // TODO: also remove any upstreams or downstreams related (only) to the project.
       return {
         ...state,
         [action.payload.group]: _.omit(state[action.payload.group], action.payload.projects),
       };
-    case "TOGGLE_PROJECTS":
+    }
+    case "TOGGLE_PROJECTS": {
       // TODO: hide exclusive upstreams and downstreams if group is PROJECTS
       return {
         ...state,
@@ -125,7 +126,8 @@ const selectorReducer = (state: State, action: Action): State => {
           ),
         },
       };
-    case "ONLY_PROJECTS":
+    }
+    case "ONLY_PROJECTS": {
       const newOnlyProjectState = { ...state };
 
       newOnlyProjectState[action.payload.group] = Object.fromEntries(
@@ -136,8 +138,8 @@ const selectorReducer = (state: State, action: Action): State => {
       );
 
       return newOnlyProjectState;
-
-    case "TOGGLE_ENTIRE_GROUP":
+    }
+    case "TOGGLE_ENTIRE_GROUP": {
       const newCheckedValue = !deriveSwitchStatus(state, action.payload.group);
       const newGroupToggledState = { ...state };
       newGroupToggledState[action.payload.group] = Object.fromEntries(
@@ -148,12 +150,12 @@ const selectorReducer = (state: State, action: Action): State => {
       );
 
       return newGroupToggledState;
-
+    }
     // Background actions.
-    case "HYDRATE_START":
+    case "HYDRATE_START": {
       return { ...state, loading: true };
-
-    case "HYDRATE_END":
+    }
+    case "HYDRATE_END": {
       const newPostAPICallState = { ...state, loading: false };
       // TODO: handle payload.
       _.forIn(action.payload.result, (v, k) => {
@@ -166,6 +168,7 @@ const selectorReducer = (state: State, action: Action): State => {
         });
       });
       return newPostAPICallState;
+    }
     default:
       throw new Error(`unknown resolver action`);
   }

--- a/frontend/workflows/projectSelector/src/hello-world.tsx
+++ b/frontend/workflows/projectSelector/src/hello-world.tsx
@@ -85,7 +85,6 @@ const useDispatch = () => {
 const selectorReducer = (state: State, action: Action): State => {
   switch (action.type) {
     case "ADD_PROJECTS":
-      // TODO: don't add if it already exists.
       return {
         ...state,
         [action.payload.group]: {
@@ -317,6 +316,10 @@ const ProjectSelector = () => {
   const handleAdd = () => {
     if (customProject === "") {
       return;
+    }
+    if (customProject in state[Group.PROJECTS]){
+      // TODO: alert/show an "error" that the project is already in the list
+      return setCustomProject("");
     }
     dispatch({
       type: "ADD_PROJECTS",


### PR DESCRIPTION
### Description
Previously, for each new custom project added to the list, an API call is made to retrieve that project even if the project already exists in the list. 

PR checks if the project has already been added in the state to avoid making an unnecessary API call.

### Testing Performed
before
![before](https://user-images.githubusercontent.com/39421794/121979516-52820180-cd58-11eb-94c4-f1d18784c95d.gif)

after
![after](https://user-images.githubusercontent.com/39421794/121979514-501fa780-cd58-11eb-9df0-35fea2a4d7e3.gif)