### PR TITLE
tools: update golangci-lint 1.42.1

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -3,21 +3,21 @@ linters:
   disable-all: true
   enable:
   - deadcode
-  - gci
   - errcheck
+  - exportloopref
+  - gci
   - gocritic
   - goimports
   - gosec
   - gosimple
   - govet
   - ineffassign
-  - scopelint
   - staticcheck
   - structcheck
   - typecheck
   - unused
-  - whitespace
   - varcheck
+  - whitespace
 linters-settings:
   gocritic:
     disabled-checks:

--- a/backend/cmd/assets/placeholder.go
+++ b/backend/cmd/assets/placeholder.go
@@ -1,4 +1,4 @@
-// +build !withAssets
+//go:build !withAssets
 
 package assets
 

--- a/backend/service/chaos/experimentation/experimentstore/experiment_run_details.go
+++ b/backend/service/chaos/experimentation/experimentstore/experiment_run_details.go
@@ -22,7 +22,9 @@ func NewRunDetails(run *ExperimentRun, config *ExperimentConfig, transformer *Tr
 		return nil, err
 	}
 
-	properties := append(runProperties, configProperties...)
+	var properties []*experimentation.Property
+	properties = append(properties, runProperties...)
+	properties = append(properties, configProperties...)
 	properties = append(properties, transformerProperties...)
 
 	if err != nil {

--- a/backend/service/chaos/experimentation/experimentstore/list_view.go
+++ b/backend/service/chaos/experimentation/experimentstore/list_view.go
@@ -22,7 +22,9 @@ func NewRunListView(run *ExperimentRun, config *ExperimentConfig, transformer *T
 		return nil, err
 	}
 
-	properties := append(runProperties, configProperties...)
+	var properties []*experimentation.Property
+	properties = append(properties, runProperties...)
+	properties = append(properties, configProperties...)
 	properties = append(properties, transformerProperties...)
 	propertiesMapItems := make(map[string]*experimentation.Property)
 	for _, p := range properties {

--- a/tools/golangci-lint.sh
+++ b/tools/golangci-lint.sh
@@ -6,9 +6,9 @@ BUILD_ROOT="${REPO_ROOT}/build"
 BUILD_BIN="${BUILD_ROOT}/bin"
 
 NAME=golangci-lint
-RELEASE=v1.37.1
-OSX_RELEASE_MD5=1d0f4389bfa56a0eda0e938ddef45ac3
-LINUX_RELEASE_MD5=cbc07eda24cbd20a41ff3af27861617b
+RELEASE=v1.42.1
+OSX_RELEASE_256=9c0042e91218dc1dd4eb7b54e29c7331eff081b3ac3f88b0d5df89b976fcd45c
+LINUX_RELEASE_256=214b093c15863430c4b66dd39df677dab6e38fc873ded147e331740d50eea51f
 
 ARCH=amd64
 
@@ -28,8 +28,8 @@ ensure_binary() {
     mkdir -p "${BUILD_BIN}"
 
     case "${OSTYPE}" in
-      "darwin"*) os_type="darwin"; md5="${OSX_RELEASE_MD5}" ;;
-      "linux"*) os_type="linux"; md5="${LINUX_RELEASE_MD5}" ;;
+      "darwin"*) os_type="darwin"; sum="${OSX_RELEASE_256}" ;;
+      "linux"*) os_type="linux"; sum="${LINUX_RELEASE_256}" ;;
       *) echo "error: Unsupported OS '${OSTYPE}' for shellcheck install, please install manually" && exit 1 ;;
     esac
 
@@ -37,7 +37,7 @@ ensure_binary() {
 
     URL="https://github.com/golangci/golangci-lint/releases/download/${RELEASE}/golangci-lint-${RELEASE:1}-${os_type}-${ARCH}.tar.gz"
     curl -sSL -o "${release_archive}" "${URL}"
-    echo ${md5} ${release_archive} | md5sum --check --quiet -
+    echo ${sum} ${release_archive} | sha256sum --check --quiet -
 
     release_tmp_dir="/tmp/${NAME}-${RELEASE}"
     mkdir -p "${release_tmp_dir}"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Updating `golangci-lint` to the latest, this required some minor tweaks but nothing major.

Summary of changes
* Now using `sha256sum` as its provide upstream so we dont need to compute `MD5` our selves when checking the binary
* replaced deprecated`scopelint` with supported `exportloopref`
```
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
```

* Fixed a couple new `gocritic` lints
```
service/chaos/experimentation/experimentstore/experiment_run_details.go:25:16: appendAssign: append result not assigned to the same slice (gocritic)
	properties := append(runProperties, configProperties...)
	              ^
service/chaos/experimentation/experimentstore/list_view.go:25:16: appendAssign: append result not assigned to the same slice (gocritic)
	properties := append(runProperties, configProperties...)
```

### Testing Performed
Locally & CI.

```
➜ clutch git:(main) make backend-lint
tools/golangci-lint.sh run
info: Downloading golangci-lint v1.42.1 to build environment
```

