### PR TITLE
dash: add return type to useDashState hook

### DIFF
--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -22,6 +22,6 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
   };
 };
 
-export const useDashState = () => {
+export const useDashState = (): DashState => {
   return React.useContext(DashStateContext);
 };

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -23,5 +23,5 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
 };
 
 export const useDashState = (): DashState => {
-  return React.useContext(DashStateContext);
+  return React.useContext<DashState>(DashStateContext);
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Was missing return type resulting in `any` for consumers of hook.