### PR TITLE
docs: add support for blog authors twitter handles

### DIFF
--- a/docs/_website/src/components/Share/index.tsx
+++ b/docs/_website/src/components/Share/index.tsx
@@ -30,6 +30,7 @@ interface ShareProps {
   authors: {
     name: string;
     url: string;
+    twitter_username: string;
   }[];
 }
 
@@ -39,7 +40,10 @@ const Share = ({title, authors}: ShareProps) => {
   return (
       <BrowserOnly>
         {() => {
-          const tweet = encodeURI(`https://twitter.com/intent/tweet?text=${title} by ${authors.map(a => a.name).join(", ")} ${window.location.href}`);
+          const twitter_authors = authors.map(a => a.twitter_username ? `@${a.twitter_username}` : a.name);
+          const tweet = encodeURI(
+            `https://twitter.com/intent/tweet?text=${title} by ${twitter_authors.join(", ")} ${window.location.href}`
+          );
           return (
             <Popover
               isOpen={open}

--- a/docs/_website/src/components/Share/index.tsx
+++ b/docs/_website/src/components/Share/index.tsx
@@ -30,7 +30,7 @@ interface ShareProps {
   authors: {
     name: string;
     url: string;
-    twitter_username: string;
+    twitter_username?: string;
   }[];
 }
 

--- a/docs/blog/2020-07-22-announcing-clutch.md
+++ b/docs/blog/2020-07-22-announcing-clutch.md
@@ -4,9 +4,11 @@ authors:
   - name: Daniel Hochman
     url: https://github.com/danielhochman
     avatar: https://user-images.githubusercontent.com/4712430/87979981-839a7900-ca98-11ea-9d35-07c01b4cec14.png
+    twitter_username: danielhochman
   - name: Derek Schaller
     url: https://github.com/dschaller
     avatar: https://avatars2.githubusercontent.com/u/1004789?s=460&u=e4028c0a2f8c51aa78d9ce90288ee99451e80b71&v=4
+    twitter_username: _derek_
 description: Announcing Clutch, the Open-source Platform for Infrastructure Tooling.
 image: https://user-images.githubusercontent.com/4712430/104760766-7a2c5980-5727-11eb-93f5-3296b23ba3a0.png
 hide_table_of_contents: false

--- a/docs/blog/2021-02-01-frontend-asset-passthrough.md
+++ b/docs/blog/2021-02-01-frontend-asset-passthrough.md
@@ -4,6 +4,7 @@ authors:
   - name: Mike Cutalo
     url: https://github.com/mikecutalo
     avatar: https://avatars1.githubusercontent.com/u/2250844?s=460&u=24deb32096e9f892cc91a6ff1ca1af50193b1fbd&v=4
+    twitter_username: mikecutalo
 description: How caching and hashed frontend builds can lead to a blank screen; and how to fix it.
 image: https://user-images.githubusercontent.com/2250844/106201558-7956e700-616d-11eb-887d-28410b67d558.png
 hide_table_of_contents: false

--- a/docs/blog/2021-04-05-great-design-is-transparent.md
+++ b/docs/blog/2021-04-05-great-design-is-transparent.md
@@ -4,6 +4,7 @@ authors:
   - name: Derek Schaller
     url: https://github.com/dschaller
     avatar: https://avatars1.githubusercontent.com/u/1004789?s=460&u=24deb32096e9f892cc91a6ff1ca1af50193b1fbd&v=4
+    twitter_username: _derek_
 description: How we designed and then redesigned the Frontend of Clutch.
 image: https://user-images.githubusercontent.com/1004789/113597092-0eec7800-95f0-11eb-8f94-b953dd790c23.png
 hide_table_of_contents: false

--- a/docs/blog/2021-06-16-tailor-your-slack-audit-sink-messages.md
+++ b/docs/blog/2021-06-16-tailor-your-slack-audit-sink-messages.md
@@ -4,6 +4,7 @@ authors:
   - name: Scarlett Perry
     url: https://github.com/scarlettperry
     avatar: https://user-images.githubusercontent.com/39421794/122237227-2a47ef00-ce8d-11eb-95c9-1b95df5d7706.jpeg
+    twitter_username: scarlettp3rry
 description: How we extended the Clutch Slack sink to support customized Slack audit messages
 image: https://user-images.githubusercontent.com/39421794/122236515-937b3280-ce8c-11eb-9144-67058f4ef78e.png
 hide_table_of_contents: false


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add support for twitter handle attribution when sharing blog posts via twitter

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![twitter](https://user-images.githubusercontent.com/1004789/123481350-71825e00-d5b8-11eb-8048-ee241cd16746.gif)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual