### PR TITLE
project-selector: hide exclusive upstreams/downstreams

### DIFF
--- a/frontend/workflows/projectSelector/src/helpers.tsx
+++ b/frontend/workflows/projectSelector/src/helpers.tsx
@@ -102,7 +102,6 @@ const hidden = (
   state: State,
   group: Group,
   project: string,
-  projectState: ProjectState,
   dependency: string,
   depMapping: DependencyMappings
 ): boolean => {
@@ -111,7 +110,7 @@ const hidden = (
     _.forIn(depMapping.upstreams, (v, k) => {
       if (v[project]) {
         // if project is unchecked and dependency is exclusive to that project, hide the dependency
-        if (!projectState.checked && Object.keys(v).length === 1) {
+        if (!state[Group.PROJECTS][project].checked && Object.keys(v).length === 1) {
           hiddenDep.push(k);
         } else if (Object.keys(v).every(p => !state[Group.PROJECTS][p].checked)) {
           // although the dependency is exclusive to more than 1 Group.Projects, if all Group.Projects share the dependency
@@ -124,7 +123,7 @@ const hidden = (
     _.forIn(depMapping.downstreams, (v, k) => {
       if (v[project]) {
         // if project is unchecked and dependency is exclusive to that project, hide the dependency
-        if (!projectState.checked && Object.keys(v).length === 1) {
+        if (!state[Group.PROJECTS][project].checked && Object.keys(v).length === 1) {
           hiddenDep.push(k);
         } else if (Object.keys(v).every(p => !state[Group.PROJECTS][p].checked)) {
           // although the dependency is exclusive to more than 1 Group.Projects, if all Group.Projects share the dependency
@@ -154,19 +153,18 @@ const deriveStateData = (state: State): State => {
 
   // get the relationships b/w upstreams/downstreams to projects
   const depMapping = dependencyToProjects(state, Group.PROJECTS);
-
   const hiddenUpstreams = [];
   const hiddenDownstreams = [];
 
-  _.forIn(state[Group.PROJECTS], (projectState, project) => {
+  _.forEach(Object.keys(state[Group.PROJECTS]), project => {
     _.forEach(Object.keys(state[Group.UPSTREAM]), upstream => {
-      if (hidden(state, Group.UPSTREAM, project, projectState, upstream, depMapping)) {
+      if (hidden(state, Group.UPSTREAM, project, upstream, depMapping)) {
         hiddenUpstreams.push(upstream);
       }
     });
 
     _.forEach(Object.keys(state[Group.DOWNSTREAM]), downstream => {
-      if (hidden(state, Group.DOWNSTREAM, project, projectState, downstream, depMapping)) {
+      if (hidden(state, Group.DOWNSTREAM, project, downstream, depMapping)) {
         hiddenDownstreams.push(downstream);
       }
     });

--- a/frontend/workflows/projectSelector/src/helpers.tsx
+++ b/frontend/workflows/projectSelector/src/helpers.tsx
@@ -96,7 +96,7 @@ const exclusiveProjectDependencies = (
   });
   return { upstreams, downstreams };
 };
-
+// TODO: (perf/efficiency) compute the projects that should be displayed rather than computing the hidden projects
 // returns the upstreams/downstreams that should be hidden based on the checked status of/exclusivity to project(s)
 const deriveHiddenDependencies = (state: State): { upstreams: string[]; downstreams: string[] } => {
   const upstreams = [];

--- a/frontend/workflows/projectSelector/src/helpers.tsx
+++ b/frontend/workflows/projectSelector/src/helpers.tsx
@@ -107,7 +107,7 @@ const exclusiveProjectDependencies = (
 // the checked status of/exclusivity to projects in Group.Projects
 const deriveHiddenStatus = (state: State, group: Group, key: string): boolean => {
   // if true, don't need to go through the flow below as we only hide an upstream/downstream
-  if (group == Group.PROJECTS) {
+  if (group === Group.PROJECTS) {
     return false;
   }
 
@@ -135,7 +135,10 @@ const deriveHiddenStatus = (state: State, group: Group, key: string): boolean =>
         // hide an upstream if it's exclusive to the unchecked project (ie. no other checked project(s) share it)
         if (v[p] && Object.keys(v).length === 1) {
           exclusive.push(k);
-        } else if (unchecked.length > 1 && unchecked.every(p => Object.keys(v).includes(p))) {
+        } else if (
+          unchecked.length > 1 &&
+          unchecked.every(project => Object.keys(v).includes(project))
+        ) {
           // hide an upstream if all unchecked projects share it
           exclusive.push(k);
         }
@@ -147,7 +150,10 @@ const deriveHiddenStatus = (state: State, group: Group, key: string): boolean =>
         // hide a downstream if it's exclusive to the unchecked project (ie. no other checked project(s) share it)
         if (v[p] && Object.keys(v).length === 1) {
           exclusive.push(k);
-        } else if (unchecked.length > 1 && unchecked.every(p => Object.keys(v).includes(p))) {
+        } else if (
+          unchecked.length > 1 &&
+          unchecked.every(project => Object.keys(v).includes(project))
+        ) {
           // hide a downstream if all unchecked projects share it
           exclusive.push(k);
         }

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -118,7 +118,6 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
 
   const numProjects = Object.keys(state[group]).length;
   const checkedProjects = Object.keys(state[group]).filter(k => state[group][k].checked);
-  const hiddenProjects = Object.keys(state[group]).filter(k => state[group][k].hidden === false);
 
   return (
     <>
@@ -151,8 +150,6 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
             disabled={numProjects === 0 || state.loading}
           />
         </StyledHeaderColumn>
-        {/* TODO: just for testing the prototype */}
-        {hiddenProjects.length > 0 && <div>Hidden: {hiddenProjects.length}</div>}
       </StyledProjectHeader>
       {!collapsed && (
         <div>

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -6,7 +6,7 @@ import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import ClearIcon from "@material-ui/icons/Clear";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
-import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
+import { deriveHiddenStatus, deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
 import type { Group } from "./types";
 
 const StyledCount = styled.span({
@@ -129,6 +129,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           <StyledProjectTitle>
             {title}
             <StyledCount>
+              {/* TODO: should the numbers below reflect what's hidden? */}
               {checkedProjects.length}
               {numProjects > 0 && `/${numProjects}`}
             </StyledCount>
@@ -143,6 +144,8 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                 payload: { group },
               })
             }
+            // TODO: if everything in a upstream/downstream group is hidden but since we are preserving
+            // the checked status, should this reflect that everything is checked or not?
             checked={deriveSwitchStatus(state, group)}
             disabled={numProjects === 0 || state.loading}
           />
@@ -155,51 +158,54 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           )}
           {Object.keys(state[group])
             .sort()
-            .map(key => (
-              <StyledMenuItem key={key}>
-                <Checkbox
-                  name={key}
-                  size="small"
-                  disabled={state.loading}
-                  onChange={() =>
-                    dispatch({
-                      type: "TOGGLE_PROJECTS",
-                      payload: { group, projects: [key] },
-                    })
-                  }
-                  checked={!!state[group][key].checked}
-                />
-                <StyledMenuItemName>{key}</StyledMenuItemName>
-                <StyledHoverOptions hidden>
-                  <StyledOnlyButton
-                    onClick={() =>
-                      !state.loading &&
-                      dispatch({
-                        type: "ONLY_PROJECTS",
-                        payload: { group, projects: [key] },
-                      })
-                    }
-                  >
-                    Only
-                  </StyledOnlyButton>
-                  <StyledClearIcon>
-                    {state[group][key].custom && (
-                      <IconButton
+            .map(
+              key =>
+                !deriveHiddenStatus(state, group, key) && (
+                  <StyledMenuItem key={key}>
+                    <Checkbox
+                      name={key}
+                      size="small"
+                      disabled={state.loading}
+                      onChange={() =>
+                        dispatch({
+                          type: "TOGGLE_PROJECTS",
+                          payload: { group, projects: [key] },
+                        })
+                      }
+                      checked={!!state[group][key].checked}
+                    />
+                    <StyledMenuItemName>{key}</StyledMenuItemName>
+                    <StyledHoverOptions hidden>
+                      <StyledOnlyButton
                         onClick={() =>
                           !state.loading &&
                           dispatch({
-                            type: "REMOVE_PROJECTS",
+                            type: "ONLY_PROJECTS",
                             payload: { group, projects: [key] },
                           })
                         }
                       >
-                        <ClearIcon />
-                      </IconButton>
-                    )}
-                  </StyledClearIcon>
-                </StyledHoverOptions>
-              </StyledMenuItem>
-            ))}
+                        Only
+                      </StyledOnlyButton>
+                      <StyledClearIcon>
+                        {state[group][key].custom && (
+                          <IconButton
+                            onClick={() =>
+                              !state.loading &&
+                              dispatch({
+                                type: "REMOVE_PROJECTS",
+                                payload: { group, projects: [key] },
+                              })
+                            }
+                          >
+                            <ClearIcon />
+                          </IconButton>
+                        )}
+                      </StyledClearIcon>
+                    </StyledHoverOptions>
+                  </StyledMenuItem>
+                )
+            )}
         </div>
       )}
     </>

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -129,7 +129,6 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           <StyledProjectTitle>
             {title}
             <StyledCount>
-              {/* TODO: should the numbers below reflect what's hidden? */}
               {checkedProjects.length}
               {numProjects > 0 && `/${numProjects}`}
             </StyledCount>
@@ -144,8 +143,6 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                 payload: { group },
               })
             }
-            // TODO: if everything in a upstream/downstream group is hidden but since we are preserving
-            // the checked status, should this reflect that everything is checked or not?
             checked={deriveSwitchStatus(state, group)}
             disabled={numProjects === 0 || state.loading}
           />

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -118,6 +118,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
 
   const numProjects = Object.keys(state[group]).length;
   const checkedProjects = Object.keys(state[group]).filter(k => state[group][k].checked);
+  const hiddenProjects = Object.keys(state[group]).filter(k => state[group][k].hidden === false);
 
   return (
     <>
@@ -150,6 +151,8 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
             disabled={numProjects === 0 || state.loading}
           />
         </StyledHeaderColumn>
+        {/* TODO: just for testing the prototype */}
+        {hiddenProjects.length > 0 && <div>Hidden: {hiddenProjects.length}</div>}
       </StyledProjectHeader>
       {!collapsed && (
         <div>

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -6,7 +6,7 @@ import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import ClearIcon from "@material-ui/icons/Clear";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
-import { deriveHiddenStatus, deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
+import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
 import type { Group } from "./types";
 
 const StyledCount = styled.span({
@@ -158,54 +158,51 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           )}
           {Object.keys(state[group])
             .sort()
-            .map(
-              key =>
-                !deriveHiddenStatus(state, group, key) && (
-                  <StyledMenuItem key={key}>
-                    <Checkbox
-                      name={key}
-                      size="small"
-                      disabled={state.loading}
-                      onChange={() =>
-                        dispatch({
-                          type: "TOGGLE_PROJECTS",
-                          payload: { group, projects: [key] },
-                        })
-                      }
-                      checked={!!state[group][key].checked}
-                    />
-                    <StyledMenuItemName>{key}</StyledMenuItemName>
-                    <StyledHoverOptions hidden>
-                      <StyledOnlyButton
+            .map(key => (
+              <StyledMenuItem key={key}>
+                <Checkbox
+                  name={key}
+                  size="small"
+                  disabled={state.loading}
+                  onChange={() =>
+                    dispatch({
+                      type: "TOGGLE_PROJECTS",
+                      payload: { group, projects: [key] },
+                    })
+                  }
+                  checked={!!state[group][key].checked}
+                />
+                <StyledMenuItemName>{key}</StyledMenuItemName>
+                <StyledHoverOptions hidden>
+                  <StyledOnlyButton
+                    onClick={() =>
+                      !state.loading &&
+                      dispatch({
+                        type: "ONLY_PROJECTS",
+                        payload: { group, projects: [key] },
+                      })
+                    }
+                  >
+                    Only
+                  </StyledOnlyButton>
+                  <StyledClearIcon>
+                    {state[group][key].custom && (
+                      <IconButton
                         onClick={() =>
                           !state.loading &&
                           dispatch({
-                            type: "ONLY_PROJECTS",
+                            type: "REMOVE_PROJECTS",
                             payload: { group, projects: [key] },
                           })
                         }
                       >
-                        Only
-                      </StyledOnlyButton>
-                      <StyledClearIcon>
-                        {state[group][key].custom && (
-                          <IconButton
-                            onClick={() =>
-                              !state.loading &&
-                              dispatch({
-                                type: "REMOVE_PROJECTS",
-                                payload: { group, projects: [key] },
-                              })
-                            }
-                          >
-                            <ClearIcon />
-                          </IconButton>
-                        )}
-                      </StyledClearIcon>
-                    </StyledHoverOptions>
-                  </StyledMenuItem>
-                )
-            )}
+                        <ClearIcon />
+                      </IconButton>
+                    )}
+                  </StyledClearIcon>
+                </StyledHoverOptions>
+              </StyledMenuItem>
+            ))}
         </div>
       )}
     </>

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -140,7 +140,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
             onChange={() =>
               dispatch({
                 type: "TOGGLE_ENTIRE_GROUP",
-                payload: { group },
+                payload: { group, projects: Object.keys(state[group]) },
               })
             }
             checked={deriveSwitchStatus(state, group)}

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -8,7 +8,7 @@ import LayersIcon from "@material-ui/icons/Layers";
 import _ from "lodash";
 
 import { useDashUpdater } from "./dash-hooks";
-import { DispatchContext, StateContext } from "./helpers";
+import { deriveStateData, DispatchContext, StateContext } from "./helpers";
 import ProjectGroup from "./project-group";
 import selectorReducer from "./selector-reducer";
 import type { DashState, State } from "./types";
@@ -117,6 +117,10 @@ const ProjectSelector = () => {
     }
   }, [state[Group.PROJECTS]]);
 
+  // computes the final state for rendering across other components
+  // (ie. filters out upstream/downstreams that are "hidden")
+  const derivedState = React.useMemo(() => deriveStateData(state), [state]);
+
   // This hook updates the global dash state based on the currently selected projects for cards to consume (including upstreams and downstreams).
   React.useEffect(() => {
     const dashState: DashState = { projectData: {}, selected: [] };
@@ -164,7 +168,7 @@ const ProjectSelector = () => {
 
   return (
     <DispatchContext.Provider value={dispatch}>
-      <StateContext.Provider value={state}>
+      <StateContext.Provider value={derivedState}>
         <StyledSelectorContainer>
           <StyledWorkflowHeader>
             {/* TODO: change icon to match design */}

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -127,18 +127,18 @@ const ProjectSelector = () => {
 
     // Determine selected projects.
     const selected = new Set<string>();
-    _.forEach(Object.keys(state[Group.PROJECTS]), p => {
-      if (state[Group.PROJECTS][p].checked) {
+    _.forEach(Object.keys(derivedState[Group.PROJECTS]), p => {
+      if (derivedState[Group.PROJECTS][p].checked) {
         selected.add(p);
       }
     });
-    _.forEach(Object.keys(state[Group.DOWNSTREAM]), p => {
-      if (state[Group.DOWNSTREAM][p].checked) {
+    _.forEach(Object.keys(derivedState[Group.DOWNSTREAM]), p => {
+      if (derivedState[Group.DOWNSTREAM][p].checked) {
         selected.add(p);
       }
     });
-    _.forEach(Object.keys(state[Group.UPSTREAM]), p => {
-      if (state[Group.UPSTREAM][p].checked) {
+    _.forEach(Object.keys(derivedState[Group.UPSTREAM]), p => {
+      if (derivedState[Group.UPSTREAM][p].checked) {
         selected.add(p);
       }
     });

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -126,15 +126,21 @@ const selectorReducer = (state: State, action: Action): State => {
     }
     case "TOGGLE_ENTIRE_GROUP": {
       const newCheckedValue = !deriveSwitchStatus(state, action.payload.group);
-      const newState = { ...state };
-      newState[action.payload.group] = Object.fromEntries(
-        Object.keys(state[action.payload.group]).map(key => [
-          key,
-          { ...state[action.payload.group][key], checked: newCheckedValue },
-        ])
-      );
-
-      return newState;
+      return {
+        ...state,
+        [action.payload.group]: {
+          ...state[action.payload.group],
+          ...Object.fromEntries(
+            action.payload.projects.map(key => [
+              key,
+              {
+                ...state[action.payload.group][key],
+                checked: newCheckedValue,
+              },
+            ])
+          ),
+        },
+      };
     }
     // Background actions.
 

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -96,7 +96,6 @@ const selectorReducer = (state: State, action: Action): State => {
       return newState;
     }
     case "TOGGLE_PROJECTS": {
-      // TODO: hide exclusive upstreams and downstreams if group is PROJECTS
       return {
         ...state,
         [action.payload.group]: {


### PR DESCRIPTION
### Description
PR adds support for hiding exclusive upstreams/downstreams of a user-owned/custom project when the latter are unchecked.

PR flow derives the hidden status based on the checked value (ie `true`/`false`) of the user-owned/custom project. In this way, we don't need to handle the flow in the `actions` as a the hidden status of an upstream/downstream is influenced by various user actions (the toggle, the only button, the checkbox, if a new project is added, etc).

### Testing Performed
locally with real API data

### TODOs
- [x] hide an upstream/downstream if all unchecked projects share it

### Questions:
~1. how do we want to handle the switch status b/c we preserve the checked status of hidden projects. we can simply filter by "if checked but not hidden". the `deriveSwitchStatus` helper is used in other parts tho so we'll need to create a helper for the non-switch status use cases.~ **in latest commit, we pass the derived data to the components so the project count already correctly reflects what's _not_ hidden**

~2. how do we want to alert the user to the number of hidden projects. we currently display total number of projects in the chip; we can simply subtract the number of hidden from that project but should we let the users know that some projects have been hidden?~ **we can revisit after collecting user feedback on the hiding behavior**
