### PR TITLE
backend: github service: add commitRange() from comparison API

### DIFF
--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -8,7 +8,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
-	githubv1 "github.com/lyft/clutch/backend/api/sourcecontrol/github/v1"
 	sourcecontrolv1 "github.com/lyft/clutch/backend/api/sourcecontrol/v1"
 	"github.com/lyft/clutch/backend/service"
 	"github.com/lyft/clutch/backend/service/github"
@@ -40,7 +39,7 @@ func (s svc) CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRe
 	return &sourcecontrolv1.CreateRepositoryResponse{Url: "https://github.com/lyft/clutch"}, nil
 }
 
-func (s svc) CompareCommits(ctx context.Context, ref *github.RemoteRef, compareSHA string) (*githubv1.CommitComparison, error) {
+func (s svc) CompareCommits(ctx context.Context, ref *github.RemoteRef, compareSHA string) (*githubv3.CommitsComparison, error) {
 	panic("implement me")
 }
 

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	githubv1 "github.com/lyft/clutch/backend/api/config/service/github/v1"
-	scgithubv1 "github.com/lyft/clutch/backend/api/sourcecontrol/github/v1"
 	sourcecontrolv1 "github.com/lyft/clutch/backend/api/sourcecontrol/v1"
 	"github.com/lyft/clutch/backend/service"
 )
@@ -79,7 +78,7 @@ type Client interface {
 	CreatePullRequest(ctx context.Context, ref *RemoteRef, base, title, body string) (*PullRequestInfo, error)
 	CreateRepository(ctx context.Context, req *sourcecontrolv1.CreateRepositoryRequest) (*sourcecontrolv1.CreateRepositoryResponse, error)
 	CreateIssueComment(ctx context.Context, ref *RemoteRef, number int, body string) error
-	CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*scgithubv1.CommitComparison, error)
+	CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*githubv3.CommitsComparison, error)
 	GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error)
 	GetRepository(ctx context.Context, ref *RemoteRef) (*Repository, error)
 	GetOrganization(ctx context.Context, organization string) (*githubv3.Organization, error)
@@ -345,34 +344,15 @@ func (s *svc) GetFile(ctx context.Context, ref *RemoteRef, path string) (*File, 
 	return f, nil
 }
 
-func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*scgithubv1.CommitComparison, error) {
+/*
+ * Rather than calling GetCommit() multiple times, we can use CompareCommits to get a range of commits
+ */
+func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*githubv3.CommitsComparison, error) {
 	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get compare status for %s and %s. %+v", ref.Ref, compareSHA, err)
+		return nil, fmt.Errorf("Could not get comparison for %s and %s. %+v", ref.Ref, compareSHA, err)
 	}
-
-	status, ok := scgithubv1.CommitCompareStatus_value[strings.ToUpper(comp.GetStatus())]
-	if !ok {
-		return nil, fmt.Errorf("unknown status %s", comp.GetStatus())
-	}
-
-	return &scgithubv1.CommitComparison{
-		Status: scgithubv1.CommitCompareStatus(status),
-	}, nil
-}
-
-/*
- * CommitRange() is used to get multiple commits between 2 SHAs. It is useful because we can do one API call and get a bunch
- * of commits, rather than calling GetCommit() multiple times.
- * compareSHA is the base (parent) while the ref.ref is the head
- */
-func (s *svc) CommitRange(ctx context.Context, baseSHA string, ref *RemoteRef) ([]*githubv3.RepositoryCommit, error) {
-	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, baseSHA, ref.Ref)
-	if err != nil {
-		return nil, fmt.Errorf("could not get commits from comparison for %s and %s in %s/%s. %+v", baseSHA, ref.Ref, ref.RepoOwner, ref.RepoName, err)
-	}
-
-	return comp.Commits, nil
+	return comp, nil
 }
 
 type Commit struct {

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -361,6 +361,15 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
 	}, nil
 }
 
