### PR TITLE
tools: enforce a global yarn version when generating workflow

### DIFF
--- a/tools/scaffolding/templates/frontend/package.json
+++ b/tools/scaffolding/templates/frontend/package.json
@@ -26,6 +26,7 @@
     "@clutch-sh/tools": "^1.0.0-beta"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.0.0",
+    "yarn": "^1.22.5"
   }
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Enforce workflows are generated with a proper yarn version. This is a short term fix as we should ideally use the existing yarn binary within Clutch.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual