### PR TITLE
frontend: hide overflow of Links

### DIFF
--- a/frontend/packages/core/src/link.tsx
+++ b/frontend/packages/core/src/link.tsx
@@ -10,6 +10,8 @@ const StyledLink = styled(MuiLink)(
     maxWidth: "fit-content",
     fontSize: "14px",
     color: "#3548D4",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
   },
   props => ({
     textTransform: props["data-text-transform"],


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
When Links overflow they should be hidden.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
