### PR TITLE
dynamodb: add UpdateGSICapacity endpoint

### DIFF
--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -121,8 +121,9 @@ func (s *svc) UpdateTableCapacity(ctx context.Context, region string, tableName 
 	return stat, nil
 }
 
-func (s *svc) UpdateGSICapacity(ctx context.Context, region string, tableName string, indexName string, targetRCU int64, targetWCU int64) error {
-	return nil
+func (s *svc) UpdateGSICapacity(ctx context.Context, region string, tableName string, indexName string, targetRCU int64, targetWCU int64) (dynamodbv1.Status, error) {
+	stat := dynamodbv1.Status(3)
+	return stat, nil
 }
 
 func (s *svc) Regions() []string {

--- a/backend/module/dynamodb/dynamodb.go
+++ b/backend/module/dynamodb/dynamodb.go
@@ -3,9 +3,6 @@ package dynamodb
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	dynamodbv1 "github.com/lyft/clutch/backend/api/aws/dynamodb/v1"
 	"github.com/lyft/clutch/backend/service/aws"
 )
@@ -39,5 +36,10 @@ func (a *dynamodbAPI) UpdateTableCapacity(ctx context.Context, req *dynamodbv1.U
 }
 
 func (a *dynamodbAPI) UpdateGSICapacity(ctx context.Context, req *dynamodbv1.UpdateGSICapacityRequest) (*dynamodbv1.UpdateGSICapacityResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+	result, err := a.client.UpdateGSICapacity(ctx, req.Region, req.TableName, req.IndexName, req.TargetIndexRcu, req.TargetIndexWcu)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dynamodbv1.UpdateGSICapacityResponse{TableName: req.TableName, TableStatus: result}, nil
 }

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -116,6 +116,7 @@ type Client interface {
 
 	DescribeTable(ctx context.Context, region string, tableName string) (*dynamodbv1.Table, error)
 	UpdateTableCapacity(ctx context.Context, region string, tableName string, targetTableRcu int64, targetTableWcu int64) (dynamodbv1.Status, error)
+	UpdateGSICapacity(ctx context.Context, region string, tableName string, indexName string, targetIndexRcu int64, targetIndexWcu int64) (dynamodbv1.Status, error)
 
 	Regions() []string
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR implements the UpdateGSICapacity endpoint for the AWS Dynamodb service. UpdateGSICapacity will perform an update action on a specified global secondary index's provisioned capacity, checking against limits for safety.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
Unit and manual.

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
N/A

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
