### PR TITLE
frontend: add support for propagating service state to project selector

### DIFF
--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -1,7 +1,7 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 
-import ProjectSelector from "./project-selector";
 import { useReducerState } from "./helpers";
+import ProjectSelector from "./project-selector";
 import { Group } from "./types";
 
 export interface WorkflowProps extends BaseWorkflowProps {}

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -1,6 +1,8 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 
 import ProjectSelector from "./project-selector";
+import { useReducerState } from "./helpers";
+import { Group } from "./types";
 
 export interface WorkflowProps extends BaseWorkflowProps {}
 
@@ -26,4 +28,4 @@ const register = (): WorkflowConfiguration => {
 
 export default register;
 
-export { ProjectSelector };
+export { Group, ProjectSelector, useReducerState };

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -56,7 +56,7 @@ const StyledProgressContainer = styled.div({
   },
 });
 
-const ProjectSelector = ({children}) => {
+const ProjectSelector = ({ children }) => {
   // On load, we'll request a list of owned projects and their upstreams and downstreams from the API.
   // The API will contain information about the relationships between projects and upstreams and downstreams.
   // By default, the owned projects will be checked and others will be unchecked.

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -56,7 +56,7 @@ const StyledProgressContainer = styled.div({
   },
 });
 
-const ProjectSelector = () => {
+const ProjectSelector = ({children}) => {
   // On load, we'll request a list of owned projects and their upstreams and downstreams from the API.
   // The API will contain information about the relationships between projects and upstreams and downstreams.
   // By default, the owned projects will be checked and others will be unchecked.
@@ -156,6 +156,7 @@ const ProjectSelector = () => {
           <Divider />
           <ProjectGroup title="Downstreams" group={Group.DOWNSTREAM} />
         </StyledSelectorContainer>
+        {children}
       </StateContext.Provider>
     </DispatchContext.Provider>
   );

--- a/frontend/workflows/projectSelector/tsconfig.json
+++ b/frontend/workflows/projectSelector/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./dist",
     "rootDir": "./src"
   },


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This adds support for the project selector to share its state with cards.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
