### PR TITLE
frontend: wait for all projects to return information in dash

### DIFF
--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -61,8 +61,12 @@ const StyledProgressContainer = styled.div({
 // Determines if every project has projectData (i.e. the effect has finished fetching the data)
 const allPresent = (state: State): boolean => {
   let ret = true;
-  // We could potentially check all groups but it's really not necessary since an upstream cannot be added manually.
-  _.forEach(Object.keys(state[Group.PROJECTS]), p => {
+  const allProjects = new Set([
+    ...Object.keys(state[Group.PROJECTS]),
+    ...Object.keys(state[Group.UPSTREAM]),
+    ...Object.keys(state[Group.DOWNSTREAM]),
+  ]);
+  allProjects.forEach(p => {
     if (!(p in state.projectData)) {
       ret = false;
     }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Wait for all projects (including upstream and downstream) to finish loading before returning state.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual