### PR TITLE
dash: use a dash context updated by selector

### DIFF
--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+import type { DashAction, DashState } from "./types";
+
+export const DashStateContext = React.createContext<DashState | undefined>(undefined);
+
+export const DashDispatchContext = React.createContext<(action: DashAction) => void | undefined>(
+  undefined
+);
+
+type useDashUpdaterReturn = {
+  updateSelected: (state: DashState) => void;
+};
+
+export const useDashUpdater = (): useDashUpdaterReturn => {
+  const dispatch = React.useContext(DashDispatchContext);
+
+  return {
+    updateSelected: projects => {
+      dispatch({ type: "UPDATE_SELECTED", payload: projects });
+    },
+  };
+};
+
+export const useDashState = () => {
+  return React.useContext(DashStateContext);
+};

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -1,35 +1,8 @@
 import * as React from "react";
+
+import { DashDispatchContext, DashStateContext } from "./dash-hooks";
 import ProjectSelector from "./project-selector";
-import type { DashState } from "./types";
-
-type DashActionKind = "UPDATE_SELECTED";
-
-interface DashAction {
-  type: DashActionKind;
-  payload: DashState;
-}
-
-const StateContext = React.createContext<DashState | undefined>(undefined);
-
-export const useDashState = () => {
-  return React.useContext(StateContext);
-};
-
-const DispatchContext = React.createContext<(action: DashAction) => void | undefined>(undefined);
-
-type useDashUpdater = {
-  updateSelected: (state: DashState) => void;
-};
-
-export const useDashUpdater = (): useDashUpdater => {
-  const dispatch = React.useContext(DispatchContext);
-
-  return {
-    updateSelected: projects => {
-      dispatch({ type: "UPDATE_SELECTED", payload: projects });
-    },
-  };
-};
+import type { DashAction, DashState } from "./types";
 
 const initialState = {
   selected: [],
@@ -46,17 +19,17 @@ const dashReducer = (state: DashState, action: DashAction): DashState => {
   }
 };
 
