### PR TITLE
frontend: remove zero restriction for resize workflows

### DIFF
--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -54,7 +54,7 @@ const GroupDetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "size.min",
-              validation: number().integer().moreThan(0),
+              validation: group.size.min > 0 ? number().integer().moreThan(0) : number().integer().min(0),
             },
           },
           {

--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -54,7 +54,8 @@ const GroupDetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "size.min",
-              validation: group.size.min > 0 ? number().integer().moreThan(0) : number().integer().min(0),
+              validation:
+                group.size.min > 0 ? number().integer().moreThan(0) : number().integer().min(0),
             },
           },
           {

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -77,7 +77,8 @@ const HPADetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "sizing.minReplicas",
-              validation: number().integer().moreThan(0),
+              validation:
+                hpa.sizing.minReplicas > 0 ? number().integer().moreThan(0) : number().integer().min(0),
             },
           },
           {

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -78,7 +78,9 @@ const HPADetails: React.FC<WizardChild> = () => {
               type: "number",
               key: "sizing.minReplicas",
               validation:
-                hpa.sizing.minReplicas > 0 ? number().integer().moreThan(0) : number().integer().min(0),
+                hpa.sizing.minReplicas > 0
+                  ? number().integer().moreThan(0)
+                  : number().integer().min(0),
             },
           },
           {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
If the min asg/hpa size is already zero we should continue to allow it

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual