### PR TITLE
dash: move loading prop to card header

### DIFF
--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -47,18 +47,23 @@ export interface CardProps {
 
 const Card = ({ children, ...props }: CardProps) => <StyledCard {...props}>{children}</StyledCard>;
 
-interface CardHeaderProps extends Pick<MuiCardHeaderProps, "avatar" | "title"> {}
+interface CardHeaderProps extends Pick<MuiCardHeaderProps, "avatar" | "title"> {
+  children?: React.ReactNode;
+}
 
-const CardHeader = ({ avatar, title }: CardHeaderProps) => (
-  <MuiCardHeader
-    style={{
-      background: "#EBEDFB",
-      padding: "16px",
-    }}
-    disableTypography
-    avatar={avatar}
-    title={<StyledTypography variant="h3">{title}</StyledTypography>}
-  />
+const CardHeader = ({ avatar, children, title }: CardHeaderProps) => (
+  <>
+    <MuiCardHeader
+      style={{
+        background: "#EBEDFB",
+        padding: "16px",
+      }}
+      disableTypography
+      avatar={avatar}
+      title={<StyledTypography variant="h3">{title}</StyledTypography>}
+    />
+    {children}
+  </>
 );
 
 interface CardContentProps extends MuiCardContentProps {}

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -47,15 +47,18 @@ export interface CardProps {
 
 const Card = ({ children, ...props }: CardProps) => <StyledCard {...props}>{children}</StyledCard>;
 
+const StyledCardHeaderContainer = styled.div({
+  background: "#EBEDFB",
+});
+
 interface CardHeaderProps extends Pick<MuiCardHeaderProps, "avatar" | "title"> {
   children?: React.ReactNode;
 }
 
 const CardHeader = ({ avatar, children, title }: CardHeaderProps) => (
-  <>
+  <StyledCardHeaderContainer>
     <MuiCardHeader
       style={{
-        background: "#EBEDFB",
         padding: "16px",
       }}
       disableTypography
@@ -63,7 +66,7 @@ const CardHeader = ({ avatar, children, title }: CardHeaderProps) => (
       title={<StyledTypography variant="h3">{title}</StyledTypography>}
     />
     {children}
-  </>
+  </StyledCardHeaderContainer>
 );
 
 interface CardContentProps extends MuiCardContentProps {}

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -6,6 +6,7 @@ import { Grid, LinearProgress } from "@material-ui/core";
 
 const StyledProgressContainer = styled.div({
   height: "4px",
+  background: "rgb(235, 237, 251)",
   ".MuiLinearProgress-root": {
     backgroundColor: "rgb(194, 200, 242)",
   },
@@ -25,12 +26,11 @@ interface CardProps {
 const Card = ({ avatar, children, error, isLoading, title }: CardProps) => (
   <Grid item xs={12} sm={6}>
     <ClutchCard>
-      <CardHeader avatar={avatar} title={title} />
-      {isLoading && (
+      <CardHeader avatar={avatar} title={title}>
         <StyledProgressContainer>
-          <LinearProgress color="secondary" />
+          {isLoading && <LinearProgress color="secondary" />}
         </StyledProgressContainer>
-      )}
+      </CardHeader>
       {error ? <Error subject={error} /> : children}
     </ClutchCard>
   </Grid>

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -6,7 +6,6 @@ import { Grid, LinearProgress } from "@material-ui/core";
 
 const StyledProgressContainer = styled.div({
   height: "4px",
-  background: "rgb(235, 237, 251)",
   ".MuiLinearProgress-root": {
     backgroundColor: "rgb(194, 200, 242)",
   },


### PR DESCRIPTION
### Description
Previously, the loading component was conditionally rendered in between the card header & children and so it pushed down the child component every time there was loading state.

Before:
![before](https://user-images.githubusercontent.com/39421794/129745096-f601e078-4370-46df-8ccb-e76561f68bb9.gif)

PR moves the loading component to the card header so that it doesn't push down the child component
After:
![after](https://user-images.githubusercontent.com/39421794/129747318-6c9f5e3b-367d-4cde-b775-1c873bd8f57e.gif)


### Testing Performed
locally with internal cards