### PR TITLE
frontend: add custom react-router hooks

### DIFF
--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 import {
   ClickAwayListener,
@@ -19,6 +18,7 @@ import type { FilterOptionsState } from "@material-ui/lab/useAutocomplete";
 import _ from "lodash";
 
 import { useAppContext } from "../Contexts";
+import { useNavigate } from "../navigation";
 
 import type { SearchIndex } from "./utils";
 import { searchIndexes } from "./utils";

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
 import styled from "@emotion/styled";
 import _ from "lodash";
 
@@ -8,6 +7,7 @@ import { useWizardContext } from "../Contexts";
 import { Error } from "../Feedback";
 import { HorizontalRule } from "../horizontal-rule";
 import Loadable from "../loading";
+import { useSearchParams } from "../navigation";
 import type { ClutchError } from "../Network/errors";
 
 import { fetchResourceSchemas, resolveResource } from "./fetch";

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useForm } from "react-hook-form";
-import { useSearchParams } from "react-router-dom";
 import type { clutch } from "@clutch-sh/api";
 import styled from "@emotion/styled";
 import SearchIcon from "@material-ui/icons/Search";
@@ -15,6 +14,7 @@ import {
 import { Button } from "../button";
 import { Alert } from "../Feedback";
 import TextField from "../Input/text-field";
+import { useSearchParams } from "../navigation";
 import { client } from "../Network";
 
 import type { ChangeEventTarget } from "./hydrator";

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -27,6 +27,7 @@ import { FeatureOff, FeatureOn, SimpleFeatureFlag } from "./flags";
 import { AvatarIcon, StatusIcon } from "./icon";
 import { Link } from "./link";
 import Loadable from "./loading";
+import { useLocation, useNavigate, useParams, useSearchParams } from "./navigation";
 import { client } from "./Network";
 import ExpansionPanel from "./panel";
 import Paper from "./paper";
@@ -111,6 +112,10 @@ export {
   TreeTable,
   Typography,
   userId,
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
   useWizardContext,
   Warning,
   WizardContext,

--- a/frontend/packages/core/src/landing.tsx
+++ b/frontend/packages/core/src/landing.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 import { Grid } from "@material-ui/core";
 import Typography from "@material-ui/core/Typography";
@@ -8,6 +7,7 @@ import { userId } from "./AppLayout/user";
 import { MonsterGraphic } from "./Assets/Graphics";
 import { LandingCard } from "./card";
 import { useAppContext } from "./Contexts";
+import { useNavigate } from "./navigation";
 
 const StyledLanding = styled.div({
   backgroundColor: "#f9f9fe",

--- a/frontend/packages/core/src/navigation.tsx
+++ b/frontend/packages/core/src/navigation.tsx
@@ -46,6 +46,12 @@ export interface NavigateOptions extends ReactRouterNavigateOptions {
 
 /**
  * Convert custom search param object to string.
+ *
+ * ```ts
+ * const searchObject = new URLSearchParams({ query: "value" });
+ * const searchString = convertSearchParam(searchObject);
+ * console.log(searchString); // "?query=value"
+ * ```
  */
 const convertSearchParam = (params: URLSearchParams) => {
   const p = params.toString();

--- a/frontend/packages/core/src/navigation.tsx
+++ b/frontend/packages/core/src/navigation.tsx
@@ -1,0 +1,171 @@
+import type { URLSearchParamsInit } from "react-router-dom";
+import {
+  createSearchParams,
+  useLocation,
+  useNavigate as rrUseNavigate,
+  useParams,
+  useSearchParams as rrUseSearchParams,
+} from "react-router-dom";
+import type { PartialPath, State } from "history";
+
+const UTM_PARAMS = ["utm_source", "utm_medium"];
+
+/**
+ * A custom partial Path object that may be missing some properties.
+ *
+ * This custom interface exists to provide an easier interface for
+ * setting search params. See https://github.com/ReactTraining/react-router/issues/7743#issuecomment-785435977
+ * for additional context.
+ */
+interface CustomPartialPath extends Pick<PartialPath, "pathname" | "hash"> {
+  /**
+   * Search params to include in navigation.
+   */
+  search?: URLSearchParamsInit;
+}
+
+type To = string | CustomPartialPath;
+
+/**
+ * React Router specific navigation options.
+ */
+interface ReactRouterNavigateOptions {
+  replace?: boolean;
+  state?: State;
+}
+
+/**
+ * Custom navigation options to control Clutch specific routing functionality.
+ */
+export interface NavigateOptions extends ReactRouterNavigateOptions {
+  // Include current URL in state as origin. Defaults to false.
+  origin?: boolean;
+  // Persist UTM search params after navigation. Defaults to true.
+  utm?: boolean;
+}
+
+/**
+ * Convert custom search param object to string.
+ */
+const convertSearchParam = (params: URLSearchParams) => {
+  const p = params.toString();
+  if (p.indexOf("=") < 0) {
+    return "";
+  }
+  return `?${p}`;
+};
+
+/**
+ * Returns an imperative method for changing the location.
+ *
+ * This method wraps useNavigate from react-router but has custom
+ * logic that:
+ *   * Automatically preserves UTM parameters during navigation
+ *   * Easily preserves the origin of navigation in state
+ *   * Provides an easy interface to specify search parameters
+ *
+ * @see https://reactrouter.com/api/useNavigate for more information.
+ */
+const useNavigate = () => {
+  const navigation = rrUseNavigate();
+  const [currentSearchParams] = rrUseSearchParams();
+  const customNavigate = (to: To, options: NavigateOptions = {}) => {
+    const finalNavOptions = {} as ReactRouterNavigateOptions;
+    if (options?.replace) {
+      finalNavOptions.replace = options.replace;
+    }
+    if (options?.state) {
+      finalNavOptions.state = options.state;
+    }
+    let newSearchParams = {} as URLSearchParamsInit;
+    if (typeof to !== "string") {
+      newSearchParams = (to?.search || {}) as URLSearchParamsInit;
+    }
+    const searchParams = createSearchParams(newSearchParams);
+    if (options?.utm || options?.utm === undefined) {
+      UTM_PARAMS.forEach(p => {
+        const param = currentSearchParams.get(p);
+        if (param && !searchParams.get(p)) {
+          searchParams.set(p, param);
+        }
+      });
+    }
+
+    if (options?.origin) {
+      const origin = `${window.location.pathname}${window.location.search}`;
+      // n.b. if origin is specified in the options don't overwrite it.
+      // @ts-ignore
+      if (!options.state?.origin) {
+        // @ts-ignore
+        finalNavOptions.state = { ...finalNavOptions.state, origin };
+      }
+    }
+
+    let navPath = {} as PartialPath;
+    if (typeof to === "string") {
+      navPath.pathname = to;
+    } else {
+      navPath = { pathname: to?.pathname, hash: to?.hash };
+    }
+    const [path, search] = navPath.pathname.split("?");
+    navPath.pathname = path;
+    if (search) {
+      new URLSearchParams(search).forEach((v, k) => {
+        searchParams.set(k, v);
+      });
+    }
+    navPath.search = convertSearchParam(searchParams);
+    navigation(navPath, finalNavOptions);
+  };
+
+  return customNavigate;
+};
+
+/**
+ * Custom search param options to control Clutch specific routing functionality.
+ */
+interface SearchParamOptions extends ReactRouterNavigateOptions {
+  utm?: boolean;
+}
+
+/**
+ * A convienence wrapper for reading and writing search parameters via the
+ * URLSearchParams interface. This custom hook wraps react-routers implementation
+ * but changes the function to write search parameters to preserve UTM parameters
+ * by default.
+ */
+const useSearchParams = (): readonly [
+  URLSearchParams,
+  (params: URLSearchParamsInit, options?: SearchParamOptions | undefined) => void
+] => {
+  const [searchParams, setSearchParams] = rrUseSearchParams();
+
+  const customSetSearchParams = (
+    params: URLSearchParamsInit,
+    options?: SearchParamOptions | undefined
+  ) => {
+    const newSearchParams = params;
+    const reactRouterOptions = {} as ReactRouterNavigateOptions;
+    if (options?.replace) {
+      reactRouterOptions.replace = options.replace;
+    }
+    if (options?.state) {
+      reactRouterOptions.state = options.state;
+    }
+
+    if (options?.utm || options?.utm === undefined) {
+      UTM_PARAMS.forEach(p => {
+        const param = searchParams.get(p);
+        if (param && !newSearchParams[p]) {
+          newSearchParams[p] = param;
+        }
+      });
+    }
+
+    setSearchParams(newSearchParams, reactRouterOptions);
+  };
+
+  return [searchParams, customSetSearchParams];
+};
+
+export { convertSearchParam, useLocation, useParams, useSearchParams, useNavigate };

--- a/frontend/packages/core/src/tests/navigation.test.tsx
+++ b/frontend/packages/core/src/tests/navigation.test.tsx
@@ -1,0 +1,260 @@
+import { convertSearchParam, useNavigate, useSearchParams } from "../navigation";
+
+const mockNav = jest.fn();
+const mockSearchParams = jest.fn();
+const mockSetSearchParams = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...(jest.requireActual("react-router-dom") as any),
+  useNavigate: () => mockNav,
+  useSearchParams: () => [{ get: mockSearchParams }, mockSetSearchParams],
+}));
+
+describe("convertSearchParam", () => {
+  it("handles empty objects", () => {
+    const result = convertSearchParam(new URLSearchParams({}));
+    expect(result).toEqual("");
+  });
+
+  it("prepends ?", () => {
+    const result = convertSearchParam(new URLSearchParams({ foo: "bar" }));
+    expect(result).toEqual("?foo=bar");
+  });
+
+  it("joins entries", () => {
+    const result = convertSearchParam(new URLSearchParams({ foo: "bar", test: "42" }));
+    expect(result).toEqual("?foo=bar&test=42");
+  });
+});
+
+describe("useNavigate", () => {
+  const nav = useNavigate();
+
+  beforeEach(() => {
+    mockNav.mockReset();
+  });
+
+  describe("by default", () => {
+    it("calls react-router navigate with partial path and no options", () => {
+      nav("/foo");
+      expect(mockNav).toHaveBeenCalledWith({ pathname: "/foo", search: "" }, {});
+    });
+
+    it("preserves only react router options", () => {
+      nav("/foo", { utm: true, replace: true, state: { foo: "bar" } });
+      expect(mockNav).toHaveBeenCalledWith(
+        { pathname: "/foo", search: "" },
+        { replace: true, state: { foo: "bar" } }
+      );
+    });
+  });
+
+  describe("with UTM search params", () => {
+    beforeAll(() => {
+      mockSearchParams.mockImplementation(
+        k =>
+          ({
+            utm_source: "test",
+            utm_medium: "run",
+            randon: "value",
+          }[k])
+      );
+    });
+
+    afterAll(() => {
+      mockSearchParams.mockImplementation();
+    });
+
+    it("preserves only UTM params from existing search", () => {
+      nav("/foo");
+      expect(mockNav).toHaveBeenCalledWith(
+        { pathname: "/foo", search: "?utm_source=test&utm_medium=run" },
+        {}
+      );
+    });
+
+    it("merges UTM params with new search", () => {
+      nav({
+        pathname: "/foo",
+        search: {
+          new: "value",
+        },
+      });
+      expect(mockNav).toHaveBeenCalledWith(
+        { pathname: "/foo", search: "?new=value&utm_source=test&utm_medium=run" },
+        {}
+      );
+    });
+
+    it("can bypass UTM tracking", () => {
+      nav("/foo", { utm: false });
+      expect(mockNav).toHaveBeenCalledWith({ pathname: "/foo", search: "" }, {});
+    });
+
+    it("overwrites existing UTM params", () => {
+      nav({
+        pathname: "/foo",
+        search: {
+          utm_source: "newsource",
+          utm_medium: "newmedium",
+        },
+      });
+      expect(mockNav).toHaveBeenCalledWith(
+        { pathname: "/foo", search: "?utm_source=newsource&utm_medium=newmedium" },
+        {}
+      );
+    });
+  });
+
+  it("merges search param in path", () => {
+    nav({
+      pathname: "/foo?some=value",
+      search: {
+        search: "param",
+      },
+    });
+    expect(mockNav).toHaveBeenCalledWith(
+      { pathname: "/foo", search: "?search=param&some=value" },
+      {}
+    );
+  });
+
+  it("gives priority to pathname search param", () => {
+    nav({
+      pathname: "/foo?some=value",
+      search: {
+        some: "error",
+      },
+    });
+    expect(mockNav).toHaveBeenCalledWith({ pathname: "/foo", search: "?some=value" }, {});
+  });
+
+  it("allows for custom partial path object", () => {
+    nav({
+      pathname: "/foo",
+      search: { some: "param" },
+    });
+    expect(mockNav).toHaveBeenCalledWith(
+      { hash: undefined, pathname: "/foo", search: "?some=param" },
+      { replace: undefined, state: undefined }
+    );
+  });
+
+  describe("origin", () => {
+    const { location } = window;
+
+    beforeAll(() => {
+      delete window.location;
+      // @ts-ignore
+      window.location = { pathname: "/current/path", search: "?test=value" };
+    });
+
+    afterAll(() => {
+      window.location = location;
+    });
+
+    it("can be persisted in state", () => {
+      nav("/foo", { origin: true });
+      expect(mockNav).toHaveBeenCalledWith(
+        { pathname: "/foo", search: "" },
+        { state: { origin: "/current/path?test=value" } }
+      );
+    });
+
+    it("will not overwrite specified state origin", () => {
+      nav("/foo", { origin: true, state: { origin: "/new/path" } });
+      expect(mockNav).toHaveBeenCalledWith(
+        { pathname: "/foo", search: "" },
+        { state: { origin: "/new/path" } }
+      );
+    });
+  });
+});
+
+describe("useSearchParams", () => {
+  beforeAll(() => {
+    mockSearchParams.mockImplementation(
+      k =>
+        ({
+          foo: "bar",
+        }[k])
+    );
+  });
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  beforeEach(() => {
+    mockSetSearchParams.mockReset();
+  });
+
+  it("passes through search params", () => {
+    expect(searchParams.get("foo")).toBe("bar");
+  });
+
+  describe("setSearchParams", () => {
+    it("calls react-router navigate with new search params and no options", () => {
+      setSearchParams({ foo: "bar" });
+      expect(mockSetSearchParams).toHaveBeenCalledWith({ foo: "bar" }, {});
+    });
+
+    it("preserves only react router options", () => {
+      setSearchParams({ foo: "bar" }, { utm: true, replace: true, state: { foo: "bar" } });
+      expect(mockSetSearchParams).toHaveBeenCalledWith(
+        { foo: "bar" },
+        { replace: true, state: { foo: "bar" } }
+      );
+    });
+  });
+
+  describe("with UTM search params", () => {
+    beforeAll(() => {
+      mockSearchParams.mockImplementation(
+        k =>
+          ({
+            utm_source: "test",
+            utm_medium: "run",
+            randon: "value",
+          }[k])
+      );
+    });
+
+    afterAll(() => {
+      mockSearchParams.mockImplementation();
+    });
+
+    it("preserves only UTM params from existing search", () => {
+      setSearchParams({});
+      expect(mockSetSearchParams).toHaveBeenCalledWith(
+        { utm_source: "test", utm_medium: "run" },
+        {}
+      );
+    });
+
+    it("merges UTM params with new search", () => {
+      setSearchParams({ new: "value" });
+      expect(mockSetSearchParams).toHaveBeenCalledWith(
+        { utm_source: "test", utm_medium: "run", new: "value" },
+        {}
+      );
+    });
+
+    it("can bypass UTM tracking", () => {
+      setSearchParams({ foo: "bar" }, { utm: false });
+      expect(mockSetSearchParams).toHaveBeenCalledWith({ foo: "bar" }, {});
+    });
+
+    it("overwrites existing UTM params", () => {
+      setSearchParams({
+        utm_source: "newsource",
+        utm_medium: "newmedium",
+      });
+      expect(mockSetSearchParams).toHaveBeenCalledWith(
+        {
+          utm_source: "newsource",
+          utm_medium: "newmedium",
+        },
+        {}
+      );
+    });
+  });
+});

--- a/frontend/packages/wizard/package.json
+++ b/frontend/packages/wizard/package.json
@@ -34,9 +34,7 @@
     "clsx": "^1.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-is": "^17.0.2",
-    "react-router": "^6.0.0-beta",
-    "react-router-dom": "^6.0.0-beta"
+    "react-is": "^17.0.2"
   },
   "devDependencies": {
     "@clutch-sh/tools": "^1.0.0-beta"

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -1,6 +1,15 @@
 import React from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { Button, ButtonGroup, Step, Stepper, Warning, WizardContext } from "@clutch-sh/core";
+import {
+  Button,
+  ButtonGroup,
+  Step,
+  Stepper,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+  Warning,
+  WizardContext,
+} from "@clutch-sh/core";
 import type { ManagerLayout } from "@clutch-sh/data-layout";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";

--- a/frontend/workflows/experimentation/package.json
+++ b/frontend/workflows/experimentation/package.json
@@ -28,7 +28,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
-    "react-router-dom": "^6.0.0-beta",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import type { ClutchError } from "@clutch-sh/core";
-import { BaseWorkflowProps, Button, ButtonGroup, client } from "@clutch-sh/core";
+import { BaseWorkflowProps, Button, ButtonGroup, client, useNavigate } from "@clutch-sh/core";
 
 import PageLayout from "./core/page-layout";
 import type { Column } from "./list-view";

--- a/frontend/workflows/experimentation/src/tests/list-experiments.test.tsx
+++ b/frontend/workflows/experimentation/src/tests/list-experiments.test.tsx
@@ -3,9 +3,9 @@ import { shallow } from "enzyme";
 
 import ListExperiments from "../list-experiments";
 
-jest.mock("react-router-dom", () => {
+jest.mock("@clutch-sh/core", () => {
   return {
-    ...jest.requireActual("react-router-dom"),
+    ...(jest.requireActual("@clutch-sh/core") as any),
     useNavigate: jest.fn(),
   };
 });

--- a/frontend/workflows/experimentation/src/tests/view-experiment-run.test.tsx
+++ b/frontend/workflows/experimentation/src/tests/view-experiment-run.test.tsx
@@ -3,9 +3,9 @@ import { shallow } from "enzyme";
 
 import ViewExperimentRun from "../view-experiment-run";
 
-jest.mock("react-router-dom", () => {
+jest.mock("@clutch-sh/core", () => {
   return {
-    ...jest.requireActual("react-router-dom"),
+    ...(jest.requireActual("@clutch-sh/core") as any),
     useNavigate: jest.fn(),
   };
 });

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
 import { clutch as IClutch } from "@clutch-sh/api";
 import type { ClutchError } from "@clutch-sh/core";
 import {
@@ -10,6 +9,8 @@ import {
   Form,
   Link,
   TextField,
+  useNavigate,
+  useParams,
 } from "@clutch-sh/core";
 
 import PageLayout from "./core/page-layout";

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -33,9 +33,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^6.11.0",
-    "react-router-dom": "^6.0.0-beta",
-    "yup": "^0.32.8",
-    "react-timeago": "^6.0.0"
+    "react-timeago": "^6.0.0",
+    "yup": "^0.32.8"
   },
   "devDependencies": {
     "@clutch-sh/tools": "^1.0.0-beta"

--- a/frontend/workflows/k8s/src/pods-table.tsx
+++ b/frontend/workflows/k8s/src/pods-table.tsx
@@ -1,8 +1,14 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import TimeAgo from "react-timeago";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Chip, Table, TableRow, TableRowAction, TableRowActions } from "@clutch-sh/core";
+import {
+  Chip,
+  Table,
+  TableRow,
+  TableRowAction,
+  TableRowActions,
+  useNavigate,
+} from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
 import DeleteIcon from "@material-ui/icons/Delete";

--- a/frontend/workflows/redisexperimentation/package.json
+++ b/frontend/workflows/redisexperimentation/package.json
@@ -29,7 +29,6 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^6.11.0",
     "react-is": "^17.0.2",
-    "react-router-dom": "^6.0.0-beta",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/frontend/workflows/redisexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/redisexperimentation/src/start-experiment.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import type { BaseWorkflowProps, ClutchError } from "@clutch-sh/core";
 import {
@@ -11,6 +10,7 @@ import {
   DialogActions,
   DialogContent,
   Form,
+  useNavigate,
 } from "@clutch-sh/core";
 import { FormFields, PageLayout } from "@clutch-sh/experimentation";
 import { yupResolver } from "@hookform/resolvers/yup";

--- a/frontend/workflows/redisexperimentation/src/tests/experiment-details.test.tsx
+++ b/frontend/workflows/redisexperimentation/src/tests/experiment-details.test.tsx
@@ -4,9 +4,9 @@ import { shallow } from "enzyme";
 
 import { ExperimentDetails } from "../start-experiment";
 
-jest.mock("react-router-dom", () => {
+jest.mock("@clutch-sh/core", () => {
   return {
-    ...jest.requireActual("react-router-dom"),
+    ...(jest.requireActual("@clutch-sh/core") as any),
     useNavigate: jest.fn(),
   };
 });

--- a/frontend/workflows/redisexperimentation/src/tests/start-experiment.test.tsx
+++ b/frontend/workflows/redisexperimentation/src/tests/start-experiment.test.tsx
@@ -3,9 +3,9 @@ import { shallow } from "enzyme";
 
 import { StartExperiment } from "../start-experiment";
 
-jest.mock("react-router-dom", () => {
+jest.mock("@clutch-sh/core", () => {
   return {
-    ...jest.requireActual("react-router-dom"),
+    ...(jest.requireActual("@clutch-sh/core") as any),
     useNavigate: jest.fn(),
   };
 });

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -29,7 +29,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^6.11.0",
-    "react-router-dom": "^6.0.0-beta",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import type { BaseWorkflowProps, ClutchError } from "@clutch-sh/core";
 import {
@@ -11,6 +10,7 @@ import {
   DialogActions,
   DialogContent,
   Form,
+  useNavigate,
 } from "@clutch-sh/core";
 import { FormFields, PageLayout } from "@clutch-sh/experimentation";
 import { yupResolver } from "@hookform/resolvers/yup";

--- a/frontend/workflows/serverexperimentation/src/tests/experiment-details.test.tsx
+++ b/frontend/workflows/serverexperimentation/src/tests/experiment-details.test.tsx
@@ -4,9 +4,9 @@ import { shallow } from "enzyme";
 
 import { ExperimentDetails } from "../start-experiment";
 
-jest.mock("react-router-dom", () => {
+jest.mock("@clutch-sh/core", () => {
   return {
-    ...jest.requireActual("react-router-dom"),
+    ...(jest.requireActual("@clutch-sh/core") as any),
     useNavigate: jest.fn(),
   };
 });

--- a/frontend/workflows/serverexperimentation/src/tests/start-experiment.test.tsx
+++ b/frontend/workflows/serverexperimentation/src/tests/start-experiment.test.tsx
@@ -3,9 +3,9 @@ import { shallow } from "enzyme";
 
 import { StartExperiment } from "../start-experiment";
 
-jest.mock("react-router-dom", () => {
+jest.mock("@clutch-sh/core", () => {
   return {
-    ...jest.requireActual("react-router-dom"),
+    ...(jest.requireActual("@clutch-sh/core") as any),
     useNavigate: jest.fn(),
   };
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2704,7 +2704,7 @@
     "@emotion/serialize" "^1.0.0"
     "@emotion/utils" "^1.0.0"
 
-"@emotion/styled@^11.1.5":
+"@emotion/styled@^11.1.5", "@emotion/styled@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
   integrity sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==

--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -28,8 +28,6 @@
     "history": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router": "^6.0.0-beta",
-    "react-router-dom": "^6.0.0-beta",
     "react-scripts": "^4.0.1"
   },
   "workspaces": [


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add custom react-router hooks to:
  -  preserve utm search params
  - provide an easier interface to track origins when routing between pages
  - provide an easier interface to specify search params (see [this](https://github.com/ReactTraining/react-router/issues/7743) for context)
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual and unit
