### PR TITLE
frontend: remove warning in table css

### DIFF
--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -50,7 +50,7 @@ const StyledTableHead = styled(MuiTableHead)({
 
 const StyledTableRow = styled(MuiTableRow)<{ responsive?: boolean }>(
   {
-    ":nth-child(even)": {
+    ":nth-of-type(even)": {
       background: "rgba(13, 16, 48, 0.03)",
     },
     ":hover": {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix `The pseudo class ":nth-child" is potentially unsafe when doing server-side rendering. Try changing it to ":nth-of-type". ` warning.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual