### PR TITLE
frontend: metadata table should not update values if errors are present

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -140,6 +140,8 @@ interface MutableRowProps extends ImmutableRowProps {
 const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, validation }) => {
   const error = validation.errors?.[data.name];
 
+  // intercept the update callback to prevent updates if there are form errors present
+  // based on the validation.
   const updateCallback = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
     error ? () => {} : onUpdate(e);
 

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -140,6 +140,9 @@ interface MutableRowProps extends ImmutableRowProps {
 const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, validation }) => {
   const error = validation.errors?.[data.name];
 
+  const updateCallback = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
+    error ? () => {} : onUpdate(e);
+
   return (
     <TableRow key={data.id}>
       <KeyCell data={data} />
@@ -154,9 +157,9 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
             name={data.name}
             defaultValue={data.value}
             type={data?.input?.type}
-            onChange={onUpdate}
+            onChange={updateCallback}
             onReturn={onReturn}
-            onFocus={onUpdate}
+            onFocus={updateCallback}
             inputRef={validation.register}
             helperText={error?.message || ""}
             error={!!error || false}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
If a metadata table row has validation errors it should not update the source field.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
