### PR TITLE
github: upgrade github to v38

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.14.1
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-github/v29 v29.0.3 // indirect
-	github.com/google/go-github/v37 v37.0.0
+	github.com/google/go-github/v38 v38.1.0
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -355,8 +355,8 @@ github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv3
 github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
 github.com/google/go-github/v29 v29.0.3 h1:IktKCTwU//aFHnpA+2SLIi7Oo9uhAzgsdZNbcAqhgdc=
 github.com/google/go-github/v29 v29.0.3/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
-github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
-github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
+github.com/google/go-github/v38 v38.1.0 h1:C6h1FkaITcBFK7gAmq4eFzt6gbhEhk7L5z6R3Uva+po=
+github.com/google/go-github/v38 v38.1.0/go.mod h1:cStvrz/7nFr0FoENgG6GLbp53WaelXucT+BBz/3VKx4=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/any"
-	githubv3 "github.com/google/go-github/v37/github"
+	githubv3 "github.com/google/go-github/v38/github"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -23,7 +23,7 @@ import (
 	gittransport "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/golang/protobuf/ptypes/any"
-	githubv3 "github.com/google/go-github/v37/github"
+	githubv3 "github.com/google/go-github/v38/github"
 	"github.com/shurcooL/githubv4"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
@@ -403,7 +403,7 @@ func (s *svc) GetFile(ctx context.Context, ref *RemoteRef, path string) (*File, 
  * Rather than calling GetCommit() multiple times, we can use CompareCommits to get a range of commits
  */
 func (s *svc) CompareCommits(ctx context.Context, ref *RemoteRef, compareSHA string) (*githubv3.CommitsComparison, error) {
-	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref)
+	comp, _, err := s.rest.Repositories.CompareCommits(ctx, ref.RepoOwner, ref.RepoName, compareSHA, ref.Ref, &githubv3.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("Could not get comparison for %s and %s. %+v", ref.Ref, compareSHA, err)
 	}
@@ -419,7 +419,7 @@ type Commit struct {
 }
 
 func (s *svc) GetCommit(ctx context.Context, ref *RemoteRef) (*Commit, error) {
-	commit, _, err := s.rest.Repositories.GetCommit(ctx, ref.RepoOwner, ref.RepoName, ref.Ref)
+	commit, _, err := s.rest.Repositories.GetCommit(ctx, ref.RepoOwner, ref.RepoName, ref.Ref, &githubv3.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	githubv3 "github.com/google/go-github/v37/github"
+	githubv3 "github.com/google/go-github/v38/github"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 
@@ -166,7 +166,7 @@ func (m *mockRepositories) GetContents(_ context.Context, _, _, _ string, _ *git
 	return &githubv3.RepositoryContent{}, nil, nil, nil
 }
 
-func (m *mockRepositories) CompareCommits(ctx context.Context, owner, repo, base, head string) (*githubv3.CommitsComparison, *githubv3.Response, error) {
+func (m *mockRepositories) CompareCommits(ctx context.Context, owner, repo, base, head string, opts *githubv3.ListOptions) (*githubv3.CommitsComparison, *githubv3.Response, error) {
 	if m.generalError {
 		return nil, nil, errors.New(problem)
 	}
@@ -178,7 +178,7 @@ func (m *mockRepositories) CompareCommits(ctx context.Context, owner, repo, base
 		}}, nil, nil
 }
 
-func (m *mockRepositories) GetCommit(ctx context.Context, owner, repo, sha string) (*githubv3.RepositoryCommit, *githubv3.Response, error) {
+func (m *mockRepositories) GetCommit(ctx context.Context, owner, repo, sha string, opts *githubv3.ListOptions) (*githubv3.RepositoryCommit, *githubv3.Response, error) {
 	file := "testfile.go"
 	message := "committing some changes (#1)"
 	authorLogin := "foobar"

--- a/backend/service/github/iface.go
+++ b/backend/service/github/iface.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	githubv3 "github.com/google/go-github/v37/github"
+	githubv3 "github.com/google/go-github/v38/github"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -24,8 +24,8 @@ type v3repositories interface {
 	// Create a new repository. If an org is specified, the new repository will be created under that org. If the empty string is specified, it will be created for the authenticated user.
 	Create(ctx context.Context, org string, repo *githubv3.Repository) (*githubv3.Repository, *githubv3.Response, error)
 	GetContents(ctx context.Context, owner, repo, path string, opt *githubv3.RepositoryContentGetOptions) (*githubv3.RepositoryContent, []*githubv3.RepositoryContent, *githubv3.Response, error)
-	CompareCommits(ctx context.Context, owner, repo string, base, head string) (*githubv3.CommitsComparison, *githubv3.Response, error)
-	GetCommit(ctx context.Context, owner, repo, sha string) (*githubv3.RepositoryCommit, *githubv3.Response, error)
+	CompareCommits(ctx context.Context, owner, repo string, base, head string, opts *githubv3.ListOptions) (*githubv3.CommitsComparison, *githubv3.Response, error)
+	GetCommit(ctx context.Context, owner, repo, sha string, opts *githubv3.ListOptions) (*githubv3.RepositoryCommit, *githubv3.Response, error)
 }
 
 // Interface for struct defined in https://github.com/google/go-github/blob/master/github/pulls.go.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Updating github lib to v38, which includes some interface changes that we need to accommodate. 

### Testing Performed
unit

- [ ] check new paging behavior
- [ ] decide if we want to expose page / limit to our pubic api

