### PR TITLE
frontend: use typography in cards and add card header

### DIFF
--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import type { CardHeaderProps as MuiCardHeaderProps} from "@material-ui/core";
+import type { CardHeaderProps as MuiCardHeaderProps } from "@material-ui/core";
 import {
   Avatar,
   Card as MuiCard,
@@ -45,9 +45,7 @@ interface CardProps {
   children?: React.ReactNode | React.ReactNode[];
 }
 
-const Card = ({ children, ...props }: CardProps) => (
-  <StyledCard {...props}>{children}</StyledCard>
-);
+const Card = ({ children, ...props }: CardProps) => <StyledCard {...props}>{children}</StyledCard>;
 
 interface CardHeaderProps extends Pick<MuiCardHeaderProps, "avatar" | "title"> {}
 
@@ -61,7 +59,7 @@ const CardHeader = ({ avatar, title }: CardHeaderProps) => (
     avatar={avatar}
     title={<StyledTypography variant="h3">{title}</StyledTypography>}
   />
-)
+);
 
 const StyledLandingCard = styled(Card)({
   border: "none",
@@ -102,13 +100,13 @@ export const LandingCard = ({ group, title, description, onClick, ...props }: La
         </div>
         <div>
           <StyledTypography variant="h3">{title}</StyledTypography>
-          <StyledTypography style={{color: "rgba(13, 16, 48, 0.6)"}} variant="body2">{description}</StyledTypography>
+          <StyledTypography style={{ color: "rgba(13, 16, 48, 0.6)" }} variant="body2">
+            {description}
+          </StyledTypography>
         </div>
       </MuiCardContent>
     </CardActionArea>
   </StyledLandingCard>
 );
-
-
 
 export { Card, StyledCardContent as CardContent, CardHeader };

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import styled from "@emotion/styled";
+import type { CardHeaderProps as MuiCardHeaderProps} from "@material-ui/core";
 import {
   Avatar,
   Card as MuiCard,
   CardActionArea,
   CardActionAreaProps,
   CardContent as MuiCardContent,
-  Typography,
+  CardHeader as MuiCardHeader,
 } from "@material-ui/core";
+
+import { StyledTypography } from "./typography";
 
 const StyledCard = styled(MuiCard)({
   boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
@@ -28,13 +31,37 @@ const StyledCard = styled(MuiCard)({
   },
 });
 
-export type CardProps = {
-  children?: React.ReactNode | React.ReactNode[];
-};
+const StyledCardContent = styled(MuiCardContent)({
+  "&&": {
+    padding: "16px 0",
+  },
+  "> .MuiPaper-root": {
+    border: "0",
+    borderRadius: "0",
+  },
+});
 
-export const Card = ({ children, ...props }: CardProps) => (
+interface CardProps {
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+const Card = ({ children, ...props }: CardProps) => (
   <StyledCard {...props}>{children}</StyledCard>
 );
+
+interface CardHeaderProps extends Pick<MuiCardHeaderProps, "avatar" | "title"> {}
+
+const CardHeader = ({ avatar, title }: CardHeaderProps) => (
+  <MuiCardHeader
+    style={{
+      background: "#EBEDFB",
+      padding: "16px",
+    }}
+    disableTypography
+    avatar={avatar}
+    title={<StyledTypography variant="h3">{title}</StyledTypography>}
+  />
+)
 
 const StyledLandingCard = styled(Card)({
   border: "none",
@@ -55,16 +82,6 @@ const StyledLandingCard = styled(Card)({
     color: "rgba(13, 16, 48, 0.38)",
     backgroundColor: "rgba(13, 16, 48, 0.12)",
   },
-
-  "& .title": {
-    fontSize: "20px",
-    fontWeight: 700,
-  },
-
-  "& .description": {
-    marginTop: "5px",
-    color: "rgba(13, 16, 48, 0.6)",
-  },
 });
 
 export interface LandingCardProps extends Pick<CardActionAreaProps, "onClick"> {
@@ -84,14 +101,14 @@ export const LandingCard = ({ group, title, description, onClick, ...props }: La
           <span>{group}</span>
         </div>
         <div>
-          <Typography className="title">{title}</Typography>
-          <Typography className="description">{description}</Typography>
+          <StyledTypography variant="h3">{title}</StyledTypography>
+          <StyledTypography style={{color: "rgba(13, 16, 48, 0.6)"}} variant="body2">{description}</StyledTypography>
         </div>
       </MuiCardContent>
     </CardActionArea>
   </StyledLandingCard>
 );
 
-export const CardContent = MuiCardContent;
 
-export default Card;
+
+export { Card, StyledCardContent as CardContent, CardHeader };

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import type { CardHeaderProps as MuiCardHeaderProps } from "@material-ui/core";
+import type {
+  CardContentProps as MuiCardContentProps,
+  CardHeaderProps as MuiCardHeaderProps,
+} from "@material-ui/core";
 import {
   Avatar,
   Card as MuiCard,
@@ -32,16 +35,13 @@ const StyledCard = styled(MuiCard)({
 });
 
 const StyledCardContent = styled(MuiCardContent)({
-  "&&": {
-    padding: "16px 0",
-  },
   "> .MuiPaper-root": {
     border: "0",
     borderRadius: "0",
   },
 });
 
-interface CardProps {
+export interface CardProps {
   children?: React.ReactNode | React.ReactNode[];
 }
 
@@ -59,6 +59,12 @@ const CardHeader = ({ avatar, title }: CardHeaderProps) => (
     avatar={avatar}
     title={<StyledTypography variant="h3">{title}</StyledTypography>}
   />
+);
+
+interface CardContentProps extends MuiCardContentProps {}
+
+const CardContent = ({ children, ...props }: CardContentProps) => (
+  <StyledCardContent {...props}>{children}</StyledCardContent>
 );
 
 const StyledLandingCard = styled(Card)({
@@ -91,7 +97,7 @@ export interface LandingCardProps extends Pick<CardActionAreaProps, "onClick"> {
 export const LandingCard = ({ group, title, description, onClick, ...props }: LandingCardProps) => (
   <StyledLandingCard {...props}>
     <CardActionArea onClick={onClick}>
-      <MuiCardContent>
+      <CardContent>
         <div className="header">
           <div className="icon">
             <Avatar>{group.charAt(0)}</Avatar>
@@ -104,9 +110,9 @@ export const LandingCard = ({ group, title, description, onClick, ...props }: La
             {description}
           </StyledTypography>
         </div>
-      </MuiCardContent>
+      </CardContent>
     </CardActionArea>
   </StyledLandingCard>
 );
 
-export { Card, StyledCardContent as CardContent, CardHeader };
+export { Card, CardContent, CardHeader };

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "./accordion";
 import ClutchApp from "./AppProvider";
 import { Button, ButtonGroup, ClipboardButton, IconButton } from "./button";
-import { Card, CardContent } from "./card";
+import { Card, CardContent, CardHeader } from "./card";
 import { Chip } from "./chip";
 import Confirmation from "./confirmation";
 import { useWizardContext, WizardContext } from "./Contexts";
@@ -45,7 +45,7 @@ import {
   TableRowActions,
   TreeTable,
 } from "./Table";
-import Typography from "./typography";
+import { Typography } from "./typography";
 
 export type { BaseWorkflowProps, WorkflowConfiguration } from "./AppProvider/workflow";
 export type { ButtonProps } from "./button";
@@ -65,6 +65,7 @@ export {
   ButtonGroup,
   Card,
   CardContent,
+  CardHeader,
   Checkbox,
   CheckboxPanel,
   Chip,

--- a/frontend/packages/core/src/stories/typography.stories.tsx
+++ b/frontend/packages/core/src/stories/typography.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type { Meta, Story } from "@storybook/react";
 
 import type { TypographyProps } from "../typography";
-import Typography, { VARIANTS } from "../typography";
+import { Typography, VARIANTS } from "../typography";
 
 export default {
   title: "Core/Typography",

--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -139,4 +139,4 @@ const Typography = ({ variant, children }: TypographyProps) => {
   return <StyledTypography variant={variant}>{children}</StyledTypography>;
 };
 
-export default Typography;
+export { StyledTypography, Typography };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add `CardHeader` component and use Typography component throughout card

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual