### PR TITLE
ci: fix e2e test flakiness

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -108,10 +108,9 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mock-mod-${{ hashFiles('**/go.sum') }}  
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}  
           restore-keys: |
             ${{ runner.os }}-go-mod-
-            ${{ runner.os }}-go-mock-mod-
       - name: go build cache
         uses: actions/cache@v2
         with:
@@ -119,8 +118,8 @@ jobs:
             ~/.cache/go-build
           key: ${{ runner.os }}-go-mock-build-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-build-
             ${{ runner.os }}-go-mock-build-
+            ${{ runner.os }}-go-build-
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn --cwd frontend install

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -79,8 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Node
-        uses: actions/setup-node@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.0
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
           check-latest: true
@@ -106,9 +108,10 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}  
+          key: ${{ runner.os }}-go-mock-mod-${{ hashFiles('**/go.sum') }}  
           restore-keys: |
             ${{ runner.os }}-go-mod-
+            ${{ runner.os }}-go-mock-mod-
       - name: go build cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
I think this should help e2e tests pass more consistently. The build currently flakes because the mock server build takes longer than 30s sometimes. By using a newer and consistent version of go and referencing the mock build's cache first, it should speed things up.

### Testing Performed
CI.