### PR TITLE
backend: github service: add User object to response

### DIFF
--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -364,8 +364,7 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
 type Commit struct {
 	Files   []*githubv3.CommitFile
 	Message string
-	Author  *githubv3.CommitAuthor
-	User    *githubv3.User
+	Author  *githubv3.User
 }
 
 func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
@@ -373,13 +372,14 @@ func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The author (our User) is the person who originally wrote the code. The committer (our Author)
+	// Distinction between author and commiter:
+	// The author is the person who originally wrote the code. The committer
 	// is assumed to be the person who committed the code on behalf of the original author.
+	// Currently we are using the Author (Github) rather than commit Author (Git)
 	return &Commit{
 		Files:   commit.Files,
 		Message: commit.GetCommit().GetMessage(),
-		Author:  commit.GetCommit().GetAuthor(),
-		User:    commit.GetAuthor(),
+		Author:  commit.GetAuthor(),
 	}, nil
 }
 

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -372,9 +372,7 @@ func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Distinction between author and commiter:
-	// The author is the person who originally wrote the code. The committer
-	// is assumed to be the person who committed the code on behalf of the original author.
+
 	// Currently we are using the Author (Github) rather than commit Author (Git)
 	return &Commit{
 		Files:   commit.Files,

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -362,9 +362,11 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
 }
 
 type Commit struct {
-	Files   []*githubv3.CommitFile
-	Message string
-	Author  *githubv3.CommitAuthor
+	Files           []*githubv3.CommitFile
+	Message         string
+	Author          *githubv3.CommitAuthor
+	AuthorAvatarURL *string
+	AuthorID        int64
 }
 
 func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
