### PR TITLE
dynamodb: fix GSI mapping when resolving non-existent tables

### DIFF
--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -45,7 +45,7 @@ func (c *client) DescribeTable(ctx context.Context, region string, tableName str
 	result, err := getTable(ctx, cl, tableName)
 
 	if err != nil {
-		c.log.Error("unable to find table", zap.Error(err))
+		c.log.Warn("unable to find table", zap.Error(err))
 		return nil, err
 	}
 

--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -45,7 +45,7 @@ func (c *client) DescribeTable(ctx context.Context, region string, tableName str
 	result, err := getTable(ctx, cl, tableName)
 
 	if err != nil {
-		c.log.Warn("unable to find table", zap.Error(err))
+		c.log.Error("unable to find table", zap.Error(err))
 		return nil, err
 	}
 

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -36,7 +36,8 @@ const TableIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
         _.mapValues(_.keyBy(results[0].globalSecondaryIndexes, "name"), v =>
           v.provisionedThroughput.toJSON()
         )
-    )};
+      );
+    }
     onSubmit();
   };
 

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -28,14 +28,15 @@ const TableIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
   const capacityUpdates = useDataLayout("capacityUpdates");
 
   const onResolve = ({ results }) => {
-    // Decide how to process results.
+    // Decide how to process results
     resolvedResourceData.assign(results[0]);
-    capacityUpdates.updateData(
-      "gsi_map",
-      _.mapValues(_.keyBy(results[0].globalSecondaryIndexes, "name"), v =>
-        v.provisionedThroughput.toJSON()
-      )
-    );
+    if (_.has(results[0], "globalSecondaryIndexes")) {
+      capacityUpdates.updateData(
+        "gsi_map",
+        _.mapValues(_.keyBy(results[0].globalSecondaryIndexes, "name"), v =>
+          v.provisionedThroughput.toJSON()
+        )
+    )};
     onSubmit();
   };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR addresses potential issue of generating GSI maps with results returned from the resolver, without first checking if the resulting table contains global secondary indexes.

### Testing Performed
Local manual testing 