### PR TITLE
backend: add support for dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 build/
 
 backend/.air/
+backend/.env.local
 backend/cmd/assets/generated_assets.go

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -9,7 +9,7 @@ tmp_dir = ".air"
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o .air/clutch ."
 # Binary file yields from `cmd`.
-bin = ".air/clutch"
+bin = ".air/clutch -dev"
 # Watch these filename extensions.
 include_ext = ["go"]
 # Ignore these filename extensions or directories.

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -9,7 +9,7 @@ tmp_dir = ".air"
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o .air/clutch ."
 # Binary file yields from `cmd`.
-bin = ".air/clutch -dev"
+bin = ".air/clutch -env .env.local"
 # Watch these filename extensions.
 include_ext = ["go"]
 # Ignore these filename extensions or directories.

--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -39,7 +39,7 @@ type Flags struct {
 	ConfigPath string
 	Template   bool
 	Validate   bool
-	EnvFile    envFiles
+	EnvFiles   envFiles
 }
 
 // Link register the struct vars globally for parsing by the flag library.
@@ -47,7 +47,7 @@ func (f *Flags) Link() {
 	flag.StringVar(&f.ConfigPath, "c", "clutch-config.yaml", "path to YAML configuration")
 	flag.BoolVar(&f.Template, "template", false, "executes go templates on the configuration file")
 	flag.BoolVar(&f.Validate, "validate", false, "validates the configuration file and exits")
-	flag.Var(&f.EnvFile, "env", "path to additional .env files to load")
+	flag.Var(&f.EnvFiles, "env", "path to additional .env files to load")
 }
 
 // Parse command line arguments.

--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -28,6 +28,7 @@ type Flags struct {
 	ConfigPath string
 	Template   bool
 	Validate   bool
+	DevMode    bool
 }
 
 // Link register the struct vars globally for parsing by the flag library.
@@ -35,6 +36,7 @@ func (f *Flags) Link() {
 	flag.StringVar(&f.ConfigPath, "c", "clutch-config.yaml", "path to YAML configuration")
 	flag.BoolVar(&f.Template, "template", false, "executes go templates on the configuration file")
 	flag.BoolVar(&f.Validate, "validate", false, "validates the configuration file and exits")
+	flag.BoolVar(&f.DevMode, "dev", false, "run clutch in development mode")
 }
 
 // Parse command line arguments.

--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -24,11 +24,22 @@ import (
 	"github.com/lyft/clutch/backend/middleware/timeouts"
 )
 
+type envFiles []string
+
+func (f *envFiles) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *envFiles) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 type Flags struct {
 	ConfigPath string
 	Template   bool
 	Validate   bool
-	DevMode    bool
+	EnvFile    envFiles
 }
 
 // Link register the struct vars globally for parsing by the flag library.
