### PR TITLE
scaffolding: fix ordering for make all target

### DIFF
--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -9,7 +9,7 @@ MY_ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 YARN:=./build/bin/yarn.sh
 
 .PHONY: all # Generate API, Frontend, and backend assets.
-all: api frontend backend-tidy backend-with-assets
+all: backend-tidy api frontend backend-with-assets
 
 .PHONY: api
 api: yarn-ensure


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Run `backend-tidy` before other frontend make steps as we rely on the clutch go module being present to access our tooling scripts. For example `install-yarn.sh.

### Testing Performed
Manual