### PR TITLE
project selector: sidebar styling

### DIFF
--- a/frontend/workflows/projectSelector/src/hello-world.tsx
+++ b/frontend/workflows/projectSelector/src/hello-world.tsx
@@ -302,15 +302,28 @@ const ProjectGroup = ({
 };
 
 const SelectorContainer = styled.div({
-  backgroundColor: "#F5F6FD",
-  ".project": {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  ".only": {
-    color: "#3548D4",
-  },
+  backgroundColor: "#F9FAFE",
+  border: "1px solid rgba(13, 16, 48, 0.1)",
+  boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
+  width: "245px",
+  padding: "16px",
+});
+
+// TODO: change icon, center align icon and title
+const StyledWorkflowHeader = styled.div({
+  paddingBottom: "16px",
+});
+
+const StyledWorkflowTitle = styled.span({
+  fontWeight: "bold",
+  fontSize: "20px",
+  lineHeight: "24px",
+  margin: "0px 8px"
+});
+
+const StyledProjectTextField = styled.div({
+  paddingTop: "16px",
+  paddingBottom: "16px",
 });
 
 const ProjectSelector = () => {
@@ -367,11 +380,12 @@ const ProjectSelector = () => {
       <StateContext.Provider value={state}>
         <SelectorContainer>
           {state.loading && <LinearProgress color="secondary" />}
-          <div>
+          <StyledWorkflowHeader>
             <LayersIcon />
-            Dash
-          </div>
-          <div>
+            <StyledWorkflowTitle>Dash</StyledWorkflowTitle>
+          </StyledWorkflowHeader>
+          <Divider />
+          <StyledProjectTextField>
             <TextField
               disabled={state.loading}
               placeholder="Add a project"
@@ -379,7 +393,7 @@ const ProjectSelector = () => {
               onChange={e => setCustomProject(e.target.value)}
               onKeyDown={e => e.key === "Enter" && handleAdd()}
             />
-          </div>
+          </StyledProjectTextField>
           <ProjectGroup title="Projects" group={Group.PROJECTS} />
           <Divider />
           <ProjectGroup title="Upstreams" group={Group.UPSTREAM} collapsible />

--- a/frontend/workflows/projectSelector/src/hello-world.tsx
+++ b/frontend/workflows/projectSelector/src/hello-world.tsx
@@ -318,12 +318,12 @@ const StyledWorkflowTitle = styled.span({
   fontWeight: "bold",
   fontSize: "20px",
   lineHeight: "24px",
-  margin: "0px 8px"
+  margin: "0px 8px",
 });
 
+// TODO: add plus icon in the text field
 const StyledProjectTextField = styled.div({
   paddingTop: "16px",
-  paddingBottom: "16px",
 });
 
 const ProjectSelector = () => {


### PR DESCRIPTION
### Description

PR adds initial styling to the project selector sidebar. Left some TODOs to address later.

before
<img width="250" alt="Screen Shot 2021-06-15 at 4 30 23 PM" src="https://user-images.githubusercontent.com/39421794/122119358-1356bd80-cdf7-11eb-83f4-d0d9bfb848c2.png">


after
<img width="250" alt="Screen Shot 2021-06-15 at 4 29 46 PM" src="https://user-images.githubusercontent.com/39421794/122119364-1782db00-cdf7-11eb-97c4-271fb60eb882.png">