### PR TITLE
frontend: fix max size validation in resize workflows

### DIFF
--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -64,9 +64,12 @@ const GroupDetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "size.max",
-              validation: number()
-                .integer()
-                .min(ref("Min Size") as Reference<number>),
+              validation:
+                group.size.min > 0
+                  ? number()
+                      .integer()
+                      .min(ref("Min Size") as Reference<number>)
+                  : number().integer().moreThan(0),
             },
           },
           {

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -89,9 +89,12 @@ const HPADetails: React.FC<WizardChild> = () => {
             input: {
               type: "number",
               key: "sizing.maxReplicas",
-              validation: number()
-                .integer()
-                .min(ref("Min Size") as Reference<number>),
+              validation:
+                hpa.sizing.minReplicas > 0
+                  ? number()
+                      .integer()
+                      .min(ref("Min Size") as Reference<number>)
+                  : number().integer().moreThan(0),
             },
           },
           { name: "Cluster", value: hpa.cluster },


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Building off https://github.com/lyft/clutch/pull/1754 - now that we allow 0 as a min size for asg/hpa we still want to prevent users from scaling down to 0 completely

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
