### PR TITLE
e2e test: add 15s to startup wait

### DIFF
--- a/tools/frontend-e2e.sh
+++ b/tools/frontend-e2e.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 BE_STARTUP_COUNT=0
 FE_STARTUP_COUNT=0
-STARTUP_WAIT=30
+STARTUP_WAIT=45
 
 make backend-dev-mock &
 until curl --output /dev/null --silent --fail http://localhost:8080/healthcheck; do


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
See if it fixes flakiness on main. Hypothesis is that cache is separate on main and PRs which could cause main to run over a little bit.

### Testing Performed
CI