### PR TITLE
frontend: add describe pod workflow to k8s dashboard

### DIFF
--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -51,6 +51,11 @@ module.exports = {
         resolverType: "clutch.k8s.v1.Pod",
       },
     },
+    describePod: {
+      componentProps: {
+        resolverType: "clutch.k8s.v1.Pod",
+      },
+    },
     resizeHPA: {
       trending: true,
       componentProps: {

--- a/frontend/workflows/k8s/src/describe-pod.tsx
+++ b/frontend/workflows/k8s/src/describe-pod.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { MetadataTable, Resolver, Table, TableRow, useWizardContext } from "@clutch-sh/core";
+import { useDataLayout } from "@clutch-sh/data-layout";
+import type { WizardChild } from "@clutch-sh/wizard";
+import { Wizard, WizardStep } from "@clutch-sh/wizard";
+import _ from "lodash";
+
+import type { ResolverChild, WorkflowProps } from ".";
+
+const PodIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
+  const { onSubmit } = useWizardContext();
+  const resolvedResourceData = useDataLayout("resourceData");
+  const resolverInput = useDataLayout("resolverInput");
+
+  const onResolve = ({ results, input }) => {
+    // Decide how to process results.
+    resolvedResourceData.assign(results[0]);
+    resolverInput.assign(input);
+    onSubmit();
+  };
+
+  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} />;
+};
+
+const PodDetails: React.FC<WizardChild> = () => {
+  const resourceData = useDataLayout("resourceData");
+  const instance = resourceData.displayValue() as IClutch.k8s.v1.Pod;
+  const { containers } = instance;
+
+  return (
+    <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
+      <strong>Pod Details</strong>
+      <MetadataTable
+        data={[
+          { name: "Name", value: instance.name },
+          { name: "Cluster", value: instance.cluster },
+          { name: "Namespace", value: instance.namespace },
+          { name: "State", value: _.capitalize(instance.state.toString()) },
+          { name: "Node IP Address", value: instance.nodeIp },
+          { name: "Pod IP Address", value: instance.podIp },
+          {
+            name: "Containers",
+            value: (
+              <Table stickyHeader headings={["Name", "State", "Restart Count"]}>
+                {_.sortBy(containers, [
+                  o => {
+                    return o.name;
+                  },
+                ]).map(container => (
+                  <TableRow key={container.name} defaultCellValue="nil">
+                    {container.name}
+                    {container.state}
+                    {container.restartCount}
+                  </TableRow>
+                ))}
+              </Table>
+            ),
+          },
+        ]}
+      />
+    </WizardStep>
+  );
+};
+
+const DescribePod: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
+  const dataLayout = {
+    resolverInput: {},
+    resourceData: {},
+  };
+
+  return (
+    <Wizard dataLayout={dataLayout} heading={heading}>
+      <PodIdentifier name="Lookup" resolverType={resolverType} />
+      <PodDetails name="Details" />
+    </Wizard>
+  );
+};
+
+export default DescribePod;

--- a/frontend/workflows/k8s/src/describe-pod.tsx
+++ b/frontend/workflows/k8s/src/describe-pod.tsx
@@ -27,7 +27,7 @@ const PodDetails: React.FC<WizardChild> = () => {
   const resourceData = useDataLayout("resourceData");
   const instance = resourceData.displayValue() as IClutch.k8s.v1.Pod;
   const { containers } = instance;
-
+  const { events } = instance;
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
       <strong>Pod Details</strong>
@@ -52,6 +52,23 @@ const PodDetails: React.FC<WizardChild> = () => {
                     {container.name}
                     {container.state}
                     {container.restartCount}
+                  </TableRow>
+                ))}
+              </Table>
+            ),
+          },
+          {
+            name: "Events",
+            value: (
+              <Table stickyHeader headings={["Reason", "Description"]}>
+                {_.sortBy(events, [
+                  o => {
+                    return o.name;
+                  },
+                ]).map(container => (
+                  <TableRow key={container.name} defaultCellValue="nil">
+                    {container.reason}
+                    {container.description}
                   </TableRow>
                 ))}
               </Table>

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -2,6 +2,7 @@ import type { BaseWorkflowProps, NoteConfig, WorkflowConfiguration } from "@clut
 import type { WizardChild } from "@clutch-sh/wizard";
 
 import DeletePod from "./delete-pod";
+import DescribePod from "./describe-pod";
 import KubeDashboard from "./k8s-dashboard";
 import ResizeHPA from "./resize-hpa";
 
@@ -32,6 +33,13 @@ const register = (): WorkflowConfiguration => {
         displayName: "Delete Pod",
         description: "Delete a K8s pod.",
         component: DeletePod,
+        requiredConfigProps: ["resolverType"],
+      },
+      describePod: {
+        path: "pod/describe",
+        displayName: "Describe Pod",
+        description: "Describe a K8s pod.",
+        component: DescribePod,
         requiredConfigProps: ["resolverType"],
       },
       resizeHPA: {

--- a/frontend/workflows/k8s/src/pods-table.tsx
+++ b/frontend/workflows/k8s/src/pods-table.tsx
@@ -6,6 +6,7 @@ import { Chip, Table, TableRow, TableRowAction, TableRowActions } from "@clutch-
 import { useDataLayout } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
 import DeleteIcon from "@material-ui/icons/Delete";
+import DetailsIcon from "@material-ui/icons/ListAlt";
 import _ from "lodash";
 
 const PodsContainer = styled.div({
@@ -97,6 +98,14 @@ const PodTable = () => {
                 }
               >
                 Delete
+              </TableRowAction>
+              <TableRowAction
+                icon={<DetailsIcon />}
+                onClick={() =>
+                  navigate(`/k8s/pod/describe?q=${pod.cluster}/${pod.namespace}/${pod.name}`)
+                }
+              >
+                Details
               </TableRowAction>
             </TableRowActions>
           </TableRow>


### PR DESCRIPTION
### Description
This PR adds a new K8s workflow: Describe Pod, which provides pod details like containers in the pod, state, node IP, events etc
This PR also adds a `Details` link the K8s dashboard that routes users to the Describe Pod workflow automatically.

### Testing Performed
Local:
![ezgif com-gif-maker (51)](https://user-images.githubusercontent.com/3858939/122480784-585b2b00-cf82-11eb-9901-7aede25b3090.gif)



### TODOs
- Possibly make the pod name in the K8s dashboard clickable so it links to the Describe Pod workflow directly
