### PR TITLE
dynamodb: fix empty list mapping

### DIFF
--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -70,6 +70,10 @@ const TableDetails: React.FC<TableDetailsChild> = ({ enableOverride }) => {
     capacityUpdates.updateData("gsi_updates", updatesList);
   };
 
+  if (!_.has(table,"globalSecondaryIndexes")) {
+    table.globalSecondaryIndexes = []
+  }
+
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
       <Box>
@@ -197,7 +201,7 @@ const Confirm: React.FC<WizardChild> = () => {
   );
 };
 
-const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, enableOverride }) => {
+const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, enableOverride, heading }) => {
   const dataLayout = {
     resourceData: {},
     capacityUpdates: {},
@@ -244,8 +248,8 @@ const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, enableOverride 
   };
 
   return (
-    <Wizard dataLayout={dataLayout}>
-      <TableIdentifier name="Lookup" resolverType={resolverType} />
+    <Wizard dataLayout={dataLayout} heading={heading}>
+      <TableIdentifier name="Lookup" resolverType={resolverType}/>
       <TableDetails name="Modify" enableOverride={enableOverride} />
       <Confirm name="Results" />
     </Wizard>

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -70,8 +70,8 @@ const TableDetails: React.FC<TableDetailsChild> = ({ enableOverride }) => {
     capacityUpdates.updateData("gsi_updates", updatesList);
   };
 
-  if (!_.has(table,"globalSecondaryIndexes")) {
-    table.globalSecondaryIndexes = []
+  if (!_.has(table, "globalSecondaryIndexes")) {
+    table.globalSecondaryIndexes = [];
   }
 
   return (
@@ -249,7 +249,7 @@ const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, enableOverride,
 
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
-      <TableIdentifier name="Lookup" resolverType={resolverType}/>
+      <TableIdentifier name="Lookup" resolverType={resolverType} />
       <TableDetails name="Modify" enableOverride={enableOverride} />
       <Confirm name="Results" />
     </Wizard>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR fixes a bug when modifying tables with no global secondary indexes. Previously, it was trying to perform mapping on non-existent lists and throwing errors as a result.

This PR also adds a header to the workflow.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual local changes
