### PR TITLE
frontend: add tooltip to core design & project selector

### DIFF
--- a/frontend/packages/core/src/Feedback/index.tsx
+++ b/frontend/packages/core/src/Feedback/index.tsx
@@ -2,7 +2,8 @@ import { Alert } from "./alert";
 import Error from "./error";
 import Hint from "./hint";
 import { Note, NotePanel } from "./note";
+import { Tooltip, TooltipContainer } from "./tooltip";
 import Warning from "./warning";
 
 export type { NoteConfig } from "./note";
-export { Alert, Error, Hint, Note, NotePanel, Warning };
+export { Alert, Error, Hint, Note, NotePanel, Tooltip, TooltipContainer, Warning };

--- a/frontend/packages/core/src/Feedback/stories/tooltip.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/tooltip.stories.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import type { Meta } from "@storybook/react";
+
+import { Typography } from "../../typography";
+import type { TooltipProps } from "../tooltip";
+import { Tooltip, TooltipContainer } from "../tooltip";
+
+export default {
+  title: "Core/Feedback/Tooltip",
+  component: Tooltip,
+} as Meta;
+
+const Template = (props: TooltipProps) => <Tooltip {...props} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  title: "Some helpful text",
+  children: <InfoOutlinedIcon />,
+  placement: "right-start",
+};
+
+const text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lacinia purus scelerisque imperdiet viverra erat lectus volutpat mi.
+At purus nunc, lacus fermentum quam pulvinar vel, maecenas.`;
+
+const MultilineText = () => (
+  <>
+    <TooltipContainer>
+      <Typography variant="body3" color="#FFFFFF">
+        {text}
+      </Typography>
+    </TooltipContainer>
+    <TooltipContainer>
+      <Typography variant="body3" color="#FFFFFF">
+        {text}
+      </Typography>
+    </TooltipContainer>
+  </>
+);
+export const MultilineTooltip = Template.bind({});
+MultilineTooltip.args = {
+  title: <MultilineText />,
+  children: <InfoOutlinedIcon />,
+  placement: "bottom",
+  maxWidth: "500px",
+};

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -7,29 +7,25 @@ const BaseTooltip = ({ className, ...props }: MuiTooltipProps) => (
   <MuiTooltip classes={{ tooltip: className }} {...props} />
 );
 
-const StyledTooltip = styled(BaseTooltip)(
-  {
-    backgroundColor: "#0D1030",
-    borderRadius: "6px",
-    "&.MuiTooltip-tooltipPlacementLeft": {
-      margin: "0 2px",
-    },
-    "&.MuiTooltip-tooltipPlacementRight": {
-      margin: "0 2px",
-    },
-    "&.MuiTooltip-tooltipPlacementTop": {
-      margin: "2px 0",
-    },
-    "&.MuiTooltip-tooltipPlacementBottom": {
-      margin: "2px 0",
-    },
+const StyledTooltip = styled(BaseTooltip)((props: { maxWidth: string }) => ({
+  maxWidth: props.maxWidth,
+  backgroundColor: "#0D1030",
+  borderRadius: "6px",
+  "&.MuiTooltip-tooltipPlacementLeft": {
+    margin: "0 2px",
   },
-  props => ({
-    maxWidth: props["data-max-width"],
-  })
-);
+  "&.MuiTooltip-tooltipPlacementRight": {
+    margin: "0 2px",
+  },
+  "&.MuiTooltip-tooltipPlacementTop": {
+    margin: "2px 0",
+  },
+  "&.MuiTooltip-tooltipPlacementBottom": {
+    margin: "2px 0",
+  },
+}));
 
-export interface TooltipProps extends Pick<MuiTooltipProps, "placement"> {
+export interface TooltipProps extends Pick<MuiTooltipProps, "interactive" | "placement"> {
   // tooltip reference element (i.e. icon)
   children: React.ReactElement;
   // material ui default is 300px
@@ -40,7 +36,7 @@ export interface TooltipProps extends Pick<MuiTooltipProps, "placement"> {
 
 const Tooltip = ({ children, maxWidth = "300px", title, ...props }: TooltipProps) => {
   return (
-    <StyledTooltip title={title} data-max-width={maxWidth} {...props}>
+    <StyledTooltip title={title} maxWidth={maxWidth} {...props}>
       {children}
     </StyledTooltip>
   );

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -7,6 +7,7 @@ const BaseTooltip = ({ className, ...props }: MuiTooltipProps) => (
   <MuiTooltip classes={{ tooltip: className }} {...props} />
 );
 
+// TODO: sync with Design on margins for each possible placement
 const StyledTooltip = styled(BaseTooltip)((props: { maxWidth?: string }) => ({
   maxWidth: props.maxWidth,
   backgroundColor: "#0D1030",

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -10,10 +10,19 @@ const BaseTooltip = ({ className, ...props }: MuiTooltipProps) => (
 const StyledTooltip = styled(BaseTooltip)(
   {
     backgroundColor: "#0D1030",
-    border: "1px solid rgba(13, 16, 48, 0.1)",
-    boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
     borderRadius: "6px",
-    margin: "2px",
+    "&.MuiTooltip-tooltipPlacementLeft": {
+      margin: "0 2px",
+    },
+    "&.MuiTooltip-tooltipPlacementRight": {
+      margin: "0 2px",
+    },
+    "&.MuiTooltip-tooltipPlacementTop": {
+      margin: "2px 0",
+    },
+    "&.MuiTooltip-tooltipPlacementBottom": {
+      margin: "2px 0",
+    },
   },
   props => ({
     maxWidth: props["data-max-width"],
@@ -23,15 +32,15 @@ const StyledTooltip = styled(BaseTooltip)(
 export interface TooltipProps extends Pick<MuiTooltipProps, "placement"> {
   // tooltip reference element (i.e. icon)
   children: React.ReactElement;
-  // tooltip text
-  title: React.ReactNode;
   // material ui default is 300px
   maxWidth?: string;
+  // tooltip text
+  title: React.ReactNode;
 }
 
-const Tooltip = ({ children, title, maxWidth = "300px", ...props }: TooltipProps) => {
+const Tooltip = ({ children, maxWidth = "300px", title, ...props }: TooltipProps) => {
   return (
-    <StyledTooltip title={title} {...props} data-max-width={maxWidth}>
+    <StyledTooltip title={title} data-max-width={maxWidth} {...props}>
       {children}
     </StyledTooltip>
   );
@@ -39,7 +48,7 @@ const Tooltip = ({ children, title, maxWidth = "300px", ...props }: TooltipProps
 
 // sets the spacing between multiline content
 const TooltipContainer = styled.div({
-  paddingBottom: "4px",
+  margin: "4px 0px",
 });
 
 export { Tooltip, TooltipContainer };

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import styled from "@emotion/styled";
+import type { TooltipProps as MuiTooltipProps } from "@material-ui/core";
+import { Tooltip as MuiTooltip } from "@material-ui/core";
+
+const BaseTooltip = ({ className, ...props }: MuiTooltipProps) => (
+  <MuiTooltip classes={{ tooltip: className }} {...props} />
+);
+
+const StyledTooltip = styled(BaseTooltip)(
+  {
+    backgroundColor: "#0D1030",
+    border: "1px solid rgba(13, 16, 48, 0.1)",
+    boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
+    borderRadius: "6px",
+  },
+  props => ({
+    maxWidth: props["data-max-width"],
+  })
+);
+
+export interface TooltipProps extends Pick<MuiTooltipProps, "placement"> {
+  // tooltip reference element (i.e. icon)
+  children: React.ReactElement;
+  // tooltip text
+  title: React.ReactNode;
+  // material ui default is 300px
+  maxWidth?: string;
+}
+
+const Tooltip = ({ children, title, maxWidth = "300px", ...props }: TooltipProps) => {
+  return (
+    <StyledTooltip title={title} {...props} data-max-width={maxWidth}>
+      {children}
+    </StyledTooltip>
+  );
+};
+
+// sets the spacing between multiline content
+const TooltipContainer = styled.div({
+  paddingBottom: "4px",
+});
+
+export { Tooltip, TooltipContainer };

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -13,6 +13,7 @@ const StyledTooltip = styled(BaseTooltip)(
     border: "1px solid rgba(13, 16, 48, 0.1)",
     boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
     borderRadius: "6px",
+    margin: "2px",
   },
   props => ({
     maxWidth: props["data-max-width"],

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -7,7 +7,7 @@ const BaseTooltip = ({ className, ...props }: MuiTooltipProps) => (
   <MuiTooltip classes={{ tooltip: className }} {...props} />
 );
 
-const StyledTooltip = styled(BaseTooltip)((props: { maxWidth: string }) => ({
+const StyledTooltip = styled(BaseTooltip)((props: { maxWidth?: string }) => ({
   maxWidth: props.maxWidth,
   backgroundColor: "#0D1030",
   borderRadius: "6px",

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -22,7 +22,16 @@ import { Chip } from "./chip";
 import Confirmation from "./confirmation";
 import { useWizardContext, WizardContext } from "./Contexts";
 import { Dialog, DialogActions, DialogContent } from "./dialog";
-import { Alert, Error, Hint, Note, NotePanel, Warning } from "./Feedback";
+import {
+  Alert,
+  Error,
+  Hint,
+  Note,
+  NotePanel,
+  Tooltip,
+  TooltipContainer,
+  Warning,
+} from "./Feedback";
 import { FeatureOff, FeatureOn, SimpleFeatureFlag } from "./flags";
 import { AvatarIcon, StatusIcon } from "./icon";
 import { Link } from "./link";
@@ -110,6 +119,8 @@ export {
   TableRowActions,
   Tabs,
   TextField,
+  Tooltip,
+  TooltipContainer,
   TreeTable,
   Typography,
   userId,

--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -118,8 +118,8 @@ type TextVariant =
   | "overline"
   | "input";
 
-const StyledTypography = styled.div<{ variant: TextVariant }>(props => ({
-  color: props["data-color"],
+const StyledTypography = styled.div<{ color: string; variant: TextVariant }>(props => ({
+  color: props.color,
   fontSize: `${STYLE_MAP[props?.variant || 0].size}px`,
   fontWeight: STYLE_MAP[props?.variant || 0].weight,
   lineHeight: `${STYLE_MAP[props?.variant || 0].lineHeight}px`,
@@ -134,7 +134,7 @@ export interface TypographyProps {
 
 const Typography = ({ variant, children, color = "#0D1030" }: TypographyProps) => {
   return (
-    <StyledTypography variant={variant} data-color={color}>
+    <StyledTypography variant={variant} color={color}>
       {children}
     </StyledTypography>
   );

--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -118,25 +118,26 @@ type TextVariant =
   | "overline"
   | "input";
 
-const StyledTypography = styled.div<{ variant: TextVariant }>(
-  {
-    color: "#0D1030",
-  },
-  props => ({
-    fontSize: `${STYLE_MAP[props?.variant || 0].size}px`,
-    fontWeight: STYLE_MAP[props?.variant || 0].weight,
-    lineHeight: `${STYLE_MAP[props?.variant || 0].lineHeight}px`,
-    ...STYLE_MAP[props?.variant || 0].props,
-  })
-);
+const StyledTypography = styled.div<{ variant: TextVariant }>(props => ({
+  color: props["data-color"],
+  fontSize: `${STYLE_MAP[props?.variant || 0].size}px`,
+  fontWeight: STYLE_MAP[props?.variant || 0].weight,
+  lineHeight: `${STYLE_MAP[props?.variant || 0].lineHeight}px`,
+  ...STYLE_MAP[props?.variant || 0].props,
+}));
 
 export interface TypographyProps {
   variant: TextVariant;
   children: React.ReactNode;
+  color?: string;
 }
 
-const Typography = ({ variant, children }: TypographyProps) => {
-  return <StyledTypography variant={variant}>{children}</StyledTypography>;
+const Typography = ({ variant, children, color = "#0D1030" }: TypographyProps) => {
+  return (
+    <StyledTypography variant={variant} data-color={color}>
+      {children}
+    </StyledTypography>
+  );
 };
 
 export { StyledTypography, Typography };

--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -118,7 +118,7 @@ type TextVariant =
   | "overline"
   | "input";
 
-const StyledTypography = styled.div<{ color: string; variant: TextVariant }>(props => ({
+const StyledTypography = styled.div<{ color?: string; variant: TextVariant }>(props => ({
   color: props.color,
   fontSize: `${STYLE_MAP[props?.variant || 0].size}px`,
   fontWeight: STYLE_MAP[props?.variant || 0].weight,

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import type { ClutchError } from "@clutch-sh/core";
-import { client, TextField, userId } from "@clutch-sh/core";
+import { client, TextField, Tooltip, TooltipContainer, Typography, userId } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import { Divider, LinearProgress } from "@material-ui/core";
-import LayersIcon from "@material-ui/icons/Layers";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import LayersOutlinedIcon from "@material-ui/icons/LayersOutlined";
 import _ from "lodash";
 
 import { useDashUpdater } from "./dash-hooks";
@@ -56,6 +57,11 @@ const StyledProgressContainer = styled.div({
     backgroundColor: "#3548D4",
   },
 });
+
+const projectDescription =
+  "server, mobile app, etc. Unchecking a project hides its upstream and downstream dependencies.";
+const upstreamDescription = "receive requests and send responses to the selected project.";
+const downstreamDescription = "send requests and receive responses from the selected project.";
 
 const ProjectSelector = () => {
   // On load, we'll request a list of owned projects and their upstreams and downstreams from the API.
@@ -171,9 +177,42 @@ const ProjectSelector = () => {
       <StateContext.Provider value={derivedState}>
         <StyledSelectorContainer>
           <StyledWorkflowHeader>
-            {/* TODO: change icon to match design */}
-            <LayersIcon />
+            <LayersOutlinedIcon />
             <StyledWorkflowTitle>Dash</StyledWorkflowTitle>
+            <Tooltip
+              title={
+                <>
+                  <TooltipContainer>
+                    <Typography variant="subtitle3" color="#FFFFFF">
+                      Projects
+                    </Typography>
+                    <Typography variant="body3" color="#FFFFFF">
+                      {projectDescription}
+                    </Typography>
+                  </TooltipContainer>
+                  <TooltipContainer>
+                    <Typography variant="subtitle3" color="#FFFFFF">
+                      Upstreams
+                    </Typography>
+                    <Typography variant="body3" color="#FFFFFF">
+                      {upstreamDescription}
+                    </Typography>
+                  </TooltipContainer>
+                  <TooltipContainer>
+                    <Typography variant="subtitle3" color="#FFFFFF">
+                      Downstreams
+                    </Typography>
+                    <Typography variant="body3" color="#FFFFFF">
+                      {downstreamDescription}
+                    </Typography>
+                  </TooltipContainer>
+                </>
+              }
+              placement="right-start"
+              maxWidth="391px"
+            >
+              <InfoOutlinedIcon />
+            </Tooltip>
           </StyledWorkflowHeader>
           <StyledProgressContainer>
             {state.loading && <LinearProgress color="secondary" />}

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -58,17 +58,10 @@ const StyledProgressContainer = styled.div({
   },
 });
 
-const projectDescription =
-  "server, mobile app, etc. Unchecking a project hides its upstream and downstream dependencies.";
-const upstreamDescription = "receive requests and send responses to the selected project.";
-const downstreamDescription = "send requests and receive responses from the selected project.";
-
 const ProjectSelector = () => {
   // On load, we'll request a list of owned projects and their upstreams and downstreams from the API.
   // The API will contain information about the relationships between projects and upstreams and downstreams.
   // By default, the owned projects will be checked and others will be unchecked.
-  // TODO: If a project is unchecked, the upstream and downstreams related to it disappear from the list.
-  // TODO: If a project is rechecked, the checks were preserved.
 
   const [customProject, setCustomProject] = React.useState("");
 
@@ -85,12 +78,6 @@ const ProjectSelector = () => {
 
     let allPresent = true;
     _.forEach(Object.keys(state[Group.PROJECTS]), p => {
-      /*
-      TODO: b/c of this conditional, if a user adds an upstream/downstream we already have the project data for
-      to the custom project group, allPresent will be true and we wont trigger an api call. One way to account for this
-      is updating the conditional to additionally check if the project is included in state[Group.Downstreams]/state[Group.Upstreams]
-      and if so, mark allPresent as false.
-      */
       if (!(p in state.projectData)) {
         allPresent = false;
         return false; // Stop iteration.
@@ -177,41 +164,42 @@ const ProjectSelector = () => {
       <StateContext.Provider value={derivedState}>
         <StyledSelectorContainer>
           <StyledWorkflowHeader>
-            <LayersOutlinedIcon />
+            <LayersOutlinedIcon fontSize="small" />
             <StyledWorkflowTitle>Dash</StyledWorkflowTitle>
             <Tooltip
               title={
                 <>
-                  <TooltipContainer>
-                    <Typography variant="subtitle3" color="#FFFFFF">
-                      Projects
-                    </Typography>
-                    <Typography variant="body3" color="#E7E7EA">
-                      {projectDescription}
-                    </Typography>
-                  </TooltipContainer>
-                  <TooltipContainer>
-                    <Typography variant="subtitle3" color="#FFFFFF">
-                      Upstreams
-                    </Typography>
-                    <Typography variant="body3" color="#E7E7EA">
-                      {upstreamDescription}
-                    </Typography>
-                  </TooltipContainer>
-                  <TooltipContainer>
-                    <Typography variant="subtitle3" color="#FFFFFF">
-                      Downstreams
-                    </Typography>
-                    <Typography variant="body3" color="#E7E7EA">
-                      {downstreamDescription}
-                    </Typography>
-                  </TooltipContainer>
+                  {[
+                    {
+                      title: "Projects",
+                      description:
+                        "Service, mobile app, etc. Unchecking a project hides its upstream and downstream dependencies.",
+                    },
+                    {
+                      title: "Upstreams",
+                      description: "Receive requests and send responses to the selected project.",
+                    },
+                    {
+                      title: "Downstreams",
+                      description: "Send requests and receive responses from the selected project.",
+                    },
+                  ].map(item => (
+                    <TooltipContainer>
+                      <Typography variant="subtitle3" color="#FFFFFF">
+                        {item.title}
+                      </Typography>
+                      <Typography variant="body3" color="#E7E7EA">
+                        {item.description}
+                      </Typography>
+                    </TooltipContainer>
+                  ))}
                 </>
               }
-              placement="right-start"
+              interactive
               maxWidth="400px"
+              placement="right-start"
             >
-              <InfoOutlinedIcon />
+              <InfoOutlinedIcon fontSize="small" />
             </Tooltip>
           </StyledWorkflowHeader>
           <StyledProgressContainer>

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -186,7 +186,7 @@ const ProjectSelector = () => {
                     <Typography variant="subtitle3" color="#FFFFFF">
                       Projects
                     </Typography>
-                    <Typography variant="body3" color="#FFFFFF">
+                    <Typography variant="body3" color="#E7E7EA">
                       {projectDescription}
                     </Typography>
                   </TooltipContainer>
@@ -194,7 +194,7 @@ const ProjectSelector = () => {
                     <Typography variant="subtitle3" color="#FFFFFF">
                       Upstreams
                     </Typography>
-                    <Typography variant="body3" color="#FFFFFF">
+                    <Typography variant="body3" color="#E7E7EA">
                       {upstreamDescription}
                     </Typography>
                   </TooltipContainer>
@@ -202,14 +202,14 @@ const ProjectSelector = () => {
                     <Typography variant="subtitle3" color="#FFFFFF">
                       Downstreams
                     </Typography>
-                    <Typography variant="body3" color="#FFFFFF">
+                    <Typography variant="body3" color="#E7E7EA">
                       {downstreamDescription}
                     </Typography>
                   </TooltipContainer>
                 </>
               }
               placement="right-start"
-              maxWidth="391px"
+              maxWidth="400px"
             >
               <InfoOutlinedIcon />
             </Tooltip>


### PR DESCRIPTION
### Description
PR
* adds tooltip to core design system
* adds tooltip stories
* adds tooltip to project selector component 
* makes small change to typography component to accept a color prop

### Testing Performed
locally and storybook

<img width="500" alt="Screen Shot 2021-07-28 at 5 15 51 PM" src="https://user-images.githubusercontent.com/39421794/127398515-e0a8c905-5d1d-4498-ba69-b4144766bdba.png">

<img width="500" alt="Screen Shot 2021-07-28 at 5 28 50 PM" src="https://user-images.githubusercontent.com/39421794/127398897-d8a7071a-af0f-4710-b597-93aa9b6fc1fd.png">

<img width="500" alt="Screen Shot 2021-07-28 at 5 28 35 PM" src="https://user-images.githubusercontent.com/39421794/127398912-5e5e0539-dc31-4ed9-8fad-711aa73bbb45.png">

### TODOs
- [x] styling for distance b/w tooltip and reference element