-export const Dash = ({children}) => {
+const Dash = ({ children }) => {
   const [state, dispatch] = React.useReducer(dashReducer, initialState);
 
   return (
-    <DispatchContext.Provider value={dispatch}>
-      <StateContext.Provider value={state}>
+    <DashDispatchContext.Provider value={dispatch}>
+      <DashStateContext.Provider value={state}>
         <ProjectSelector />
-        <div>
-          {children}
-        </div>
-      </StateContext.Provider>
-    </DispatchContext.Provider>
+        <div>{children}</div>
+      </DashStateContext.Provider>
+    </DashDispatchContext.Provider>
   );
 };
+
+export default Dash;

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import ProjectSelector from "./project-selector";
+import type { DashState } from "./types";
+
+type DashActionKind = "UPDATE_SELECTED";
+
+interface DashAction {
+  type: DashActionKind;
+  payload: DashState;
+}
+
+const StateContext = React.createContext<DashState | undefined>(undefined);
+
+export const useDashState = () => {
+  return React.useContext(StateContext);
+};
+
+const DispatchContext = React.createContext<(action: DashAction) => void | undefined>(undefined);
+
+type useDashUpdater = {
+  updateSelected: (state: DashState) => void;
+};
+
+export const useDashUpdater = (): useDashUpdater => {
+  const dispatch = React.useContext(DispatchContext);
+
+  return {
+    updateSelected: projects => {
+      dispatch({ type: "UPDATE_SELECTED", payload: projects });
+    },
+  };
+};
+
+const initialState = {
+  selected: [],
+  projectData: {},
+};
+
+const dashReducer = (state: DashState, action: DashAction): DashState => {
+  switch (action.type) {
+    case "UPDATE_SELECTED": {
+      return action.payload;
+    }
+    default:
+      throw new Error("not implemented (should be unreachable)");
+  }
+};
+
+export const Dash = ({children}) => {
+  const [state, dispatch] = React.useReducer(dashReducer, initialState);
+
+  return (
+    <DispatchContext.Provider value={dispatch}>
+      <StateContext.Provider value={state}>
+        <ProjectSelector />
+        <div>
+          {children}
+        </div>
+      </StateContext.Provider>
+    </DispatchContext.Provider>
+  );
+};

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -1,7 +1,6 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
-import { Dash, useDashState } from "./dash";
 
-import { Group } from "./types";
+import { Dash, useDashState } from "./dash-hooks";
 
 export interface WorkflowProps extends BaseWorkflowProps {}
 

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -1,7 +1,6 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
+import { Dash, useDashState } from "./dash";
 
-import { useReducerState } from "./helpers";
-import ProjectSelector from "./project-selector";
 import { Group } from "./types";
 
 export interface WorkflowProps extends BaseWorkflowProps {}
@@ -9,18 +8,18 @@ export interface WorkflowProps extends BaseWorkflowProps {}
 const register = (): WorkflowConfiguration => {
   return {
     developer: {
-      name: "hello@example.com",
-      contactUrl: "mailto:hello@example.com",
+      name: "clutch@lyft.com",
+      contactUrl: "mailto:clutch@lyft.com",
     },
-    path: "projectselector",
-    group: "Project Selector",
-    displayName: "Project Selector",
+    path: "dash",
+    group: "Dash",
+    displayName: "Dash",
     routes: {
       landing: {
         path: "/",
-        displayName: "Project Selector",
-        description: "Filter your projects.",
-        component: ProjectSelector,
+        displayName: "Dash",
+        description: "Display helpful information for multiple services.",
+        component: Dash,
       },
     },
   };
@@ -28,4 +27,4 @@ const register = (): WorkflowConfiguration => {
 
 export default register;
 
-export { Group, ProjectSelector, useReducerState };
+export { Dash, useDashState };

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -1,6 +1,6 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 
-import type Dash from "./dash";
+import Dash from "./dash";
 import { useDashState } from "./dash-hooks";
 
 export interface WorkflowProps extends BaseWorkflowProps {}

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -1,6 +1,7 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 
-import { Dash, useDashState } from "./dash-hooks";
+import type Dash from "./dash";
+import { useDashState } from "./dash-hooks";
 
 export interface WorkflowProps extends BaseWorkflowProps {}
 

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -10,8 +10,9 @@ import _ from "lodash";
 import { DispatchContext, StateContext } from "./helpers";
 import ProjectGroup from "./project-group";
 import selectorReducer from "./selector-reducer";
-import type { State } from "./types";
+import type { DashState, State } from "./types";
 import { Group } from "./types";
+import { useDashUpdater } from "./dash";
 
 const initialState: State = {
   [Group.PROJECTS]: {},
@@ -56,7 +57,7 @@ const StyledProgressContainer = styled.div({
   },
 });
 
-const ProjectSelector = ({ children }) => {
+const ProjectSelector = () => {
   // On load, we'll request a list of owned projects and their upstreams and downstreams from the API.
   // The API will contain information about the relationships between projects and upstreams and downstreams.
   // By default, the owned projects will be checked and others will be unchecked.
@@ -64,6 +65,8 @@ const ProjectSelector = ({ children }) => {
   // TODO: If a project is rechecked, the checks were preserved.
 
   const [customProject, setCustomProject] = React.useState("");
+
+  const { updateSelected } = useDashUpdater();
 
   const [state, dispatch] = React.useReducer(selectorReducer, initialState);
 
@@ -114,6 +117,38 @@ const ProjectSelector = ({ children }) => {
     }
   }, [state[Group.PROJECTS]]);
 
+  // This hook updates the global dash state based on the currently selected projects for cards to consume (including upstreams and downstreams).
+  React.useEffect(() => {
+    const dashState: DashState = {projectData: {}, selected: []};
+
+    // Determine selected projects.
+    const selected = new Set<string>();
+    _.forEach(Object.keys(state[Group.PROJECTS]), p => {
+      if (state[Group.PROJECTS][p].checked) {
+        selected.add(p);
+      }
+    });
+    _.forEach(Object.keys(state[Group.DOWNSTREAM]), p => {
+      if (state[Group.DOWNSTREAM][p].checked) {
+        selected.add(p);
+      }
+    });
+    _.forEach(Object.keys(state[Group.UPSTREAM]), p => {
+      if (state[Group.UPSTREAM][p].checked) {
+        selected.add(p);
+      }
+    });
+    dashState.selected = Array.from(selected).sort();
+
+    // Collect project data.
+    _.forEach(dashState.selected), p => {
+      dashState.projectData[p] = state.projectData[p];
+    }
+
+    // Update!
+    updateSelected(dashState);
+  }, [state]);
+
   const handleAdd = () => {
     if (customProject === "") {
       return;
@@ -156,7 +191,6 @@ const ProjectSelector = ({ children }) => {
           <Divider />
           <ProjectGroup title="Downstreams" group={Group.DOWNSTREAM} />
         </StyledSelectorContainer>
-        {children}
       </StateContext.Provider>
     </DispatchContext.Provider>
   );

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -7,12 +7,12 @@ import { Divider, LinearProgress } from "@material-ui/core";
 import LayersIcon from "@material-ui/icons/Layers";
 import _ from "lodash";
 
+import { useDashUpdater } from "./dash-hooks";
 import { DispatchContext, StateContext } from "./helpers";
 import ProjectGroup from "./project-group";
 import selectorReducer from "./selector-reducer";
 import type { DashState, State } from "./types";
 import { Group } from "./types";
-import { useDashUpdater } from "./dash";
 
 const initialState: State = {
   [Group.PROJECTS]: {},
@@ -119,7 +119,7 @@ const ProjectSelector = () => {
 
   // This hook updates the global dash state based on the currently selected projects for cards to consume (including upstreams and downstreams).
   React.useEffect(() => {
-    const dashState: DashState = {projectData: {}, selected: []};
+    const dashState: DashState = { projectData: {}, selected: [] };
 
     // Determine selected projects.
     const selected = new Set<string>();
@@ -141,9 +141,9 @@ const ProjectSelector = () => {
     dashState.selected = Array.from(selected).sort();
 
     // Collect project data.
-    _.forEach(dashState.selected), p => {
+    _.forEach(dashState.selected, p => {
       dashState.projectData[p] = state.projectData[p];
-    }
+    });
 
     // Update!
     updateSelected(dashState);

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -62,6 +62,13 @@ export interface DashState {
   // Contains the names of selected projects, upstreams, and downstreams merged together.
   selected: string[];
 
-  // Contains a map of project names to the full project data. 
+  // Contains a map of project names to the full project data.
   projectData: { [projectName: string]: IClutch.core.project.v1.IProject };
+}
+
+export type DashActionKind = "UPDATE_SELECTED";
+
+export interface DashAction {
+  type: DashActionKind;
+  payload: DashState;
 }

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -57,3 +57,11 @@ export interface ProjectState {
   hidden?: boolean; // upstreams and downstreams are hidden when their parent is unchecked unless other parents also use them.
   custom?: boolean;
 }
+
+export interface DashState {
+  // Contains the names of selected projects, upstreams, and downstreams merged together.
+  selected: string[];
+
+  // Contains a map of project names to the full project data. 
+  projectData: { [projectName: string]: IClutch.core.project.v1.IProject };
+}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Instead of directly exposing the selector's context and all of its internal implementation details, we add a new dash context that will be used to track the selected projects and eventually events for the timeline view.

### Testing Performed
Integration with private card.

### TODOs
- [ ] Test with private card.
