### PR TITLE
dynamodb: fix BillingMode to proto method

### DIFF
--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -45,11 +45,16 @@ func (c *client) DescribeTable(ctx context.Context, region string, tableName str
 	result, err := getTable(ctx, cl, tableName)
 
 	if err != nil {
-		c.log.Error("unable to find table", zap.Error(err))
+		c.log.Warn("unable to find table on region: "+region, zap.Error(err))
 		return nil, err
 	}
 
-	ret := newProtoForTable(result.Table, region)
+	table, ok := result.Table
+	if !ok {
+		return nil, status.Error(codes.NotFound, "Table description not found")
+	}
+
+	ret := newProtoForTable(table, region)
 
 	return ret, nil
 }

--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -124,12 +124,13 @@ func newProtoForIndexStatus(s types.IndexStatus) dynamodbv1.GlobalSecondaryIndex
 // if a table is PAY_PER_REQUEST (on demand), it will have 0 RCU/WCU provisioned
 func checkBillingMode(t *types.ProvisionedThroughputDescription) types.BillingMode {
 	if (*t.ReadCapacityUnits > 0) || (*t.WriteCapacityUnits > 0) {
-		return "PROVISIONED"
+		return types.BillingModeProvisioned
 	}
 	if (*t.ReadCapacityUnits == 0) || (*t.WriteCapacityUnits == 0) {
-		return "PAY_PER_REQUEST"
+		return types.BillingModePayPerRequest
 	}
-	return "UNKNOWN" // unable to infer what billing mode it is
+
+	return "UNSPECIFIED" // unable to infer what billing mode it is
 }
 
 func newProtoForBillingMode(t *types.TableDescription) dynamodbv1.Table_BillingMode {
@@ -199,9 +200,9 @@ func isValidIncrease(client *regionalClient, current *types.ProvisionedThroughpu
 func isProvisioned(t *dynamodb.DescribeTableOutput) bool {
 	if t.Table.BillingModeSummary == nil {
 		billingMode := checkBillingMode(t.Table.ProvisionedThroughput)
-		return billingMode == "PROVISIONED"
+		return billingMode == types.BillingModeProvisioned
 	}
-	return t.Table.BillingModeSummary.BillingMode == "PROVISIONED"
+	return t.Table.BillingModeSummary.BillingMode == types.BillingModeProvisioned
 }
 
 func (c *client) UpdateCapacity(ctx context.Context, region string, tableName string, targetTableCapacity *dynamodbv1.Throughput, indexUpdates []*dynamodbv1.IndexUpdateAction, ignore_maximums bool) (*dynamodbv1.Table, error) {

--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -122,7 +122,7 @@ func newProtoForIndexStatus(s types.IndexStatus) dynamodbv1.GlobalSecondaryIndex
 // to cover cases where AWS does not return the mode in the table description
 // if a table is PROVISIONED, it will have at least 1 RCU/WCU provisioned
 // if a table is PAY_PER_REQUEST (on demand), it will have 0 RCU/WCU provisioned
-func checkBillingMode(t *types.ProvisionedThroughputDescription) types.BillingMode {
+func getBillingMode(t *types.ProvisionedThroughputDescription) types.BillingMode {
 	if (*t.ReadCapacityUnits > 0) || (*t.WriteCapacityUnits > 0) {
 		return types.BillingModeProvisioned
 	}
@@ -136,7 +136,7 @@ func checkBillingMode(t *types.ProvisionedThroughputDescription) types.BillingMo
 func newProtoForBillingMode(t *types.TableDescription) dynamodbv1.Table_BillingMode {
 	var billingMode types.BillingMode
 	if t.BillingModeSummary == nil {
-		billingMode = checkBillingMode(t.ProvisionedThroughput)
+		billingMode = getBillingMode(t.ProvisionedThroughput)
 	} else {
 		billingMode = t.BillingModeSummary.BillingMode
 	}
@@ -199,7 +199,7 @@ func isValidIncrease(client *regionalClient, current *types.ProvisionedThroughpu
 // as well to determine if a table capacity is provisioned
 func isProvisioned(t *dynamodb.DescribeTableOutput) bool {
 	if t.Table.BillingModeSummary == nil {
-		billingMode := checkBillingMode(t.Table.ProvisionedThroughput)
+		billingMode := getBillingMode(t.Table.ProvisionedThroughput)
 		return billingMode == types.BillingModeProvisioned
 	}
 	return t.Table.BillingModeSummary.BillingMode == types.BillingModeProvisioned

--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -49,7 +49,6 @@ func (c *client) DescribeTable(ctx context.Context, region string, tableName str
 		return nil, err
 	}
 
-	c.log.Info("generating new proto")
 	ret := newProtoForTable(result.Table, region)
 
 	return ret, nil

--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -21,6 +21,10 @@ const (
 	SafeScaleFactor = 2.0
 )
 
+// constant to cover edge case where billing mode is not in table description
+// and we cannot infer the billing mode from the provisioned throughput numbers
+const TableBillingUnspecified = "UNSPECIFIED"
+
 // get or set defaults for dynamodb scaling
 func getScalingLimits(cfg *awsv1.Config) *awsv1.ScalingLimits {
 	if cfg.GetDynamodbConfig() == nil && cfg.DynamodbConfig.GetScalingLimits() == nil {
@@ -118,7 +122,7 @@ func newProtoForIndexStatus(s types.IndexStatus) dynamodbv1.GlobalSecondaryIndex
 	return dynamodbv1.GlobalSecondaryIndex_Status(value)
 }
 
-// manually check the billing mode by inferring it from throughput
+// manually retrieve the billing mode by inferring it from throughput
 // to cover cases where AWS does not return the mode in the table description
 // if a table is PROVISIONED, it will have at least 1 RCU/WCU provisioned
 // if a table is PAY_PER_REQUEST (on demand), it will have 0 RCU/WCU provisioned
@@ -130,7 +134,7 @@ func getBillingMode(t *types.ProvisionedThroughputDescription) types.BillingMode
 		return types.BillingModePayPerRequest
 	}
 
-	return "UNSPECIFIED" // unable to infer what billing mode it is
+	return TableBillingUnspecified // unable to infer what billing mode it is
 }
 
 func newProtoForBillingMode(t *types.TableDescription) dynamodbv1.Table_BillingMode {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR revises how the BillingMode field for tables is marshaled into proto format. 

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual testing locally + unit tests
