### PR TITLE
frontend: only update selected projects in dash hook if changes

### DIFF
--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Box } from "@material-ui/core";
+import _ from "lodash";
 
 import { DashDispatchContext, DashStateContext } from "./dash-hooks";
 import ProjectSelector from "./project-selector";
@@ -13,7 +14,10 @@ const initialState = {
 const dashReducer = (state: DashState, action: DashAction): DashState => {
   switch (action.type) {
     case "UPDATE_SELECTED": {
-      return action.payload;
+      if (!_.isEqual(state.selected, action.payload.selected)) {
+        return action.payload;
+      }
+      return state;
     }
     default:
       throw new Error("not implemented (should be unreachable)");


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Removes duplicate state updates for dash cards that rely on the selected hook.

Currently, the [`updateSelected`](https://github.com/lyft/clutch/blob/main/frontend/workflows/projectSelector/src/project-selector.tsx#L153) is called anytime there is a state change which currently happens on load, on hydrate start, and on hydrate end.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual