### PR TITLE
core table row: use hex instead of rgb

### DIFF
--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -51,7 +51,7 @@ const StyledTableHead = styled(MuiTableHead)({
 const StyledTableRow = styled(MuiTableRow)<{ responsive?: boolean }>(
   {
     ":nth-of-type(even)": {
-      background: "rgba(13, 16, 48, 0.03)",
+      background: "#F8F8F9",
     },
     ":hover": {
       background: "#EBEDFB",


### PR DESCRIPTION
### Description
Noticed that the table row gray color is different between the 2 internal cards. The difference between the 2 cards is that one uses the `responsive` prop.

This can also be reproduced locally in storybook by adding the `responsive` prop here https://github.com/lyft/clutch/blob/main/frontend/packages/core/src/Table/stories/table.stories.tsx#L22.

In reviewing the styling for the TableRow, the background should be same regardless of whether the responsive prop is used https://github.com/lyft/clutch/blob/main/frontend/packages/core/src/Table/table.tsx#L51-L64. However, in locally setting the `nth` row to different colors, it seems that using an rgb value with opacity is causing this color difference b/w prop usage and changing it to HEX fixes the color difference issue (got the HEX value from figma). Weird bug, not sure why rgb vs hex would matter.

Before: Using the responsive prop
<img width="294" alt="Screen Shot 2021-08-17 at 2 34 31 PM" src="https://user-images.githubusercontent.com/39421794/129781715-1ded4a85-bbee-480d-88d9-37cfbb0ff265.png">

Before: Not using the responsive prop
<img width="294" alt="Screen Shot 2021-08-17 at 2 34 15 PM" src="https://user-images.githubusercontent.com/39421794/129781753-d6fef8e2-844d-4ad2-83d2-1d413c82056f.png">

### Testing Performed
locally