### PR TITLE
backend: fix feature flags empty config handling

### DIFF
--- a/backend/module/featureflag/featureflag.go
+++ b/backend/module/featureflag/featureflag.go
@@ -47,7 +47,10 @@ func (m *moduleImpl) Register(r module.Registrar) error {
 }
 
 func (m *moduleImpl) GetFlags(ctx context.Context, req *featureflagv1.GetFlagsRequest) (*featureflagv1.GetFlagsResponse, error) {
-	flags := make(map[string]*featureflagv1.Flag, len(m.simple.Flags))
+	flags := make(map[string]*featureflagv1.Flag)
+	if m.simple == nil {
+		return &featureflagv1.GetFlagsResponse{Flags: flags}, nil
+	}
 	for i, flag := range m.simple.Flags {
 		flags[i] = &featureflagv1.Flag{Type: &featureflagv1.Flag_BooleanValue{BooleanValue: flag}}
 	}

--- a/backend/module/featureflag/featureflag_test.go
+++ b/backend/module/featureflag/featureflag_test.go
@@ -25,7 +25,7 @@ func TestModule(t *testing.T) {
 	assert.True(t, r.JSONRegistered())
 }
 
-func TestAPI(t *testing.T) {
+func TestAPIWithFlags(t *testing.T) {
 	m, err := newModuleImpl(
 		&featureflagv1.Simple{
 			Flags: map[string]bool{
@@ -43,4 +43,18 @@ func TestAPI(t *testing.T) {
 	assert.Equal(t, true, resp.Flags["foo"].GetBooleanValue())
 	assert.Equal(t, false, resp.Flags["bar"].GetBooleanValue())
 	assert.Len(t, resp.Flags, 2)
+}
+
+func TestAPIWithoutFlags(t *testing.T) {
+	m, err := newModuleImpl(
+		&featureflagv1.Simple{
+			Flags: map[string]bool{},
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+
+	_, respErr := m.GetFlags(context.Background(), nil)
+	assert.NoError(t, respErr)
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Handle use case where feature flags are enabled in the clutch config with no flags.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