+func (s *svc) ListCommitsViaComparison(ctx context.Context, ref *RemoteRef, compareSHA string) ([]*githubv3.RepositoryCommit, error) {
+	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
+	if err != nil {
+		return nil, fmt.Errorf("could not get commits from comparison for %s and %s. %+v", ref.Ref, compareSHA, err)
+	}
+
+	return comp.Commits, nil
+}
+
 type Commit struct {
 	Files     []*githubv3.CommitFile
 	Message   string

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -364,8 +364,9 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
 /*
  * CommitRange() is used to get multiple commits between 2 SHAs. It is useful because we can do one API call and get a bunch
  * of commits, rather than calling GetCommit() multiple times.
+ * compareSHA is the base (parent) while the ref.ref is the head
  */
-func (s *svc) CommitRange(ctx context.Context, ref *RemoteRef, compareSHA string) ([]*githubv3.RepositoryCommit, error) {
+func (s *svc) CommitRange(ctx context.Context, compareSHA string, ref *RemoteRef) ([]*githubv3.RepositoryCommit, error) {
 	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
 	if err != nil {
 		return nil, fmt.Errorf("could not get commits from comparison for %s and %s in %s/%s. %+v", ref.Ref, compareSHA, ref.RepoOwner, ref.RepoName, err)

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -366,10 +366,10 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
  * of commits, rather than calling GetCommit() multiple times.
  * compareSHA is the base (parent) while the ref.ref is the head
  */
-func (s *svc) CommitRange(ctx context.Context, compareSHA string, ref *RemoteRef) ([]*githubv3.RepositoryCommit, error) {
-	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
+func (s *svc) CommitRange(ctx context.Context, baseSHA string, ref *RemoteRef) ([]*githubv3.RepositoryCommit, error) {
+	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, baseSHA, ref.Ref)
 	if err != nil {
-		return nil, fmt.Errorf("could not get commits from comparison for %s and %s in %s/%s. %+v", ref.Ref, compareSHA, ref.RepoOwner, ref.RepoName, err)
+		return nil, fmt.Errorf("could not get commits from comparison for %s and %s in %s/%s. %+v", baseSHA, ref.Ref, ref.RepoOwner, ref.RepoName, err)
 	}
 
 	return comp.Commits, nil

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -361,10 +361,14 @@ func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA str
 	}, nil
 }
 
-func (s *svc) ListCommitsViaComparison(ctx context.Context, ref *RemoteRef, compareSHA string) ([]*githubv3.RepositoryCommit, error) {
+/*
+ * CommitRange() is used to get multiple commits between 2 SHAs. It is useful because we can do one API call and get a bunch
+ * of commits, rather than calling GetCommit() multiple times.
+ */
+func (s *svc) CommitRange(ctx context.Context, ref *RemoteRef, compareSHA string) ([]*githubv3.RepositoryCommit, error) {
 	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
 	if err != nil {
-		return nil, fmt.Errorf("could not get commits from comparison for %s and %s. %+v", ref.Ref, compareSHA, err)
+		return nil, fmt.Errorf("could not get commits from comparison for %s and %s in %s/%s. %+v", ref.Ref, compareSHA, ref.RepoOwner, ref.RepoName, err)
 	}
 
 	return comp.Commits, nil

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -386,7 +386,7 @@ var listCommitsTests = []struct {
 	},
 }
 
-func TestListCommitsViaComparison(t *testing.T) {
+func TestCommitRange(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range listCommitsTests {
@@ -398,7 +398,7 @@ func TestListCommitsViaComparison(t *testing.T) {
 				Repositories: tt.mockRepo,
 			}}
 
-			commits, err := s.ListCommitsViaComparison(
+			commits, err := s.CommitRange(
 				context.Background(),
 				&RemoteRef{
 					RepoOwner: "owner",

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -314,19 +314,19 @@ func TestGetUser(t *testing.T) {
 var compareCommitsTests = []struct {
 	name         string
 	errorText    string
-	status       githubv1.CommitCompareStatus
+	status       string
 	generalError bool
 	mockRepo     *mockRepositories
 }{
 	{
 		name:         "v3 error",
 		generalError: true,
-		errorText:    "Could not get compare status",
+		errorText:    "Could not get comparison",
 		mockRepo:     &mockRepositories{generalError: true},
 	},
 	{
 		name:     "happy path",
-		status:   githubv1.CommitCompareStatus_BEHIND,
+		status:   "behind",
 		mockRepo: &mockRepositories{},
 	},
 }
@@ -362,60 +362,7 @@ func TestCompareCommits(t *testing.T) {
 				return
 			}
 			a.Equal(comp.GetStatus(), tt.status)
-			a.Nil(err)
-		})
-	}
-}
-
-var commitRangeTests = []struct {
-	name         string
-	errorText    string
-	commits      []*githubv3.RepositoryCommit
-	generalError bool
-	mockRepo     *mockRepositories
-}{
-	{
-		name:         "v3 error",
-		generalError: true,
-		errorText:    "could not get commits from comparison",
-		mockRepo:     &mockRepositories{generalError: true},
-	},
-	{
-		name:     "happy path",
-		mockRepo: &mockRepositories{},
-	},
-}
-
-func TestCommitRange(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range commitRangeTests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			a := assert.New(t)
-			s := &svc{rest: v3client{
-				Repositories: tt.mockRepo,
-			}}
-
-			commits, err := s.CommitRange(
-				context.Background(),
-				"1234", &RemoteRef{
-					RepoOwner: "owner",
-					RepoName:  "myRepo",
-					Ref:       "master",
-				},
-			)
-			if tt.errorText != "" {
-				a.Error(err)
-				a.Contains(err.Error(), tt.errorText)
-				return
-			}
-			if err != nil {
-				a.FailNowf("unexpected error: %s", err.Error())
-				return
-			}
-			a.NotNil(commits)
+			a.NotNil(comp.Commits)
 			a.Nil(err)
 		})
 	}

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -367,7 +367,7 @@ func TestCompareCommits(t *testing.T) {
 	}
 }
 
-var listCommitsTests = []struct {
+var commitRangeTests = []struct {
 	name         string
 	errorText    string
 	commits      []*githubv3.RepositoryCommit
@@ -389,7 +389,7 @@ var listCommitsTests = []struct {
 func TestCommitRange(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range listCommitsTests {
+	for _, tt := range commitRangeTests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -400,12 +400,11 @@ func TestCommitRange(t *testing.T) {
 
 			commits, err := s.CommitRange(
 				context.Background(),
-				&RemoteRef{
+				"1234", &RemoteRef{
 					RepoOwner: "owner",
 					RepoName:  "myRepo",
 					Ref:       "master",
 				},
-				"1234",
 			)
 			if tt.errorText != "" {
 				a.Error(err)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
We need to get a list of commits via the comparison API.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
unit

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
