### PR TITLE
project selector: remove exclusive upstreams/downstreams

### DIFF
--- a/frontend/workflows/projectSelector/src/helpers.tsx
+++ b/frontend/workflows/projectSelector/src/helpers.tsx
@@ -53,15 +53,15 @@ const dependencyToProjects = (state: State, group: Group): DependencyMappings =>
 
   const projects = Object.keys(state[group]);
   projects.forEach(p => {
-    const { upstreams, downstreams } = state.projectData[p]?.dependencies;
-    upstreams[PROJECT_TYPE_URL]?.ids.forEach(u => {
+    const { upstreams, downstreams } = state.projectData[p]?.dependencies || {};
+    upstreams?.[PROJECT_TYPE_URL]?.ids.forEach(u => {
       if (!upstreamMap[u]) {
         upstreamMap[u] = { [p]: true };
       } else {
         upstreamMap[u][p] = true;
       }
     });
-    downstreams[PROJECT_TYPE_URL]?.ids.forEach(d => {
+    downstreams?.[PROJECT_TYPE_URL]?.ids.forEach(d => {
       if (!downstreamMap[d]) {
         downstreamMap[d] = { [p]: true };
       } else {

--- a/frontend/workflows/projectSelector/src/helpers.tsx
+++ b/frontend/workflows/projectSelector/src/helpers.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import _ from "lodash";
+
+import type { Action, Group, ProjectState, State } from "./types";
+
+const PROJECT_TYPE_URL = "type.googleapis.com/clutch.core.project.v1.Project";
+
+interface DependencyMappings {
+  upstreams?: { [dependency: string]: { [project: string]: boolean } };
+  downstreams?: { [dependency: string]: { [project: string]: boolean } };
+}
+
+const StateContext = React.createContext<State | undefined>(undefined);
+const useReducerState = () => {
+  return React.useContext(StateContext);
+};
+
+const DispatchContext = React.createContext<(action: Action) => void | undefined>(undefined);
+const useDispatch = () => {
+  return React.useContext(DispatchContext);
+};
+
+// TODO(perf): call with useMemo().
+const deriveSwitchStatus = (state: State, group: Group): boolean => {
+  return (
+    Object.keys(state[group]).length > 0 &&
+    Object.keys(state[group]).every(key => state[group][key].checked)
+  );
+};
+
+const updateGroupstate = (
+  state: State,
+  group: Group,
+  project: string,
+  projectState: ProjectState
+): State => {
+  const newState = { ...state };
+  if (project in newState[group]) {
+    // preserve the checked value if the project is already in the group
+    newState[group][project].checked = state[group][project].checked;
+    newState[group][project].custom = projectState.custom;
+  } else {
+    // we set the projectState to the default state passed in
+    newState[group][project] = projectState;
+  }
+
+  return newState;
+};
+
+const dependencyToProjects = (state: State, group: Group): DependencyMappings => {
+  const upstreamMap = {};
+  const downstreamMap = {};
+
+  const projects = Object.keys(state[group]);
+  projects.forEach(p => {
+    const { upstreams, downstreams } = state.projectData[p]?.dependencies;
+    upstreams[PROJECT_TYPE_URL]?.ids.forEach(u => {
+      if (!upstreamMap[u]) {
+        upstreamMap[u] = { [p]: true };
+      } else {
+        upstreamMap[u][p] = true;
+      }
+    });
+    downstreams[PROJECT_TYPE_URL]?.ids.forEach(d => {
+      if (!downstreamMap[d]) {
+        downstreamMap[d] = { [p]: true };
+      } else {
+        downstreamMap[d][p] = true;
+      }
+    });
+  });
+
+  return { upstreams: upstreamMap, downstreams: downstreamMap };
+};
+
+const exclusiveProjectDependencies = (
+  state: State,
+  group: Group,
+  project: string
+): { upstreams: string[]; downstreams: string[] } => {
+  const dependencyMap = dependencyToProjects(state, group);
+
+  const upstreams = [];
+  const downstreams = [];
+  _.forIn(dependencyMap.upstreams, (v, k) => {
+    if (v[project] && Object.keys(v).length === 1) {
+      upstreams.push(k);
+    }
+  });
+
+  _.forIn(dependencyMap.downstreams, (v, k) => {
+    if (v[project] && Object.keys(v).length === 1) {
+      downstreams.push(k);
+    }
+  });
+  return { upstreams, downstreams };
+};
+
+export {
+  deriveSwitchStatus,
+  DispatchContext,
+  exclusiveProjectDependencies,
+  PROJECT_TYPE_URL,
+  StateContext,
+  updateGroupstate,
+  useDispatch,
+  useReducerState,
+};

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -6,7 +6,7 @@ import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import ClearIcon from "@material-ui/icons/Clear";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
-import { deriveSwitchStatus, useDispatch, useReducerState } from "./selector-reducer";
+import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
 import type { Group } from "./types";
 
 const StyledCount = styled.span({

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -7,8 +7,9 @@ import { Divider, LinearProgress } from "@material-ui/core";
 import LayersIcon from "@material-ui/icons/Layers";
 import _ from "lodash";
 
+import { DispatchContext, StateContext } from "./helpers";
 import ProjectGroup from "./project-group";
-import { DispatchContext, selectorReducer, StateContext } from "./selector-reducer";
+import selectorReducer from "./selector-reducer";
 import type { State } from "./types";
 import { Group } from "./types";
 

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -7,8 +7,7 @@ import { Group } from "./types";
 
 const PROJECT_TYPE_URL = "type.googleapis.com/clutch.core.project.v1.Project";
 
-// TODO: dont like this name
-interface DependencyToProject {
+interface DependencyMappings {
   upstreams?: { [dependency: string]: { [project: string]: boolean } };
   downstreams?: { [dependency: string]: { [project: string]: boolean } };
 }
@@ -50,31 +49,7 @@ const updateGroupstate = (
   return newState;
 };
 
-// TODO: make an interface for the return value?
-const exclusiveProjectDependencies = (
-  state: State,
-  group: Group,
-  project: string
-): { upstreams: string[]; downstreams: string[] } => {
-  const dependencyRelationships = dependencyToProject(state, group);
-
-  const upstreams = [];
-  const downstreams = [];
-  _.forIn(dependencyRelationships.upstreams, (v, k) => {
-    if (v[project] && Object.keys(v).length === 1) {
-      upstreams.push(k);
-    }
-  });
-
-  _.forIn(dependencyRelationships.downstreams, (v, k) => {
-    if (v[project] && Object.keys(v).length === 1) {
-      downstreams.push(k);
-    }
-  });
-  return { upstreams, downstreams };
-};
-
-const dependencyToProject = (state: State, group: Group): DependencyToProject => {
+const dependencyToProjects = (state: State, group: Group): DependencyMappings => {
   const upstreams = {};
   const downstreams = {};
 
@@ -97,6 +72,29 @@ const dependencyToProject = (state: State, group: Group): DependencyToProject =>
     });
   });
 
+  return { upstreams, downstreams };
+};
+
+const exclusiveProjectDependencies = (
+  state: State,
+  group: Group,
+  project: string
+): { upstreams: string[]; downstreams: string[] } => {
+  const dependencyMap = dependencyToProjects(state, group);
+
+  const upstreams = [];
+  const downstreams = [];
+  _.forIn(dependencyMap.upstreams, (v, k) => {
+    if (v[project] && Object.keys(v).length === 1) {
+      upstreams.push(k);
+    }
+  });
+
+  _.forIn(dependencyMap.downstreams, (v, k) => {
+    if (v[project] && Object.keys(v).length === 1) {
+      downstreams.push(k);
+    }
+  });
   return { upstreams, downstreams };
 };
 

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -50,29 +50,29 @@ const updateGroupstate = (
 };
 
 const dependencyToProjects = (state: State, group: Group): DependencyMappings => {
-  const upstreams = {};
-  const downstreams = {};
+  const upstreamMap = {};
+  const downstreamMap = {};
 
   const projects = Object.keys(state[group]);
   projects.forEach(p => {
-    state.projectData[p]?.dependencies.upstreams[PROJECT_TYPE_URL]?.ids.forEach(u => {
-      if (!upstreams[u]) {
-        upstreams[u] = { [p]: true };
+    const { upstreams, downstreams } = state.projectData[p]?.dependencies;
+    upstreams[PROJECT_TYPE_URL]?.ids.forEach(u => {
+      if (!upstreamMap[u]) {
+        upstreamMap[u] = { [p]: true };
       } else {
-        upstreams[u][p] = true;
+        upstreamMap[u][p] = true;
       }
     });
-
-    state.projectData[p]?.dependencies.downstreams[PROJECT_TYPE_URL]?.ids.forEach(d => {
-      if (!downstreams[d]) {
-        downstreams[d] = { [p]: true };
+    downstreams[PROJECT_TYPE_URL]?.ids.forEach(d => {
+      if (!downstreamMap[d]) {
+        downstreamMap[d] = { [p]: true };
       } else {
-        downstreams[d][p] = true;
+        downstreamMap[d][p] = true;
       }
     });
   });
 
-  return { upstreams, downstreams };
+  return { upstreams: upstreamMap, downstreams: downstreamMap };
 };
 
 const exclusiveProjectDependencies = (
@@ -151,10 +151,8 @@ const selectorReducer = (state: State, action: Action): State => {
       return newState;
     }
     case "REMOVE_PROJECTS": {
-      let newState = { ...state };
-
       // remove the projects from their respective group
-      newState = {
+      const newState = {
         ...state,
         [action.payload.group]: _.omit(state[action.payload.group], action.payload.projects),
       };


### PR DESCRIPTION
### Description

PR adds
* helpers to collect the exclusive upstreams/downstreams of a project in the "remove_projects" state
* removes the exclusive upstreams/downstreams of the removed project(s)

### Testing Performed
Tested locally with real API data