### PR TITLE
project-selector: fix toggle state bug

### DIFF
--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -125,7 +125,13 @@ const selectorReducer = (state: State, action: Action): State => {
       return newState;
     }
     case "TOGGLE_ENTIRE_GROUP": {
-      const newCheckedValue = !deriveSwitchStatus(state, action.payload.group);
+      // the state might not match the filtered state data passed to the components, so in the func below, we should filter out the projects
+      // that _were_ rendered in order to correctly evaluate the toggled checked status for all the projects in the respective group
+      const filteredState = {
+        ...state,
+        [action.payload.group]: _.pick(state[action.payload.group], action.payload.projects),
+      };
+      const newCheckedValue = !deriveSwitchStatus(filteredState, action.payload.group);
       return {
         ...state,
         [action.payload.group]: {


### PR DESCRIPTION
### Description
https://github.com/lyft/clutch/pull/1588 introduced a state toggle bug. In that PR, we made a change to pass filtered state data to components & updated the `toggle_entire_group` action to only update the checked status of rendered projects. However, the `deriveSwitchStatus` func received the original state data, and so it was checking the checked status of the all the projects instead of the the projects that were rendered. And as such, after users use the toggle for the first time, the toggle state gets stuck.

This PR updates the `toggle_entire_group` action to pass the filtered state data to the `deriveSwitchStatus` func

### Testing Performed
locally with real api data