### PR TITLE
project selector: add new action type to hide upstreams/downstreams

### DIFF
--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -5,9 +5,10 @@ import IconButton from "@material-ui/core/IconButton";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import ClearIcon from "@material-ui/icons/Clear";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import RemoveRedEyeIcon from "@material-ui/icons/RemoveRedEye";
 
 import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
-import type { Group } from "./types";
+import { Group } from "./types";
 
 const StyledCount = styled.span({
   color: "rgba(13, 16, 48, 0.6)",
@@ -82,6 +83,20 @@ const StyledClearIcon = styled.span({
   },
 });
 
+const StyledHideIcon = styled.span({
+  width: "24px",
+  ".MuiIconButton-root": {
+    padding: "6px",
+    color: "rgba(13, 16, 48, 0.38)",
+  },
+  ".MuiIconButton-root:hover": {
+    backgroundColor: "rgb(245, 246, 253)",
+  },
+  ".MuiIconButton-root:active": {
+    backgroundColor: "rgba(0,0,0, 0.1)",
+  },
+});
+
 const StyledOnlyButton = styled.button({
   border: "none",
   cursor: "pointer",
@@ -100,6 +115,7 @@ const StyledOnlyButton = styled.button({
   },
 });
 
+// TODO: fix alignment among the 3 icons
 const StyledHoverOptions = styled.span({
   alignItems: "center",
 });
@@ -128,6 +144,10 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           </StyledHeaderColumn>
           <StyledProjectTitle>
             {title}
+            {/* TODO: perhaps we should designate how many projects are hidden instead of trying to update the
+            the total count of checked projects/number of projects as we're not changing the checked state of hidden
+            projects and we're not technically removing them from their respective project groups
+             */}
             <StyledCount>
               {checkedProjects.length}
               {numProjects > 0 && `/${numProjects}`}
@@ -155,51 +175,69 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           )}
           {Object.keys(state[group])
             .sort()
-            .map(key => (
-              <StyledMenuItem key={key}>
-                <Checkbox
-                  name={key}
-                  size="small"
-                  disabled={state.loading}
-                  onChange={() =>
-                    dispatch({
-                      type: "TOGGLE_PROJECTS",
-                      payload: { group, projects: [key] },
-                    })
-                  }
-                  checked={!!state[group][key].checked}
-                />
-                <StyledMenuItemName>{key}</StyledMenuItemName>
-                <StyledHoverOptions hidden>
-                  <StyledOnlyButton
-                    onClick={() =>
-                      !state.loading &&
-                      dispatch({
-                        type: "ONLY_PROJECTS",
-                        payload: { group, projects: [key] },
-                      })
-                    }
-                  >
-                    Only
-                  </StyledOnlyButton>
-                  <StyledClearIcon>
-                    {state[group][key].custom && (
-                      <IconButton
+            .map(
+              key =>
+                !state[group][key].hidden && (
+                  <StyledMenuItem key={key}>
+                    <Checkbox
+                      name={key}
+                      size="small"
+                      disabled={state.loading}
+                      onChange={() =>
+                        dispatch({
+                          type: "TOGGLE_PROJECTS",
+                          payload: { group, projects: [key] },
+                        })
+                      }
+                      checked={!!state[group][key].checked}
+                    />
+                    <StyledMenuItemName>{key}</StyledMenuItemName>
+                    <StyledHoverOptions hidden>
+                      <StyledOnlyButton
                         onClick={() =>
                           !state.loading &&
                           dispatch({
-                            type: "REMOVE_PROJECTS",
+                            type: "ONLY_PROJECTS",
                             payload: { group, projects: [key] },
                           })
                         }
                       >
-                        <ClearIcon />
-                      </IconButton>
-                    )}
-                  </StyledClearIcon>
-                </StyledHoverOptions>
-              </StyledMenuItem>
-            ))}
+                        Only
+                      </StyledOnlyButton>
+                      <StyledClearIcon>
+                        {state[group][key].custom && (
+                          <IconButton
+                            onClick={() =>
+                              !state.loading &&
+                              dispatch({
+                                type: "REMOVE_PROJECTS",
+                                payload: { group, projects: [key] },
+                              })
+                            }
+                          >
+                            <ClearIcon />
+                          </IconButton>
+                        )}
+                      </StyledClearIcon>
+                      {group === Group.PROJECTS && (
+                        <StyledHideIcon>
+                          <IconButton
+                            onClick={() =>
+                              !state.loading &&
+                              dispatch({
+                                type: "HIDE_PROJECTS",
+                                payload: { group, projects: [key] },
+                              })
+                            }
+                          >
+                            <RemoveRedEyeIcon />
+                          </IconButton>
+                        </StyledHideIcon>
+                      )}
+                    </StyledHoverOptions>
+                  </StyledMenuItem>
+                )
+            )}
         </div>
       )}
     </>

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -6,6 +6,7 @@ import {
   exclusiveProjectDependencies,
   PROJECT_TYPE_URL,
   updateGroupstate,
+  updateHiddenState,
 } from "./helpers";
 import type { Action, State } from "./types";
 import { Group } from "./types";
