### PR TITLE
project selector: display total checked per group

### DIFF
--- a/frontend/workflows/projectSelector/src/hello-world.tsx
+++ b/frontend/workflows/projectSelector/src/hello-world.tsx
@@ -218,13 +218,20 @@ const ProjectGroup = ({
 
   const [collapsed, setCollapsed] = React.useState(false);
 
+  const numProjects = Object.keys(state[group]).length;
+  const checkedProjects = Object.keys(state[group]).filter(k => state[group][k].checked);
+
   return (
     <>
       <div>
         <span onClick={() => setCollapsed(!collapsed)}>
           {collapsible && (collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />)}
         </span>
-        {title}
+        <span>{title}</span>
+        <span>
+          ({checkedProjects.length}
+          {numProjects > 0 && "/" + numProjects})
+        </span>
         {!collapsible && <span>All</span>}
         <Switch
           onChange={() =>
@@ -234,12 +241,12 @@ const ProjectGroup = ({
             })
           }
           checked={deriveSwitchStatus(state, group)}
-          disabled={Object.keys(state[group]).length == 0 || state.loading}
+          disabled={numProjects == 0 || state.loading}
         />
       </div>
       {!collapsed && (
         <div>
-          {Object.keys(state[group]).length == 0 && <div>No projects in this group.</div>}
+          {numProjects == 0 && <div>No projects in this group.</div>}
           {Object.keys(state[group]).map(key => (
             <div key={key}>
               <Checkbox


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Display the total number of checked projects per group.

<img src="https://user-images.githubusercontent.com/4712430/122095648-42f3ce80-cdd3-11eb-934f-360ee26c9824.gif" width="175px" />


### Testing Performed
Manual