### PR TITLE
frontend: add onClick prop to icon button

### DIFF
--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -117,7 +117,7 @@ const StyledIconButton = styled(MuiIconButton)({
   },
 });
 
-export interface IconButtonProps extends Pick<MuiIconButtonProps, "disabled" | "type"> {
+export interface IconButtonProps extends Pick<MuiIconButtonProps, "disabled" | "type" | "onClick"> {
   children: React.ReactElement;
 }
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add `onClick` prop to icon button

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual