### PR TITLE
dash: throw error from useDashState if context invalid

### DIFF
--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -26,7 +26,7 @@ export const useDashState = (): DashState => {
   const value = React.useContext<DashState | undefined>(DashStateContext);
   if (!value) {
     throw new Error(
-      "useDashState was invoked with no value, check that it is a child of the Dash component"
+      "useDashState was invoked outside of a valid context, check that it is a child of the Dash component"
     );
   }
   return value;

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -22,6 +22,10 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
   };
 };
 
-export const useDashState = (): DashState | undefined => {
-  return React.useContext<DashState | undefined>(DashStateContext);
+export const useDashState = (): DashState => {
+  const value = React.useContext<DashState | undefined>(DashStateContext);
+  if (!value) {
+    throw new Error("useDashState was invoked with no value, check that it is a child of the Dash component");
+  }
+  return value;
 };

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -25,7 +25,9 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
 export const useDashState = (): DashState => {
   const value = React.useContext<DashState | undefined>(DashStateContext);
   if (!value) {
-    throw new Error("useDashState was invoked with no value, check that it is a child of the Dash component");
+    throw new Error(
+      "useDashState was invoked with no value, check that it is a child of the Dash component"
+    );
   }
   return value;
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Throw an error if the value is not valid for the given context. 

This will eliminate the need for the caller to continually check for and handle a null context value every time they access the context, which is a wholly invalid state anyways and can't be rectified.