@@ -14,6 +15,7 @@ const selectorReducer = (state: State, action: Action): State => {
   switch (action.type) {
     // User actions.
 
+    // TODO: when a project is added, we should check if its upstream(s)/downstream(s) are marked as hidden and unhide them
     case "ADD_PROJECTS": {
       // a given custom project may already exist in the group so don't trigger a state update for the duplicate(s)
       const uniqueCustomProjects = action.payload.projects.filter(
@@ -96,7 +98,6 @@ const selectorReducer = (state: State, action: Action): State => {
       return newState;
     }
     case "TOGGLE_PROJECTS": {
-      // TODO: hide exclusive upstreams and downstreams if group is PROJECTS
       return {
         ...state,
         [action.payload.group]: {
@@ -124,6 +125,18 @@ const selectorReducer = (state: State, action: Action): State => {
       );
 
       return newState;
+    }
+    case "HIDE_PROJECTS": {
+      // TODO: do we uncheck the Group.Project as well?
+
+      // we only support hiding upstreams/downstreams of Group.Projects
+      if (action.payload.group !== Group.PROJECTS) {
+        return state;
+      }
+
+      // TODO: currently the payload.projects will only have 1 project but in the future we might
+      // support bulk hiding
+      return updateHiddenState(state, action.payload.group, action.payload.projects[0]);
     }
     case "TOGGLE_ENTIRE_GROUP": {
       const newCheckedValue = !deriveSwitchStatus(state, action.payload.group);

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -12,7 +12,8 @@ type UserActionKind =
   | "REMOVE_PROJECTS"
   | "TOGGLE_PROJECTS"
   | "TOGGLE_ENTIRE_GROUP"
-  | "ONLY_PROJECTS";
+  | "ONLY_PROJECTS"
+  | "HIDE_PROJECTS";
 
 interface UserAction {
   type: UserActionKind;
@@ -51,6 +52,9 @@ interface GroupState {
   [projectName: string]: ProjectState;
 }
 
+// TODO: add new field to designate whether a Group.Project has hidden upstreams/downstreams so that way we can
+// support hiding all upstreams/downstreams if they are shared by other Group.Project who have already opted to
+// hide their dependencies
 export interface ProjectState {
   checked: boolean;
   // TODO: hidden should be derived?


### PR DESCRIPTION
### Description
PR adds support for hiding upstreams/downstreams of a user-owned/custom project when the eye icon is clicked

### Testing Performed
Locally

### TODOs
- [ ] add a new field in ProjectState to designate whether a project's dependencies have been hidden. In this we, we can support the next todo below
- [ ] if a dependency is shared by all other projects that have already hidden their other dependencies, then hide this dependency as well
- [ ] when a new project is added, check if any of its dependencies have been hidden and unhide them