### PR TITLE
project selector: update "add_project" state to check project data cache

### DIFF
--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -64,7 +64,7 @@ const selectorReducer = (state: State, action: Action): State => {
 
       // if the newly added project is in Group.Projects, check to see if we have
       // project data for it (b/c we don't need to make an API call) and update the state with
-      // it's upstreams/downstreams
+      // its upstreams/downstreams
       if (action.payload.group === Group.PROJECTS) {
         uniqueCustomProjects.forEach(v => {
           if (v in newState.projectData) {


### PR DESCRIPTION
Same as https://github.com/lyft/clutch/pull/1571 but closed b/c commit history issues after I merged the feature branch into main

### Description

Background
The flow only makes an API call if we don't have data on a project & on each API request we store data on the project and its upstreams/downstreams. So previously, if you added an upstream/downstream as a custom project, we weren't updating the state with its own upstreams/downstreams.

Solution
PR updates the `add_project` state to check if we have project data on a project and if so, we update the state with its upstreams/downstreams.

### Testing Performed
Locally with real API data