@@ -373,9 +375,11 @@ func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
 		return nil, err
 	}
 	return &Commit{
-		Files:   commit.Files,
-		Message: commit.GetCommit().GetMessage(),
-		Author:  commit.GetCommit().GetAuthor(),
+		Files:           commit.Files,
+		Message:         commit.GetCommit().GetMessage(),
+		Author:          commit.GetCommit().GetAuthor(),
+		AuthorAvatarURL: commit.Author.AvatarURL,
+		AuthorID:        commit.Author.GetID(),
 	}, nil
 }
 

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -374,13 +374,20 @@ func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Commit{
-		Files:           commit.Files,
-		Message:         commit.GetCommit().GetMessage(),
-		Author:          commit.GetCommit().GetAuthor(),
-		AuthorAvatarURL: commit.Author.AvatarURL,
-		AuthorID:        commit.Author.GetID(),
-	}, nil
+	retCommit := &Commit{
+		Files:   commit.Files,
+		Message: commit.GetCommit().GetMessage(),
+		Author:  commit.GetCommit().GetAuthor(),
+	}
+
+	if commit.Author != nil {
+		if commit.Author.AvatarURL != nil {
+			retCommit.AuthorAvatarURL = commit.Author.AvatarURL
+		}
+		retCommit.AuthorID = commit.Author.GetID()
+	}
+
+	return retCommit, nil
 }
 
 func (s *svc) GetRepository(ctx context.Context, repo *RemoteRef) (*Repository, error) {

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -373,6 +373,8 @@ func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The author (our User) is the person who originally wrote the code. The committer (our Author)
+	// is assumed to be the person who committed the code on behalf of the original author.
 	return &Commit{
 		Files:   commit.Files,
 		Message: commit.GetCommit().GetMessage(),

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -362,11 +362,10 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
 }
 
 type Commit struct {
-	Files           []*githubv3.CommitFile
-	Message         string
-	Author          *githubv3.CommitAuthor
-	AuthorAvatarURL *string
-	AuthorID        int64
+	Files   []*githubv3.CommitFile
+	Message string
+	Author  *githubv3.CommitAuthor
+	User    *githubv3.User
 }
 
 func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
@@ -374,20 +373,12 @@ func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-	retCommit := &Commit{
+	return &Commit{
 		Files:   commit.Files,
 		Message: commit.GetCommit().GetMessage(),
 		Author:  commit.GetCommit().GetAuthor(),
-	}
-
-	if commit.Author != nil {
-		if commit.Author.AvatarURL != nil {
-			retCommit.AuthorAvatarURL = commit.Author.AvatarURL
-		}
-		retCommit.AuthorID = commit.Author.GetID()
-	}
-
-	return retCommit, nil
+		User:    commit.Author,
+	}, nil
 }
 
 func (s *svc) GetRepository(ctx context.Context, repo *RemoteRef) (*Repository, error) {

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -377,7 +377,7 @@ func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
 		Files:   commit.Files,
 		Message: commit.GetCommit().GetMessage(),
 		Author:  commit.GetCommit().GetAuthor(),
-		User:    commit.Author,
+		User:    commit.GetAuthor(),
 	}, nil
 }
 

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -364,12 +364,14 @@ func TestCompareCommits(t *testing.T) {
 }
 
 var getCommitsTests = []struct {
-	name        string
-	errorText   string
-	mockRepo    *mockRepositories
-	file        string
-	message     string
-	authorLogin string
+	name            string
+	errorText       string
+	mockRepo        *mockRepositories
+	file            string
+	message         string
+	authorLogin     string
+	authorAvatarURL string
+	authorID        int64
 }{
 	{
 		name:      "v3 error",
@@ -377,11 +379,13 @@ var getCommitsTests = []struct {
 		errorText: "we've had a problem",
 	},
 	{
-		name:        "happy path",
-		mockRepo:    &mockRepositories{},
-		file:        "testfile.go",
-		message:     "committing some changes (#1)",
-		authorLogin: "foobar",
+		name:            "happy path",
+		mockRepo:        &mockRepositories{},
+		file:            "testfile.go",
+		message:         "committing some changes (#1)",
+		authorLogin:     "foobar",
+		authorAvatarURL: "https://foo.bar/baz.png",
+		authorID:        1234,
 	},
 }
 
@@ -416,6 +420,12 @@ func TestGetCommit(t *testing.T) {
 			a.Equal(tt.file, *commit.Files[0].Filename)
 			a.Equal(tt.message, commit.Message)
 			a.Equal(tt.authorLogin, *commit.Author.Login)
+			if commit.AuthorAvatarURL != nil {
+				a.Equal(tt.authorAvatarURL, *commit.AuthorAvatarURL)
+			}
+			if commit.AuthorID != 0 {
+				a.Equal(tt.authorID, commit.AuthorID)
+			}
 			a.Nil(err)
 		})
 	}

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -420,11 +420,9 @@ func TestGetCommit(t *testing.T) {
 			a.Equal(tt.file, *commit.Files[0].Filename)
 			a.Equal(tt.message, commit.Message)
 			a.Equal(tt.authorLogin, *commit.Author.Login)
-			if commit.AuthorAvatarURL != nil {
-				a.Equal(tt.authorAvatarURL, *commit.AuthorAvatarURL)
-			}
-			if commit.AuthorID != 0 {
-				a.Equal(tt.authorID, commit.AuthorID)
+			if commit.User != nil {
+				a.Equal(tt.authorAvatarURL, *commit.User.AvatarURL)
+				a.Equal(tt.authorID, *commit.User.ID)
 			}
 			a.Nil(err)
 		})

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -420,9 +420,9 @@ func TestGetCommit(t *testing.T) {
 			a.Equal(tt.file, *commit.Files[0].Filename)
 			a.Equal(tt.message, commit.Message)
 			a.Equal(tt.authorLogin, *commit.Author.Login)
-			if commit.User != nil {
-				a.Equal(tt.authorAvatarURL, *commit.User.AvatarURL)
-				a.Equal(tt.authorID, *commit.User.ID)
+			if commit.Author != nil {
+				a.Equal(tt.authorAvatarURL, *commit.Author.AvatarURL)
+				a.Equal(tt.authorID, *commit.Author.ID)
 			}
 			a.Nil(err)
 		})

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -383,7 +383,6 @@ var getCommitsTests = []struct {
 		mockRepo:        &mockRepositories{},
 		file:            "testfile.go",
 		message:         "committing some changes (#1)",
-		authorLogin:     "foobar",
 		authorAvatarURL: "https://foo.bar/baz.png",
 		authorID:        1234,
 	},
@@ -419,7 +418,6 @@ func TestGetCommit(t *testing.T) {
 			}
 			a.Equal(tt.file, *commit.Files[0].Filename)
 			a.Equal(tt.message, commit.Message)
-			a.Equal(tt.authorLogin, *commit.Author.Login)
 			if commit.Author != nil {
 				a.Equal(tt.authorAvatarURL, *commit.Author.AvatarURL)
 				a.Equal(tt.authorID, *commit.Author.ID)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It is useful to have some of the other fields that are returned by the go githubv3 API such as avatarURL and ID
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
