### PR TITLE
dash cards: update/add breakpoints

### DIFF
--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -96,6 +96,8 @@ const TableContainer = ({ children }: TableContainerProps) => (
 export interface TableProps extends Pick<MuiTableProps, "stickyHeader"> {
   /** The names of the columns. This must be set (even to empty string) to render the table. */
   columns: string[];
+  /** The breakpoint at which to compress the table rows. By default the small breakpoint is used. */
+  compressBreakpoint?: "xs" | "sm" | "md" | "lg" | "xl";
   /** Hide the header. By default this is false. */
   hideHeader?: boolean;
   /** Add an actions column. By default this is false. */
@@ -110,6 +112,7 @@ export interface TableProps extends Pick<MuiTableProps, "stickyHeader"> {
 
 const Table: React.FC<TableProps> = ({
   columns,
+  compressBreakpoint = "sm",
   hideHeader = false,
   actionsColumn = false,
   responsive = false,
@@ -117,7 +120,7 @@ const Table: React.FC<TableProps> = ({
   ...props
 }) => {
   const showHeader = !hideHeader;
-  const compress = useMediaQuery((theme: any) => theme.breakpoints.down("md"));
+  const compress = useMediaQuery((theme: any) => theme.breakpoints.down(compressBreakpoint));
 
   return (
     <TableContainer>

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -13,6 +13,7 @@ import {
   TableRowProps as MuiTableRowProps,
   useMediaQuery,
 } from "@material-ui/core";
+import type { Breakpoint } from "@material-ui/core/styles/createBreakpoints";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 
 import { Popper, PopperItem } from "../popper";
@@ -97,7 +98,7 @@ export interface TableProps extends Pick<MuiTableProps, "stickyHeader"> {
   /** The names of the columns. This must be set (even to empty string) to render the table. */
   columns: string[];
   /** The breakpoint at which to compress the table rows. By default the small breakpoint is used. */
-  compressBreakpoint?: "xs" | "sm" | "md" | "lg" | "xl";
+  compressBreakpoint?: Breakpoint;
   /** Hide the header. By default this is false. */
   hideHeader?: boolean;
   /** Add an actions column. By default this is false. */

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -24,7 +24,7 @@ interface CardProps {
 }
 
 const Card = ({ avatar, children, error, isLoading, summary, title }: CardProps) => (
-  <Grid item xs={12} sm={6}>
+  <Grid item xs={12} sm={12} md={6}>
     <ClutchCard>
       <CardHeader avatar={avatar} summary={summary} title={title}>
         <StyledProgressContainer>

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -24,7 +24,7 @@ interface CardProps {
 }
 
 const Card = ({ avatar, children, error, isLoading, summary, title }: CardProps) => (
-  <Grid item xs={12} sm={12} md={6}>
+  <Grid item xs={12} sm={12} md={12} lg={6}>
     <ClutchCard>
       <CardHeader avatar={avatar} summary={summary} title={title}>
         <StyledProgressContainer>

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -1,10 +1,8 @@
 import * as React from "react";
-import { Table, TableRow, Typography } from "@clutch-sh/core";
 import styled from "@emotion/styled";
-import { Box, Grid as MuiGrid } from "@material-ui/core";
+import { Box } from "@material-ui/core";
 import _ from "lodash";
 
-import Card from "./card";
 import { DashDispatchContext, DashStateContext } from "./dash-hooks";
 import ProjectSelector from "./project-selector";
 import type { DashAction, DashState } from "./types";
@@ -19,10 +17,6 @@ const CardContainer = styled.div({
   flex: 1,
   maxHeight: "100%",
   overflowY: "scroll",
-});
-
-const BigGrid = styled(MuiGrid)({
-  margin: "7px",
 });
 
 const dashReducer = (state: DashState, action: DashAction): DashState => {
@@ -46,123 +40,7 @@ const Dash = ({ children }) => {
       <DashDispatchContext.Provider value={dispatch}>
         <DashStateContext.Provider value={state}>
           <ProjectSelector />
-          <CardContainer>
-            <BigGrid
-              spacing={3}
-              container
-              direction="row"
-              justify="flex-start"
-              alignItems="flex-start"
-              alignContent="flex-start"
-            >
-              <Card
-                avatar="🚀"
-                title="Deploys"
-                summary={[
-                  {
-                    title: <Typography variant="subtitle2">-</Typography>,
-                    subheader: "Last Deploy",
-                  },
-                  {
-                    title: (
-                      <Typography variant="subtitle2" color="#3548D4">
-                        0
-                      </Typography>
-                    ),
-                    subheader: "In progress",
-                  },
-                  {
-                    title: (
-                      <Typography variant="subtitle2" color="#DB3615">
-                        0
-                      </Typography>
-                    ),
-                    subheader: "Failed Deploys",
-                  },
-                ]}
-              >
-                <Table columns={["", "", "", ""]} responsive>
-                  <TableRow>
-                    <div>clutch</div>
-                    <div>No commits</div>
-                    <div>0m</div>
-                    <div>✅ 🥚</div>
-                  </TableRow>
-                  <TableRow>
-                    <div>clutch</div>
-                    <div>No commits</div>
-                    <div>0m</div>
-                    <div>✅ 🥚</div>
-                  </TableRow>
-                  <TableRow>
-                    <div>clutch</div>
-                    <div>No commits</div>
-                    <div>0m</div>
-                    <div>✅ 🥚</div>
-                  </TableRow>
-                </Table>
-              </Card>
-              <Card
-                avatar="🚨"
-                title="Alerts"
-                summary={[
-                  {
-                    title: <Typography variant="subtitle2">-</Typography>,
-                    subheader: "Last alert",
-                  },
-                  {
-                    title: (
-                      <Typography variant="subtitle2" color="#3548D4">
-                        0
-                      </Typography>
-                    ),
-                    subheader: "Open",
-                  },
-                  {
-                    title: (
-                      <Typography variant="subtitle2" color="#DB3615">
-                        0
-                      </Typography>
-                    ),
-                    subheader: "Acknowledged",
-                  },
-                ]}
-              >
-                <Table columns={["", "", "", ""]} responsive>
-                  <TableRow>
-                    <div>clutch</div>
-                    <div>No alerts</div>
-                    <></>
-                    <></>
-                  </TableRow>
-                  <TableRow>
-                    <div>clutch</div>
-                    <div>No alerts</div>
-                    <></>
-                    <></>
-                  </TableRow>
-                  <TableRow>
-                    <div>clutch</div>
-                    <div>No alerts</div>
-                    <></>
-                    <></>
-                  </TableRow>
-                </Table>
-              </Card>
-              <Card avatar="🌏" title="Incidents">
-                <Table columns={["", ""]} responsive>
-                  <TableRow>
-                    <div>AWS</div>
-                    <div>Healthy</div>
-                  </TableRow>
-                  <TableRow>
-                    <div>Github</div>
-                    <div>Healthy</div>
-                  </TableRow>
-                </Table>
-              </Card>
-            </BigGrid>
-          </CardContainer>
+          <CardContainer>{children}</CardContainer>
         </DashStateContext.Provider>
       </DashDispatchContext.Provider>
     </Box>

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -81,7 +81,7 @@ const Dash = ({ children }) => {
                   },
                 ]}
               >
-                <Table columns={["", "", "", ""]}>
+                <Table columns={["", "", "", ""]} responsive>
                   <TableRow>
                     <div>clutch</div>
                     <div>No commits</div>
@@ -128,7 +128,7 @@ const Dash = ({ children }) => {
                   },
                 ]}
               >
-                <Table columns={["", "", "", ""]}>
+                <Table columns={["", "", "", ""]} responsive>
                   <TableRow>
                     <div>clutch</div>
                     <div>No alerts</div>
@@ -150,7 +150,7 @@ const Dash = ({ children }) => {
                 </Table>
               </Card>
               <Card avatar="🌏" title="Incidents">
-                <Table columns={["", ""]}>
+                <Table columns={["", ""]} responsive>
                   <TableRow>
                     <div>AWS</div>
                     <div>Healthy</div>

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
+import { Table, TableRow, Typography } from "@clutch-sh/core";
 import styled from "@emotion/styled";
-import { Box } from "@material-ui/core";
+import { Box, Grid as MuiGrid } from "@material-ui/core";
 import _ from "lodash";
 
+import Card from "./card";
 import { DashDispatchContext, DashStateContext } from "./dash-hooks";
 import ProjectSelector from "./project-selector";
 import type { DashAction, DashState } from "./types";
@@ -17,6 +19,10 @@ const CardContainer = styled.div({
   flex: 1,
   maxHeight: "100%",
   overflowY: "scroll",
+});
+
+const BigGrid = styled(MuiGrid)({
+  margin: "7px",
 });
 
 const dashReducer = (state: DashState, action: DashAction): DashState => {
@@ -40,7 +46,123 @@ const Dash = ({ children }) => {
       <DashDispatchContext.Provider value={dispatch}>
         <DashStateContext.Provider value={state}>
           <ProjectSelector />
-          <CardContainer>{children}</CardContainer>
+          <CardContainer>
+            <BigGrid
+              spacing={3}
+              container
+              direction="row"
+              justify="flex-start"
+              alignItems="flex-start"
+              alignContent="flex-start"
+            >
+              <Card
+                avatar="🚀"
+                title="Deploys"
+                summary={[
+                  {
+                    title: <Typography variant="subtitle2">-</Typography>,
+                    subheader: "Last Deploy",
+                  },
+                  {
+                    title: (
+                      <Typography variant="subtitle2" color="#3548D4">
+                        0
+                      </Typography>
+                    ),
+                    subheader: "In progress",
+                  },
+                  {
+                    title: (
+                      <Typography variant="subtitle2" color="#DB3615">
+                        0
+                      </Typography>
+                    ),
+                    subheader: "Failed Deploys",
+                  },
+                ]}
+              >
+                <Table columns={["", "", "", ""]}>
+                  <TableRow>
+                    <div>clutch</div>
+                    <div>No commits</div>
+                    <div>0m</div>
+                    <div>✅ 🥚</div>
+                  </TableRow>
+                  <TableRow>
+                    <div>clutch</div>
+                    <div>No commits</div>
+                    <div>0m</div>
+                    <div>✅ 🥚</div>
+                  </TableRow>
+                  <TableRow>
+                    <div>clutch</div>
+                    <div>No commits</div>
+                    <div>0m</div>
+                    <div>✅ 🥚</div>
+                  </TableRow>
+                </Table>
+              </Card>
+              <Card
+                avatar="🚨"
+                title="Alerts"
+                summary={[
+                  {
+                    title: <Typography variant="subtitle2">-</Typography>,
+                    subheader: "Last alert",
+                  },
+                  {
+                    title: (
+                      <Typography variant="subtitle2" color="#3548D4">
+                        0
+                      </Typography>
+                    ),
+                    subheader: "Open",
+                  },
+                  {
+                    title: (
+                      <Typography variant="subtitle2" color="#DB3615">
+                        0
+                      </Typography>
+                    ),
+                    subheader: "Acknowledged",
+                  },
+                ]}
+              >
+                <Table columns={["", "", "", ""]}>
+                  <TableRow>
+                    <div>clutch</div>
+                    <div>No alerts</div>
+                    <></>
+                    <></>
+                  </TableRow>
+                  <TableRow>
+                    <div>clutch</div>
+                    <div>No alerts</div>
+                    <></>
+                    <></>
+                  </TableRow>
+                  <TableRow>
+                    <div>clutch</div>
+                    <div>No alerts</div>
+                    <></>
+                    <></>
+                  </TableRow>
+                </Table>
+              </Card>
+              <Card avatar="🌏" title="Incidents">
+                <Table columns={["", ""]}>
+                  <TableRow>
+                    <div>AWS</div>
+                    <div>Healthy</div>
+                  </TableRow>
+                  <TableRow>
+                    <div>Github</div>
+                    <div>Healthy</div>
+                  </TableRow>
+                </Table>
+              </Card>
+            </BigGrid>
+          </CardContainer>
         </DashStateContext.Provider>
       </DashDispatchContext.Provider>
     </Box>


### PR DESCRIPTION
### Description
Currently, the cards remain side by side until the screen size reaches the `xs` breakpoint. Since card info can be dense (i.e. many columns) we want the cards to take the screen's full width at an earlier breakpoint.
* PR updates the small breakpoint value and adds the medium and large breakpoint so that the cards remain side by side until the screen size becomes less than 1280px. https://material-ui.com/customization/breakpoints/
* Tables are used in the internal cards and realized that it has a default breakpoint at which to compress the table rows. Since cards take up full width now, PR changes the default to `small` so that the table rows take up the full space available and also adds a `compressBreakpoint` prop so that user can change the default value.


### Testing Performed
locally

![update](https://user-images.githubusercontent.com/39421794/133285735-b8af582b-26a9-437a-861e-76318273aa07.gif)



