### PR TITLE
project-selector: add tooltip component

### DIFF
--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -4,7 +4,7 @@ import type { ClutchError } from "@clutch-sh/core";
 import { client, TextField, userId } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import { Divider, LinearProgress } from "@material-ui/core";
-import LayersIcon from "@material-ui/icons/Layers";
+import LayersOutlinedIcon from "@material-ui/icons/LayersOutlined";
 import _ from "lodash";
 
 import { useDashUpdater } from "./dash-hooks";
@@ -172,8 +172,7 @@ const ProjectSelector = () => {
       <StateContext.Provider value={derivedState}>
         <StyledSelectorContainer>
           <StyledWorkflowHeader>
-            {/* TODO: change icon to match design */}
-            <LayersIcon />
+            <LayersOutlinedIcon />
             <StyledWorkflowTitle>Dash</StyledWorkflowTitle>
             <StyledTooltip />
           </StyledWorkflowHeader>

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -11,6 +11,7 @@ import { useDashUpdater } from "./dash-hooks";
 import { deriveStateData, DispatchContext, StateContext } from "./helpers";
 import ProjectGroup from "./project-group";
 import selectorReducer from "./selector-reducer";
+import StyledTooltip from "./tooltip";
 import type { DashState, State } from "./types";
 import { Group } from "./types";
 
@@ -174,6 +175,7 @@ const ProjectSelector = () => {
             {/* TODO: change icon to match design */}
             <LayersIcon />
             <StyledWorkflowTitle>Dash</StyledWorkflowTitle>
+            <StyledTooltip />
           </StyledWorkflowHeader>
           <StyledProgressContainer>
             {state.loading && <LinearProgress color="secondary" />}

--- a/frontend/workflows/projectSelector/src/tooltip.tsx
+++ b/frontend/workflows/projectSelector/src/tooltip.tsx
@@ -47,20 +47,22 @@ const StyledTooltip = () => {
           <StyledToolTipContainer>
             <StyledTooltipTitle>Projects - </StyledTooltipTitle>
             <StyledTooltipBody>
-              are user-owned or searched services, libraries, mobile apps, etc. Unchecking a project hides its respective upstream
-              and downstream dependencies.
+              are user-owned or searched services, libraries, mobile apps, etc. Unchecking a project
+              hides its respective upstream and downstream dependencies.
             </StyledTooltipBody>
           </StyledToolTipContainer>
           <StyledToolTipContainer>
             <StyledTooltipTitle>Upstreams - </StyledTooltipTitle>
             <StyledTooltipBody>
-              are dependencies that are relied on by the respective projects (i.e. a service calls into this upstream for data).
+              are dependencies that are relied on by the respective projects (i.e. a service calls
+              into this upstream for data).
             </StyledTooltipBody>
           </StyledToolTipContainer>
           <StyledToolTipContainer>
             <StyledTooltipTitle>Downstreams - </StyledTooltipTitle>
             <StyledTooltipBody>
-              are dependencies that rely on the respective projects (i.e. this downstream calls into a service for data).
+              are dependencies that rely on the respective projects (i.e. this downstream calls into
+              a service for data).
             </StyledTooltipBody>
           </StyledToolTipContainer>
         </>

--- a/frontend/workflows/projectSelector/src/tooltip.tsx
+++ b/frontend/workflows/projectSelector/src/tooltip.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import styled from "@emotion/styled";
+import { Popper as MuiPopper, Tooltip } from "@material-ui/core";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+
+const Popper = styled(MuiPopper)({
+  ".MuiTooltip-tooltip": {
+    color: "rgba(13, 16, 48, 0.6)",
+    backgroundColor: "#FFFFFF",
+    border: "1px solid rgba(13, 16, 48, 0.1)",
+    boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
+    borderRadius: "6px",
+    minWidth: "554px",
+    maxWidth: "554px",
+    padding: "0px",
+  },
+  ".MuiTooltip-tooltipPlacementRight": {
+    margin: "0 4px",
+  },
+});
+
+const renderPopper = props => {
+  return <Popper {...props} />;
+};
+
+const StyledToolTipContainer = styled.div({
+  padding: "8px 16px 8px 16px",
+});
+
+const StyledTooltipTitle = styled.span({
+  fontWeight: 500,
+  fontSize: "14px",
+  lineHeight: "18px",
+});
+
+const StyledTooltipBody = styled.span({
+  fontWeight: 400,
+  fontSize: "12px",
+  lineHeight: "16px",
+});
+
+const StyledTooltip = () => {
+  return (
+    <Tooltip
+      title={
+        <>
+          <StyledToolTipContainer>
+            <StyledTooltipTitle>Projects - </StyledTooltipTitle>
+            <StyledTooltipBody>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque laoreet
+              tristique pharetra, eu.
+            </StyledTooltipBody>
+          </StyledToolTipContainer>
+          <StyledToolTipContainer>
+            <StyledTooltipTitle>Upstreams - </StyledTooltipTitle>
+            <StyledTooltipBody>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque laoreet
+              tristique pharetra, eu.
+            </StyledTooltipBody>
+          </StyledToolTipContainer>
+          <StyledToolTipContainer>
+            <StyledTooltipTitle>Downstreams - </StyledTooltipTitle>
+            <StyledTooltipBody>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque laoreet
+              tristique pharetra, eu.
+            </StyledTooltipBody>
+          </StyledToolTipContainer>
+        </>
+      }
+      placement="right-start"
+      PopperComponent={renderPopper}
+    >
+      <InfoOutlinedIcon />
+    </Tooltip>
+  );
+};
+
+export default StyledTooltip;

--- a/frontend/workflows/projectSelector/src/tooltip.tsx
+++ b/frontend/workflows/projectSelector/src/tooltip.tsx
@@ -47,22 +47,20 @@ const StyledTooltip = () => {
           <StyledToolTipContainer>
             <StyledTooltipTitle>Projects - </StyledTooltipTitle>
             <StyledTooltipBody>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque laoreet
-              tristique pharetra, eu.
+              are user-owned or searched services, libraries, mobile apps, etc. Unchecking a project hides its respective upstream
+              and downstream dependencies.
             </StyledTooltipBody>
           </StyledToolTipContainer>
           <StyledToolTipContainer>
             <StyledTooltipTitle>Upstreams - </StyledTooltipTitle>
             <StyledTooltipBody>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque laoreet
-              tristique pharetra, eu.
+              are dependencies that are relied on by the respective projects (i.e. a service calls into this upstream for data).
             </StyledTooltipBody>
           </StyledToolTipContainer>
           <StyledToolTipContainer>
             <StyledTooltipTitle>Downstreams - </StyledTooltipTitle>
             <StyledTooltipBody>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque laoreet
-              tristique pharetra, eu.
+              are dependencies that rely on the respective projects (i.e. this downstream calls into a service for data).
             </StyledTooltipBody>
           </StyledToolTipContainer>
         </>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
PR adds a tooltip to the project selector to explain to users what the different groups (projects/upstreams/downstreams) are

### Testing Performed
Locally

<img width="1587" alt="Screen Shot 2021-07-21 at 12 56 25 PM" src="https://user-images.githubusercontent.com/39421794/126528609-8944eb2d-8c3f-4beb-ba29-31f1d41b7b66.png">



### TODOs
- [x] add explanation of what a project/upstream/downstream is
