### PR TITLE
frontend: fix width layout of dash content

### DIFF
--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -11,7 +11,7 @@ interface CardProps {
 }
 
 const Card = ({ avatar, title, error, children }: CardProps) => (
-  <Grid item xs={12} sm={7}>
+  <Grid item xs={12} sm={6}>
     <ClutchCard>
       <CardHeader avatar={avatar} title={title} />
       {error ? <Error subject={error} /> : children}

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -24,11 +24,11 @@ const Dash = ({ children }) => {
   const [state, dispatch] = React.useReducer(dashReducer, initialState);
 
   return (
-    <Box display="flex" width="100%">
+    <Box display="flex" flex={1}>
       <DashDispatchContext.Provider value={dispatch}>
         <DashStateContext.Provider value={state}>
           <ProjectSelector />
-          <Box flexGrow={1}>{children}</Box>
+          <Box display="flex" flex={1}>{children}</Box>
         </DashStateContext.Provider>
       </DashDispatchContext.Provider>
     </Box>

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -28,7 +28,9 @@ const Dash = ({ children }) => {
       <DashDispatchContext.Provider value={dispatch}>
         <DashStateContext.Provider value={state}>
           <ProjectSelector />
-          <Box display="flex" flex={1}>{children}</Box>
+          <Box display="flex" flex={1}>
+            {children}
+          </Box>
         </DashStateContext.Provider>
       </DashDispatchContext.Provider>
     </Box>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes width of Dash content layout. Previously it would overflow given the 100% width.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2021-07-29 at 2 50 35 PM](https://user-images.githubusercontent.com/1004789/127570445-4b3ab0b6-f41b-4253-9fb6-43ae495b9881.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
