### PR TITLE
ci: update stale action config to stop issue handling

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,6 +9,7 @@ jobs:
     - uses: actions/stale@v4
       with:
         days-before-stale: 7
+        days-before-issue-stale: -1
         days-before-close: 3
         exempt-pr-labels: 'on hold'
         stale-pr-message: >


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Looks like the bump from v3 -> v4 had some changes that weren't accounted for in the changelog. I'm adding this additional config option to prevent stalebot from doing anything with issues like we had it before.