### PR TITLE
dash: add the delta in state change in (un)selected project(s)

### DIFF
--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -18,7 +18,7 @@ const initialState = {
 const dashReducer = (state: DashState, action: DashAction): DashState => {
   switch (action.type) {
     case "UPDATE_SELECTED": {
-      // comparisons of what was selected and removed
+      // comparisons of what was (un)selected
       const selected = _.difference(action.payload.selected, state.selected);
       const unselected = _.difference(state.selected, action.payload.selected);
 

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -9,13 +9,28 @@ import type { DashAction, DashState } from "./types";
 const initialState = {
   selected: [],
   projectData: {},
+  delta: {
+    newSelected: [],
+    newUnselected: [],
+  },
 };
 
 const dashReducer = (state: DashState, action: DashAction): DashState => {
   switch (action.type) {
     case "UPDATE_SELECTED": {
+      // comparisons of what was selected and removed
+      const selected = _.difference(action.payload.selected, state.selected);
+      const unselected = _.difference(state.selected, action.payload.selected);
+
       if (!_.isEqual(state.selected, action.payload.selected)) {
-        return action.payload;
+        return {
+          selected: action.payload.selected,
+          projectData: action.payload.projectData,
+          delta: {
+            newSelected: selected,
+            newUnselected: unselected,
+          },
+        };
       }
       return state;
     }

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -65,7 +65,7 @@ export interface DashState {
   // Contains a map of project names to the full project data.
   projectData: { [projectName: string]: IClutch.core.project.v1.IProject };
 
-  // contains delta in state change of newly selected/removed project(s) based on the previous selected state
+  // contains delta in state change of newly (un)selected project(s)
   delta?: DashStateDelta;
 }
 

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -64,6 +64,14 @@ export interface DashState {
 
   // Contains a map of project names to the full project data.
   projectData: { [projectName: string]: IClutch.core.project.v1.IProject };
+
+  // contains delta in state change of newly selected/removed project(s) based on the previous selected state
+  delta?: DashStateDelta;
+}
+
+interface DashStateDelta {
+  newSelected: string[];
+  newUnselected: string[];
 }
 
 export type DashActionKind = "UPDATE_SELECTED";


### PR DESCRIPTION
### Description
For card workflows, it's useful to know the deltas in state change for what was added to/removed from `selectedProjects`. For example, in this way, cards can make API requests to just newly added projects instead of having to request data for all selected projects again + the newly added project(s).

PR adds a new `delta` field to the dash hook containing the values of what projects where newly added/removed by doing comparisons between the state and action payload.

### Testing Performed
locally in internal implementation