@@ -36,7 +47,7 @@ func (f *Flags) Link() {
 	flag.StringVar(&f.ConfigPath, "c", "clutch-config.yaml", "path to YAML configuration")
 	flag.BoolVar(&f.Template, "template", false, "executes go templates on the configuration file")
 	flag.BoolVar(&f.Validate, "validate", false, "validates the configuration file and exits")
-	flag.BoolVar(&f.DevMode, "dev", false, "run clutch in development mode")
+	flag.Var(&f.EnvFile, "env", "path to additional .env files to load")
 }
 
 // Parse command line arguments.

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -42,7 +42,6 @@ type ComponentFactory struct {
 }
 
 func loadEnv(f *Flags) {
-
 	// Order is important as godotenv will NOT overwrite existing environment variables.
 	envFiles := []string{".env.local", ".env.development", ".env"}
 	for _, filename := range envFiles {
@@ -56,7 +55,10 @@ func loadEnv(f *Flags) {
 		if err != nil {
 			tmpLogger.Fatal("parsing .env file failed", zap.Error(err))
 		}
-		godotenv.Load(p)
+		err = godotenv.Load(p)
+		if err != nil {
+			tmpLogger.Fatal("parsing .env file failed", zap.Error(err))
+		}
 	}
 }
 

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -43,8 +43,7 @@ type ComponentFactory struct {
 
 func loadEnv(f *Flags) {
 	// Order is important as godotenv will NOT overwrite existing environment variables.
-	envFiles := []string{".env.local"}
-	envFiles = append(envFiles, f.EnvFile...)
+	envFiles := f.EnvFiles
 
 	for _, filename := range envFiles {
 		// Use a temporary logger to parse the environment files

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -56,7 +56,10 @@ func loadEnv(f *Flags) {
 		// Ignore lint below as it is ok to to ignore dotenv loads as not all env files are guaranteed
 		// to be present.
 		// nolint
-		godotenv.Load(p)
+		err = godotenv.Load(p)
+		if err == nil {
+			tmpLogger.Info("successfully loaded environment variables")
+		}
 	}
 }
 

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -43,18 +43,19 @@ type ComponentFactory struct {
 
 func loadEnv(f *Flags) {
 	// Order is important as godotenv will NOT overwrite existing environment variables.
-	envFiles := []string{".env.local", ".env.development", ".env"}
+	envFiles := []string{".env.local"}
+	envFiles = append(envFiles, f.EnvFile...)
+
 	for _, filename := range envFiles {
 		// Use a temporary logger to parse the environment files
 		tmpLogger := newTmpLogger().With(zap.String("file", filename))
 
-		if filename == ".env.development" && !f.DevMode {
-			continue
-		}
 		p, err := filepath.Abs(filename)
 		if err != nil {
 			tmpLogger.Fatal("parsing .env file failed", zap.Error(err))
 		}
+		// Ignore lint below as it is ok to to ignore dotenv loads as not all env files are guaranteed
+		// to be present.
 		// nolint
 		godotenv.Load(p)
 	}

--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -55,10 +55,8 @@ func loadEnv(f *Flags) {
 		if err != nil {
 			tmpLogger.Fatal("parsing .env file failed", zap.Error(err))
 		}
-		err = godotenv.Load(p)
-		if err != nil {
-			tmpLogger.Fatal("parsing .env file failed", zap.Error(err))
-		}
+		// nolint
+		godotenv.Load(p)
 	}
 }
 

--- a/backend/gateway/gateway_test.go
+++ b/backend/gateway/gateway_test.go
@@ -1,0 +1,77 @@
+package gateway
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadEnv(t *testing.T) {
+	type File struct {
+		name  string
+		value string
+	}
+	var testCases = []struct {
+		files         []File
+		envVar        string
+		expectedValue string
+	}{
+		{
+			files: []File{
+				{
+					name:  ".env.dev",
+					value: "FOOBAR1=true",
+				},
+				{
+					name:  ".env",
+					value: "FOOBAR1=false",
+				},
+			},
+			envVar:        "FOOBAR1",
+			expectedValue: "true",
+		},
+		{
+			files: []File{
+				{
+					name:  ".env.dev",
+					value: "",
+				},
+				{
+					name:  ".env",
+					value: "FOOBAR2=true",
+				},
+			},
+			envVar:        "FOOBAR2",
+			expectedValue: "true",
+		},
+	}
+	for idx, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			t.Parallel()
+			tmpVar := os.Getenv(tc.envVar)
+			fileNames := []string{}
+			for _, f := range tc.files {
+				envFile, err := ioutil.TempFile(".", f.name)
+				if err != nil {
+					log.Fatal(err)
+				}
+				defer os.Remove(envFile.Name())
+				ioutil.WriteFile(envFile.Name(), []byte(f.value), 0644)
+				fileNames = append(fileNames, envFile.Name())
+			}
+
+			flags := &Flags{EnvFiles: fileNames}
+
+			loadEnv(flags)
+			v := os.Getenv(tc.envVar)
+			assert.Equal(t, tc.expectedValue, v)
+			os.Setenv(tc.envVar, tmpVar)
+		})
+	}
+
+}

--- a/backend/gateway/gateway_test.go
+++ b/backend/gateway/gateway_test.go
@@ -61,7 +61,7 @@ func TestLoadEnv(t *testing.T) {
 					log.Fatal(err)
 				}
 				defer os.Remove(envFile.Name())
-				ioutil.WriteFile(envFile.Name(), []byte(f.value), 0644)
+				_ = ioutil.WriteFile(envFile.Name(), []byte(f.value), 0644)
 				fileNames = append(fileNames, envFile.Name())
 			}
 
@@ -73,5 +73,4 @@ func TestLoadEnv(t *testing.T) {
 			os.Setenv(tc.envVar, tmpVar)
 		})
 	}
-
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jhump/protoreflect v1.9.0
-	github.com/joho/godotenv v1.3.0 // indirect
+	github.com/joho/godotenv v1.3.0
 	github.com/lib/pq v1.10.2
 	github.com/m3db/prometheus_client_golang v0.8.1 // indirect
 	github.com/m3db/prometheus_client_model v0.1.0 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jhump/protoreflect v1.9.0
+	github.com/joho/godotenv v1.3.0 // indirect
 	github.com/lib/pq v1.10.2
 	github.com/m3db/prometheus_client_golang v0.8.1 // indirect
 	github.com/m3db/prometheus_client_model v0.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -491,6 +491,7 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=

--- a/tools/scaffolding/templates/gateway/.gitignore
+++ b/tools/scaffolding/templates/gateway/.gitignore
@@ -1,2 +1,3 @@
 build/
 backend/.air/
+backend/.env.local

--- a/tools/scaffolding/templates/gateway/backend/.air.toml
+++ b/tools/scaffolding/templates/gateway/backend/.air.toml
@@ -9,7 +9,7 @@ tmp_dir = ".air"
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o .air/clutch ."
 # Binary file yields from `cmd`.
-bin = ".air/clutch"
+bin = ".air/clutch -dev"
 # Watch these filename extensions.
 include_ext = ["go"]
 # Ignore these filename extensions or directories.

--- a/tools/scaffolding/templates/gateway/backend/.air.toml
+++ b/tools/scaffolding/templates/gateway/backend/.air.toml
@@ -9,7 +9,7 @@ tmp_dir = ".air"
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o .air/clutch ."
 # Binary file yields from `cmd`.
-bin = ".air/clutch -dev"
+bin = ".air/clutch -env .env.local"
 # Watch these filename extensions.
 include_ext = ["go"]
 # Ignore these filename extensions or directories.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add support for dotenv files to the backend. This will always allow local env variable to take precedence (either through the command line or `.env.local`). In development, `.env.development` will be loaded, if present.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
