### PR TITLE
docs: only show share button on individual blog pages

### DIFF
--- a/docs/_website/src/theme/BlogPostItem/index.tsx
+++ b/docs/_website/src/theme/BlogPostItem/index.tsx
@@ -49,8 +49,7 @@ function BlogPostItem(props) {
             {month} {day}, {year}{' '}
             {readingTime && <> · {Math.ceil(readingTime)} min read</>}
           </time>
-          <>&nbsp;·&nbsp;</>
-          <Share title={title} authors={authors} style={{margin: "0 7px"}} />
+          {!truncated && <>&nbsp;·&nbsp;<Share title={title} authors={authors} style={{margin: "0 7px"}} /></>}
         </div>
 
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Only show share button on full blog pages. At the moment truncated blogs will show a share button for each blog on the root blog page which uses the windows current URL. This change removes the share and fixes that bug.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
