### PR TITLE
core: add configurable padding to CardContent

### DIFF
--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -35,7 +35,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@material-ui/system": "^4.12.1",
+    "@material-ui/system": "^4.11.4",
     "axios": "^0.21.1",
     "history": "^5.0.0",
     "js-cookie": "^3.0.0",

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -35,6 +35,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
+    "@material-ui/system": "^4.12.1",
     "axios": "^0.21.1",
     "history": "^5.0.0",
     "js-cookie": "^3.0.0",

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import type {
-  CardContentProps as MuiCardContentProps,
-  CardHeaderProps as MuiCardHeaderProps,
-} from "@material-ui/core";
+import type { CardHeaderProps as MuiCardHeaderProps } from "@material-ui/core";
 import {
   Avatar,
   Card as MuiCard,
   CardActionArea,
   CardActionAreaProps,
-  CardContent as MuiCardContent,
   CardHeader as MuiCardHeader,
 } from "@material-ui/core";
+import { spacing } from "@material-ui/system";
 
 import { StyledTypography } from "./typography";
 
@@ -32,16 +29,6 @@ const StyledCard = styled(MuiCard)({
     backgroundColor: "#D7DAF6",
   },
 });
-
-const StyledCardContent = styled(MuiCardContent)((props: { disablePadding?: boolean }) => ({
-  "> .MuiPaper-root": {
-    border: "0",
-    borderRadius: "0",
-  },
-  "&.MuiCardContent-root": {
-    padding: props.disablePadding ? "0px" : "32px",
-  },
-}));
 
 export interface CardProps {
   children?: React.ReactNode | React.ReactNode[];
@@ -71,14 +58,31 @@ const CardHeader = ({ avatar, children, title }: CardHeaderProps) => (
   </StyledCardHeaderContainer>
 );
 
-interface CardContentProps extends MuiCardContentProps {
-  disablePadding?: boolean;
+// Material UI Spacing system supports many props https://material-ui.com/system/spacing/#api
+// We can add more to this list as use cases arise
+interface SpacingProps {
+  padding?: number;
+  // shorthand for padding
+  p?: number;
 }
 
-const CardContent = ({ children, disablePadding = false, ...props }: CardContentProps) => (
-  <StyledCardContent disablePadding={disablePadding} {...props}>
-    {children}
-  </StyledCardContent>
+const BaseCardContent = styled.div<SpacingProps>`
+  ${spacing}
+`;
+
+const StyledCardContent = styled(BaseCardContent)({
+  "> .MuiPaper-root": {
+    border: "0",
+    borderRadius: "0",
+  },
+});
+
+interface CardContentProps extends SpacingProps {
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+const CardContent = ({ children, ...props }: CardContentProps) => (
+  <StyledCardContent {...props}>{children}</StyledCardContent>
 );
 
 const StyledLandingCard = styled(Card)({
@@ -111,7 +115,7 @@ export interface LandingCardProps extends Pick<CardActionAreaProps, "onClick"> {
 export const LandingCard = ({ group, title, description, onClick, ...props }: LandingCardProps) => (
   <StyledLandingCard {...props}>
     <CardActionArea onClick={onClick}>
-      <CardContent>
+      <CardContent padding={4}>
         <div className="header">
           <div className="icon">
             <Avatar>{group.charAt(0)}</Avatar>

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -20,7 +20,6 @@ const StyledCard = styled(MuiCard)({
   border: "1px solid rgba(13, 16, 48, 0.1)",
 
   ".MuiCardContent-root": {
-    padding: "32px",
     color: "#0D1030",
     fontSize: "16px",
   },
@@ -34,12 +33,15 @@ const StyledCard = styled(MuiCard)({
   },
 });
 
-const StyledCardContent = styled(MuiCardContent)({
+const StyledCardContent = styled(MuiCardContent)((props: { disablePadding?: boolean }) => ({
   "> .MuiPaper-root": {
     border: "0",
     borderRadius: "0",
   },
-});
+  "&.MuiCardContent-root": {
+    padding: props.disablePadding ? "0px" : "32px",
+  },
+}));
 
 export interface CardProps {
   children?: React.ReactNode | React.ReactNode[];
@@ -69,10 +71,14 @@ const CardHeader = ({ avatar, children, title }: CardHeaderProps) => (
   </StyledCardHeaderContainer>
 );
 
-interface CardContentProps extends MuiCardContentProps {}
+interface CardContentProps extends MuiCardContentProps {
+  disablePadding?: boolean;
+}
 
-const CardContent = ({ children, ...props }: CardContentProps) => (
-  <StyledCardContent {...props}>{children}</StyledCardContent>
+const CardContent = ({ children, disablePadding = false, ...props }: CardContentProps) => (
+  <StyledCardContent disablePadding={disablePadding} {...props}>
+    {children}
+  </StyledCardContent>
 );
 
 const StyledLandingCard = styled(Card)({

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -8,18 +8,14 @@ import {
   CardActionAreaProps,
   CardHeader as MuiCardHeader,
 } from "@material-ui/core";
+import type { SpacingProps as MuiSpacingProps } from "@material-ui/system";
 import { spacing } from "@material-ui/system";
 
-import { StyledTypography } from "./typography";
+import { Typography } from "./typography";
 
 const StyledCard = styled(MuiCard)({
   boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
   border: "1px solid rgba(13, 16, 48, 0.1)",
-
-  ".MuiCardContent-root": {
-    color: "#0D1030",
-    fontSize: "16px",
-  },
 
   ".MuiCardActionArea-root:hover": {
     backgroundColor: "#F5F6FD",
@@ -52,7 +48,7 @@ const CardHeader = ({ avatar, children, title }: CardHeaderProps) => (
       }}
       disableTypography
       avatar={avatar}
-      title={<StyledTypography variant="h3">{title}</StyledTypography>}
+      title={<Typography variant="h3">{title}</Typography>}
     />
     {children}
   </StyledCardHeaderContainer>
@@ -60,11 +56,7 @@ const CardHeader = ({ avatar, children, title }: CardHeaderProps) => (
 
 // Material UI Spacing system supports many props https://material-ui.com/system/spacing/#api
 // We can add more to this list as use cases arise
-interface SpacingProps {
-  padding?: number;
-  // shorthand for padding
-  p?: number;
-}
+interface SpacingProps extends Pick<MuiSpacingProps, "padding" | "p"> {}
 
 const BaseCardContent = styled.div<SpacingProps>`
   ${spacing}
@@ -123,10 +115,10 @@ export const LandingCard = ({ group, title, description, onClick, ...props }: La
           <span>{group}</span>
         </div>
         <div>
-          <StyledTypography variant="h3">{title}</StyledTypography>
-          <StyledTypography style={{ color: "rgba(13, 16, 48, 0.6)" }} variant="body2">
+          <Typography variant="h3">{title}</Typography>
+          <Typography color="rgba(13, 16, 48, 0.6)" variant="body2">
             {description}
-          </StyledTypography>
+          </Typography>
         </div>
       </CardContent>
     </CardActionArea>

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -30,7 +30,7 @@ const Card = ({ avatar, children, error, isLoading, title }: CardProps) => (
           {isLoading && <LinearProgress color="secondary" />}
         </StyledProgressContainer>
       </CardHeader>
-      <CardContent disablePadding>{error ? <Error subject={error} /> : children}</CardContent>
+      <CardContent padding={0}>{error ? <Error subject={error} /> : children}</CardContent>
     </ClutchCard>
   </Grid>
 );

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { ClutchError } from "@clutch-sh/core";
-import { Card as ClutchCard, CardHeader, Error } from "@clutch-sh/core";
+import { Card as ClutchCard, CardContent, CardHeader, Error } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import { Grid, LinearProgress } from "@material-ui/core";
 
@@ -30,7 +30,7 @@ const Card = ({ avatar, children, error, isLoading, title }: CardProps) => (
           {isLoading && <LinearProgress color="secondary" />}
         </StyledProgressContainer>
       </CardHeader>
-      {error ? <Error subject={error} /> : children}
+      <CardContent disablePadding>{error ? <Error subject={error} /> : children}</CardContent>
     </ClutchCard>
   </Grid>
 );


### PR DESCRIPTION
### Description

PR also makes the CardContent padding configurable via the Material UI spacing system https://material-ui.com/system/spacing/#api

PR also wraps the Dash card children in the CardContent component to fix issues where the card children have their own border styling. Example below: the Table component's [Paper ](https://github.com/lyft/clutch/blob/d3632a1426c51211f66b690e871a485e09a6f0c0/frontend/packages/core/src/Table/table.tsx#L21)has border styling and so it looks like the card children area isn't aligned with the card header. (Also, the CardContent component will be useful if we want to add card actions to it, ie "expand to see more").
<img width="63" alt="Screen Shot 2021-08-23 at 11 06 17 AM" src="https://user-images.githubusercontent.com/39421794/130471720-6caaac00-f754-4697-bf9a-221a5693ac74.png">

### Testing Performed
locally

0px padding on the CardContent
<img width="555" alt="Screen Shot 2021-08-31 at 12 03 42 PM" src="https://user-images.githubusercontent.com/39421794/131537199-0403720b-6243-4a74-9bb6-d85113f029c5.png">

32px padding (the value we currently use) on the Landing cards which use the CardContent as well

<img width="1284" alt="Screen Shot 2021-08-31 at 12 04 02 PM" src="https://user-images.githubusercontent.com/39421794/131537251-ace4ac6e-f789-47dc-a99b-04461378daea.png">