### PR TITLE
frontend: move project selector to strict typescript

### DIFF
--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -4,8 +4,8 @@ import type { DashAction, DashState } from "./types";
 
 export const DashStateContext = React.createContext<DashState | undefined>(undefined);
 
-export const DashDispatchContext = React.createContext<(action: DashAction) => void | undefined>(
-  () => undefined
+export const DashDispatchContext = React.createContext<((action: DashAction) => void) | undefined>(
+  undefined
 );
 
 type useDashUpdaterReturn = {
@@ -17,7 +17,7 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
 
   return {
     updateSelected: projects => {
-      dispatch({ type: "UPDATE_SELECTED", payload: projects });
+      dispatch && dispatch({ type: "UPDATE_SELECTED", payload: projects });
     },
   };
 };

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -22,6 +22,6 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
   };
 };
 
-export const useDashState = (): DashState => {
-  return React.useContext<DashState>(DashStateContext);
+export const useDashState = (): DashState | undefined => {
+  return React.useContext<DashState | undefined>(DashStateContext);
 };

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -5,7 +5,7 @@ import type { DashAction, DashState } from "./types";
 export const DashStateContext = React.createContext<DashState | undefined>(undefined);
 
 export const DashDispatchContext = React.createContext<(action: DashAction) => void | undefined>(
-  undefined
+  () => undefined
 );
 
 type useDashUpdaterReturn = {

--- a/frontend/workflows/projectSelector/src/helpers.tsx
+++ b/frontend/workflows/projectSelector/src/helpers.tsx
@@ -16,7 +16,7 @@ const useReducerState = () => {
   return React.useContext(StateContext);
 };
 
-const DispatchContext = React.createContext<(action: Action) => void | undefined>(() => undefined);
+const DispatchContext = React.createContext<((action: Action) => void) | undefined>(undefined);
 const useDispatch = () => {
   return React.useContext(DispatchContext);
 };

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -116,8 +116,9 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
 
   const [collapsed, setCollapsed] = React.useState(false);
 
-  const numProjects = Object.keys(state[group]).length;
-  const checkedProjects = Object.keys(state[group]).filter(k => state[group][k].checked);
+  const groupKeys = Object.keys(state?.[group] || {});
+  const numProjects = groupKeys.length;
+  const checkedProjects = groupKeys.filter(k => state?.[group][k].checked);
 
   return (
     <>
@@ -140,11 +141,11 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
             onChange={() =>
               dispatch({
                 type: "TOGGLE_ENTIRE_GROUP",
-                payload: { group, projects: Object.keys(state[group]) },
+                payload: { group, projects: groupKeys },
               })
             }
             checked={deriveSwitchStatus(state, group)}
-            disabled={numProjects === 0 || state.loading}
+            disabled={numProjects === 0 || state?.loading}
           />
         </StyledHeaderColumn>
       </StyledProjectHeader>
@@ -153,53 +154,51 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           {numProjects === 0 && (
             <StyledNoProjectsText>No projects in this group yet.</StyledNoProjectsText>
           )}
-          {Object.keys(state[group])
-            .sort()
-            .map(key => (
-              <StyledMenuItem key={key}>
-                <Checkbox
-                  name={key}
-                  size="small"
-                  disabled={state.loading}
-                  onChange={() =>
+          {groupKeys.sort().map(key => (
+            <StyledMenuItem key={key}>
+              <Checkbox
+                name={key}
+                size="small"
+                disabled={state?.loading}
+                onChange={() =>
+                  dispatch({
+                    type: "TOGGLE_PROJECTS",
+                    payload: { group, projects: [key] },
+                  })
+                }
+                checked={!!state?.[group][key].checked}
+              />
+              <StyledMenuItemName>{key}</StyledMenuItemName>
+              <StyledHoverOptions hidden>
+                <StyledOnlyButton
+                  onClick={() =>
+                    !state?.loading &&
                     dispatch({
-                      type: "TOGGLE_PROJECTS",
+                      type: "ONLY_PROJECTS",
                       payload: { group, projects: [key] },
                     })
                   }
-                  checked={!!state[group][key].checked}
-                />
-                <StyledMenuItemName>{key}</StyledMenuItemName>
-                <StyledHoverOptions hidden>
-                  <StyledOnlyButton
-                    onClick={() =>
-                      !state.loading &&
-                      dispatch({
-                        type: "ONLY_PROJECTS",
-                        payload: { group, projects: [key] },
-                      })
-                    }
-                  >
-                    Only
-                  </StyledOnlyButton>
-                  <StyledClearIcon>
-                    {state[group][key].custom && (
-                      <IconButton
-                        onClick={() =>
-                          !state.loading &&
-                          dispatch({
-                            type: "REMOVE_PROJECTS",
-                            payload: { group, projects: [key] },
-                          })
-                        }
-                      >
-                        <ClearIcon />
-                      </IconButton>
-                    )}
-                  </StyledClearIcon>
-                </StyledHoverOptions>
-              </StyledMenuItem>
-            ))}
+                >
+                  Only
+                </StyledOnlyButton>
+                <StyledClearIcon>
+                  {state?.[group][key].custom && (
+                    <IconButton
+                      onClick={() =>
+                        !state?.loading &&
+                        dispatch({
+                          type: "REMOVE_PROJECTS",
+                          payload: { group, projects: [key] },
+                        })
+                      }
+                    >
+                      <ClearIcon />
+                    </IconButton>
+                  )}
+                </StyledClearIcon>
+              </StyledHoverOptions>
+            </StyledMenuItem>
+          ))}
         </div>
       )}
     </>

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -116,7 +116,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
 
   const [collapsed, setCollapsed] = React.useState(false);
 
-  const groupKeys = Object.keys(state?.[group] || {});
+  const groupKeys = Object.keys(state?.[group] ?? {});
   const numProjects = groupKeys.length;
   const checkedProjects = groupKeys.filter(k => state?.[group][k].checked);
 
@@ -139,6 +139,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
           {displayToggleHelperText && <StyledAllText>All</StyledAllText>}
           <Switch
             onChange={() =>
+              dispatch &&
               dispatch({
                 type: "TOGGLE_ENTIRE_GROUP",
                 payload: { group, projects: groupKeys },
@@ -161,6 +162,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                 size="small"
                 disabled={state?.loading}
                 onChange={() =>
+                  dispatch &&
                   dispatch({
                     type: "TOGGLE_PROJECTS",
                     payload: { group, projects: [key] },
@@ -173,6 +175,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                 <StyledOnlyButton
                   onClick={() =>
                     !state?.loading &&
+                    dispatch &&
                     dispatch({
                       type: "ONLY_PROJECTS",
                       payload: { group, projects: [key] },
@@ -186,6 +189,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                     <IconButton
                       onClick={() =>
                         !state?.loading &&
+                        dispatch &&
                         dispatch({
                           type: "REMOVE_PROJECTS",
                           payload: { group, projects: [key] },

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -97,7 +97,10 @@ const ProjectSelector = () => {
       dispatch({ type: "HYDRATE_START" });
 
       // TODO: have userId check be server driven
-      const requestParams = { users: [userId()], projects: [] };
+      const requestParams = { users: [userId()], projects: [] } as {
+        users: string[];
+        projects: string[];
+      };
       _.forEach(Object.keys(state[Group.PROJECTS]), p => {
         // if the project is custom
         if (state[Group.PROJECTS][p].custom) {

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -140,7 +140,10 @@ const selectorReducer = (state: State, action: Action): State => {
       // that _were_ rendered in order to correctly evaluate the toggled checked status for all the projects in the respective group
       const filteredState = {
         ...state,
-        [action.payload.group]: _.pick(state[action.payload.group], action.payload.projects),
+        [action.payload.group]: _.pick(
+          state[action.payload.group],
+          action?.payload?.projects || []
+        ),
       };
       const newCheckedValue = !deriveSwitchStatus(filteredState, action.payload.group);
       return {

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -16,9 +16,10 @@ const selectorReducer = (state: State, action: Action): State => {
 
     case "ADD_PROJECTS": {
       // a given custom project may already exist in the group so don't trigger a state update for the duplicate(s)
-      const uniqueCustomProjects = action.payload.projects.filter(
-        (project: string) => !(project in state[action.payload.group])
-      );
+      const uniqueCustomProjects =
+        action?.payload?.projects?.filter(
+          (project: string) => !(project in state[action.payload.group])
+        ) || [];
       if (uniqueCustomProjects.length === 0) {
         // since there's no new projects to add, we return the original state as it wasn't modified
         return state;
@@ -47,13 +48,17 @@ const selectorReducer = (state: State, action: Action): State => {
           return;
         }
 
-        const { upstreams, downstreams } = newState.projectData[v].dependencies;
-        upstreams[PROJECT_TYPE_URL]?.ids.forEach(upstreamDep => {
+        const dependencies = newState.projectData[v]?.dependencies || {
+          upstreams: {},
+          downstreams: {},
+        };
+        const { upstreams, downstreams } = dependencies;
+        upstreams?.[PROJECT_TYPE_URL]?.ids?.forEach(upstreamDep => {
           newState = updateGroupstate(newState, Group.UPSTREAM, upstreamDep, {
             checked: false,
           });
         });
-        downstreams[PROJECT_TYPE_URL]?.ids.forEach(downstreamDep => {
+        downstreams?.[PROJECT_TYPE_URL]?.ids?.forEach(downstreamDep => {
           newState = updateGroupstate(newState, Group.DOWNSTREAM, downstreamDep, {
             checked: false,
           });
@@ -66,7 +71,10 @@ const selectorReducer = (state: State, action: Action): State => {
       // remove the projects from their respective group
       const newState = {
         ...state,
-        [action.payload.group]: _.omit(state[action.payload.group], action.payload.projects),
+        [action.payload.group]: _.omit(
+          state[action.payload.group],
+          action?.payload?.projects || []
+        ),
       };
 
       if (action.payload.group !== Group.PROJECTS) {
@@ -75,9 +83,9 @@ const selectorReducer = (state: State, action: Action): State => {
 
       // for the removed projects in Group.Projects we get their upstreams/dowstreams that are exclusive
       // (i.e. not shared by other projects that weren't removed)
-      const exclusiveUpstreams = [];
-      const exclusiveDownstreams = [];
-      action.payload.projects.forEach(p => {
+      const exclusiveUpstreams = [] as string[];
+      const exclusiveDownstreams = [] as string[];
+      action?.payload?.projects?.forEach(p => {
         /* get the upstreams/downstreams that are exclusive to the removed project(s)
 
         TODO: (sperry) "remove_projects" supports bulk removal & since this func checks if upstreams/downstreams are exclusive
@@ -101,13 +109,13 @@ const selectorReducer = (state: State, action: Action): State => {
         [action.payload.group]: {
           ...state[action.payload.group],
           ...Object.fromEntries(
-            action.payload.projects.map(key => [
+            action?.payload?.projects?.map(key => [
               key,
               {
                 ...state[action.payload.group][key],
                 checked: !state[action.payload.group][key].checked,
               },
-            ])
+            ]) || []
           ),
         },
       };
@@ -118,7 +126,10 @@ const selectorReducer = (state: State, action: Action): State => {
       newState[action.payload.group] = Object.fromEntries(
         Object.keys(state[action.payload.group]).map(key => [
           key,
-          { ...state[action.payload.group][key], checked: action.payload.projects.includes(key) },
+          {
+            ...state[action.payload.group][key],
+            checked: action?.payload?.projects?.includes(key) || false,
+          },
         ])
       );
 
@@ -137,13 +148,13 @@ const selectorReducer = (state: State, action: Action): State => {
         [action.payload.group]: {
           ...state[action.payload.group],
           ...Object.fromEntries(
-            action.payload.projects.map(key => [
+            action?.payload?.projects?.map(key => [
               key,
               {
                 ...state[action.payload.group][key],
                 checked: newCheckedValue,
               },
-            ])
+            ]) || []
           ),
         },
       };
@@ -154,15 +165,15 @@ const selectorReducer = (state: State, action: Action): State => {
       return { ...state, loading: true };
     }
     case "HYDRATE_END": {
-      let newState = { ...state, loading: false, error: undefined };
+      let newState = { ...state, loading: false, error: undefined } as State;
 
       _.forIn(
-        action.payload.result as IClutch.project.v1.IGetProjectsResponse,
+        action?.payload?.result as { [k: string]: IClutch.project.v1.IProjectResult } | null,
         (v: IClutch.project.v1.IProjectResult, k: string) => {
           // user owned project vs custom project
-          if (v.from.users.length > 0) {
+          if (v?.from?.users && v.from.users.length > 0) {
             newState = updateGroupstate(newState, Group.PROJECTS, k, { checked: true });
-          } else if (v.from.selected) {
+          } else if (v?.from?.selected) {
             newState = updateGroupstate(newState, Group.PROJECTS, k, {
               checked: true,
               custom: true,
@@ -170,14 +181,15 @@ const selectorReducer = (state: State, action: Action): State => {
           }
 
           // add each upstream/downstream for the selected or user project
-          if (v.from.users.length > 0 || v.from.selected) {
-            const { upstreams, downstreams } = v.project.dependencies;
-            upstreams[PROJECT_TYPE_URL]?.ids.forEach(upstreamDep => {
+          if ((v?.from?.users && v.from.users.length > 0) || v?.from?.selected) {
+            const dependencies = v?.project?.dependencies || { upstreams: {}, downstreams: {} };
+            const { upstreams, downstreams } = dependencies;
+            upstreams?.[PROJECT_TYPE_URL]?.ids?.forEach(upstreamDep => {
               newState = updateGroupstate(newState, Group.UPSTREAM, upstreamDep, {
                 checked: false,
               });
             });
-            downstreams[PROJECT_TYPE_URL]?.ids.forEach(downstreamDep => {
+            downstreams?.[PROJECT_TYPE_URL]?.ids?.forEach(downstreamDep => {
               newState = updateGroupstate(newState, Group.DOWNSTREAM, downstreamDep, {
                 checked: false,
               });
@@ -185,7 +197,9 @@ const selectorReducer = (state: State, action: Action): State => {
           }
 
           // stores the raw project data for each project in the API result
-          newState.projectData[k] = v.project;
+          if (v?.project) {
+            newState.projectData[k] = v.project;
+          }
         }
       );
       return newState;
@@ -199,7 +213,7 @@ const selectorReducer = (state: State, action: Action): State => {
        TODO: when we add error handling for projects not found, we'll need to make sure we remove the not-found-project from project group
        (it's added automatically in the "ADD_PROJECTS" state)
       */
-      return { ...state, loading: false, error: action.payload.result };
+      return { ...state, loading: false, error: action?.payload?.result };
     default:
       throw new Error(`unknown resolver action`);
   }

--- a/frontend/workflows/projectSelector/tsconfig.json
+++ b/frontend/workflows/projectSelector/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "strict": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Enable strict typescript rules for project selector and make appropriate fixes.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
