### PR TITLE
scaffolding: fix copy when ~ is in path

### DIFF
--- a/tools/scaffolding/scaffolder.go
+++ b/tools/scaffolding/scaffolder.go
@@ -270,14 +270,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println("DEST WAS", dest)
 	// Fix tilde HOME path.
 	if strings.HasPrefix(dest, "~/") {
-		homeUser, _ := user.Current()
+		homeUser, err := user.Current()
+		if err != nil {
+			log.Fatal("could not get user's information", err)
+		}
 		dest = filepath.Join(homeUser.HomeDir, dest[2:])
 	}
-
-	fmt.Println("DEST IS", dest)
 
 	// Check if dest exists.
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {

--- a/tools/scaffolding/scaffolder.go
+++ b/tools/scaffolding/scaffolder.go
@@ -270,6 +270,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	fmt.Println("DEST WAS", dest)
+	// Fix tilde HOME path.
+	if strings.HasPrefix(dest, "~/") {
+		homeUser, _ := user.Current()
+		dest = filepath.Join(homeUser.HomeDir, dest[2:])
+	}
+
+	fmt.Println("DEST IS", dest)
+
 	// Check if dest exists.
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
 		log.Fatal("ERROR destination folder exists")


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Scaffolding `os.Rename` would fail when it contained a leading `~` for the users home directory.

e.g. `2021/07/23 16:32:09 rename /tmp/clutch-scaffolding-474555198 ~/go/src/github.com/dhochman/clutch-custom-gateway/frontend/workflows/amiibo: invalid argument`
