### PR TITLE
frontend: projectSelector/Dash: custom hooks for reading and writing to timeline

### DIFF
--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { clutch as IClutch } from "@clutch-sh/api";
 
 import type { DashAction, DashState, TimelineState } from "./types";
 
@@ -16,6 +17,10 @@ type useDashUpdaterReturn = {
   updateSelected: (state: DashState) => void;
 };
 
+type useTimelineUpdaterReturn = {
+  updateTimeline: (key: string, points: IClutch.timeseries.v1.IPoint[]) => void;
+};
+
 export const useDashUpdater = (): useDashUpdaterReturn => {
   const dispatch = React.useContext(DashDispatchContext);
 
@@ -26,14 +31,15 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
   };
 };
 
-export const useTimelineUpdate = (): React.Dispatch<any> => {
-  const setTimeData = React.useContext(TimelineUpdateContext);
-  if (!setTimeData) {
-    throw new Error(
-      "useTimelineUpdate was invoked outside of a valid context, check that it is a child of the Timeline component"
-    );
-  }
-  return setTimeData;
+export const useTimelineUpdater = (): useTimelineUpdaterReturn => {
+  const dispatch = React.useContext(TimelineUpdateContext);
+
+  return {
+    // TODO: how do we pass the key and points here instead of the state?
+    updateTimeline: (key, points) => {
+      dispatch && dispatch({ type: "UPDATE", payload: { key, points } });
+    },
+  };
 };
 
 export const useDashState = (): DashState => {

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 
 import type { DashAction, DashState, TimeDataUpdate, TimelineAction, TimelineState } from "./types";
 
-// Contexts for project selector / DASH
-export const DashStateContext = React.createContext<DashState | undefined>(undefined);
-export const DashDispatchContext = React.createContext<((action: DashAction) => void) | undefined>(
-  undefined
-);
+// Contexts for project selector
+export const ProjectSelectorStateContext = React.createContext<DashState | undefined>(undefined);
+export const ProjectSelectorDispatchContext = React.createContext<
+  ((action: DashAction) => void) | undefined
+>(undefined);
 
 // Contexts for timeline
 export const TimelineStateContext = React.createContext<TimelineState | undefined>(undefined);
@@ -14,13 +14,13 @@ export const TimelineDispatchContext = React.createContext<
   ((action: TimelineAction) => void) | undefined
 >(undefined);
 
-// project selector / DASH hooks
+// project selector hooks
 type useDashUpdaterReturn = {
   updateSelected: (state: DashState) => void;
 };
 
 export const useDashUpdater = (): useDashUpdaterReturn => {
-  const dispatch = React.useContext(DashDispatchContext);
+  const dispatch = React.useContext(ProjectSelectorDispatchContext);
 
   return {
     updateSelected: projects => {
@@ -30,7 +30,7 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
 };
 
 export const useDashState = (): DashState => {
-  const value = React.useContext<DashState | undefined>(DashStateContext);
+  const value = React.useContext<DashState | undefined>(ProjectSelectorStateContext);
   if (!value) {
     throw new Error(
       "useDashState was invoked outside of a valid context, check that it is a child of the Dash component"

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -1,9 +1,13 @@
 import * as React from "react";
 
-import type { DashAction, DashState } from "./types";
+import type { DashAction, DashState, TimelineState } from "./types";
 
 export const DashStateContext = React.createContext<DashState | undefined>(undefined);
-
+export const TimelineStateContext = React.createContext<TimelineState | undefined>(undefined);
+// TODO: What type goes here? React.Dispatch<any> or? ???
+export const TimelineUpdateContext = React.createContext<React.Dispatch<any> | undefined>(
+  undefined
+);
 export const DashDispatchContext = React.createContext<((action: DashAction) => void) | undefined>(
   undefined
 );
@@ -22,11 +26,31 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
   };
 };
 
+export const useTimelineUpdate = (): React.Dispatch<any> => {
+  const setTimeData = React.useContext(TimelineUpdateContext);
+  if (!setTimeData) {
+    throw new Error(
+      "useTimelineUpdate was invoked outside of a valid context, check that it is a child of the Timeline component"
+    );
+  }
+  return setTimeData;
+};
+
 export const useDashState = (): DashState => {
   const value = React.useContext<DashState | undefined>(DashStateContext);
   if (!value) {
     throw new Error(
       "useDashState was invoked outside of a valid context, check that it is a child of the Dash component"
+    );
+  }
+  return value;
+};
+
+export const useTimelineState = (): TimelineState => {
+  const value = React.useContext<TimelineState | undefined>(TimelineStateContext);
+  if (!value) {
+    throw new Error(
+      "useTimelineState was invoked outside of a valid context, check that it is a child of the Timeline component"
     );
   }
   return value;

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -1,23 +1,23 @@
 import * as React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 
-import type { DashAction, DashState, TimelineAction, TimelineState } from "./types";
+import type { DashAction, DashState, TimeDataUpdate, TimelineAction, TimelineState } from "./types";
 
+// Contexts for project selector / DASH
 export const DashStateContext = React.createContext<DashState | undefined>(undefined);
-export const TimelineStateContext = React.createContext<TimelineState | undefined>(undefined);
-export const TimelineUpdateContext = React.createContext<
-  ((action: TimelineAction) => void) | undefined
->(undefined);
 export const DashDispatchContext = React.createContext<((action: DashAction) => void) | undefined>(
   undefined
 );
 
+// Contexts for timeline
+export const TimelineStateContext = React.createContext<TimelineState | undefined>(undefined);
+export const TimelineDispatchContext = React.createContext<
+  ((action: TimelineAction) => void) | undefined
+>(undefined);
+
+// project selector / DASH hooks
 type useDashUpdaterReturn = {
   updateSelected: (state: DashState) => void;
-};
-
-type useTimelineUpdaterReturn = {
-  updateTimeline: (key: string, points: IClutch.timeseries.v1.IPoint[]) => void;
 };
 
 export const useDashUpdater = (): useDashUpdaterReturn => {
@@ -26,16 +26,6 @@ export const useDashUpdater = (): useDashUpdaterReturn => {
   return {
     updateSelected: projects => {
       dispatch && dispatch({ type: "UPDATE_SELECTED", payload: projects });
-    },
-  };
-};
-
-export const useTimelineUpdater = (): useTimelineUpdaterReturn => {
-  const dispatch = React.useContext(TimelineUpdateContext);
-
-  return {
-    updateTimeline: (key, points) => {
-      dispatch && dispatch({ type: "UPDATE", payload: { key, points } });
     },
   };
 };
@@ -50,6 +40,23 @@ export const useDashState = (): DashState => {
   return value;
 };
 
+// timeline hooks
+type useTimelineUpdaterReturn = {
+  updateTimeline: (update: TimeDataUpdate) => void;
+};
+
+// hook for writing
+export const useTimelineUpdater = (): useTimelineUpdaterReturn => {
+  const dispatch = React.useContext(TimelineDispatchContext);
+
+  return {
+    updateTimeline: (update: TimeDataUpdate) => {
+      dispatch && dispatch({ type: "UPDATE", payload: update });
+    },
+  };
+};
+
+// hook for reading
 export const useTimelineState = (): TimelineState => {
   const value = React.useContext<TimelineState | undefined>(TimelineStateContext);
   if (!value) {

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 
-import type { DashAction, DashState, TimelineState } from "./types";
+import type { DashAction, DashState, TimelineAction, TimelineState } from "./types";
 
 export const DashStateContext = React.createContext<DashState | undefined>(undefined);
 export const TimelineStateContext = React.createContext<TimelineState | undefined>(undefined);
-// TODO: What type goes here? React.Dispatch<any> or? ???
-export const TimelineUpdateContext = React.createContext<React.Dispatch<any> | undefined>(
+export const TimelineUpdateContext = React.createContext<((action: TimelineAction) => void) | undefined>(
   undefined
 );
 export const DashDispatchContext = React.createContext<((action: DashAction) => void) | undefined>(

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -34,7 +34,6 @@ export const useTimelineUpdater = (): useTimelineUpdaterReturn => {
   const dispatch = React.useContext(TimelineUpdateContext);
 
   return {
-    // TODO: how do we pass the key and points here instead of the state?
     updateTimeline: (key, points) => {
       dispatch && dispatch({ type: "UPDATE", payload: { key, points } });
     },

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -5,9 +5,9 @@ import type { DashAction, DashState, TimelineAction, TimelineState } from "./typ
 
 export const DashStateContext = React.createContext<DashState | undefined>(undefined);
 export const TimelineStateContext = React.createContext<TimelineState | undefined>(undefined);
-export const TimelineUpdateContext = React.createContext<((action: TimelineAction) => void) | undefined>(
-  undefined
-);
+export const TimelineUpdateContext = React.createContext<
+  ((action: TimelineAction) => void) | undefined
+>(undefined);
 export const DashDispatchContext = React.createContext<((action: DashAction) => void) | undefined>(
   undefined
 );

--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import type { clutch as IClutch } from "@clutch-sh/api";
 
 import type { DashAction, DashState, TimeDataUpdate, TimelineAction, TimelineState } from "./types";
 

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -46,8 +46,9 @@ const timelineReducer = (state: TimelineState, action: TimelineAction): Timeline
     case "UPDATE": {
       // TODO: should disable lint for this? (no param assign)
       // for now, clobber any existing data
-      state.timeData[action.payload.key] = action.payload.points;
-      return state;
+      const newState = state;
+      newState.timeData[action.payload.key] = action.payload.points;
+      return newState;
     }
     default:
       throw new Error("not implemented (should be unreachable)");

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -3,7 +3,12 @@ import styled from "@emotion/styled";
 import { Box } from "@material-ui/core";
 import _ from "lodash";
 
-import { DashDispatchContext, DashStateContext } from "./dash-hooks";
+import {
+  DashDispatchContext,
+  DashStateContext,
+  TimelineStateContext,
+  TimelineUpdateContext,
+} from "./dash-hooks";
 import ProjectSelector from "./project-selector";
 import type { DashAction, DashState } from "./types";
 
@@ -34,13 +39,18 @@ const dashReducer = (state: DashState, action: DashAction): DashState => {
 
 const Dash = ({ children }) => {
   const [state, dispatch] = React.useReducer(dashReducer, initialState);
-
+  // TODO: should we use reducer instead of state here?
+  const [timeData, setTimeData] = React.useState<any>({});
   return (
     <Box display="flex" flex={1} minHeight="100%" maxHeight="100%">
       <DashDispatchContext.Provider value={dispatch}>
         <DashStateContext.Provider value={state}>
-          <ProjectSelector />
-          <CardContainer>{children}</CardContainer>
+          <TimelineUpdateContext.Provider value={setTimeData}>
+            <TimelineStateContext.Provider value={timeData}>
+              <ProjectSelector />
+              <CardContainer>{children}</CardContainer>
+            </TimelineStateContext.Provider>
+          </TimelineUpdateContext.Provider>
         </DashStateContext.Provider>
       </DashDispatchContext.Provider>
     </Box>

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -4,8 +4,8 @@ import { Box } from "@material-ui/core";
 import _ from "lodash";
 
 import {
-  DashDispatchContext,
-  DashStateContext,
+  ProjectSelectorDispatchContext,
+  ProjectSelectorStateContext,
   TimelineDispatchContext,
   TimelineStateContext,
 } from "./dash-hooks";
@@ -43,6 +43,7 @@ const dashReducer = (state: DashState, action: DashAction): DashState => {
 
 const timelineReducer = (state: TimelineState, action: TimelineAction): TimelineState => {
   switch (action.type) {
+    // TODO: Add more actions like slicing by time
     case "UPDATE": {
       // for now, clobber any existing data
       const newState = { ...state };
@@ -59,16 +60,17 @@ const Dash = ({ children }) => {
   const [timelineState, timelineDispatch] = React.useReducer(timelineReducer, initialTimelineState);
   return (
     <Box display="flex" flex={1} minHeight="100%" maxHeight="100%">
-      <DashDispatchContext.Provider value={dispatch}>
-        <DashStateContext.Provider value={state}>
+      {/* TODO: Maybe in the future invert proj selector and timeline contexts */}
+      <ProjectSelectorDispatchContext.Provider value={dispatch}>
+        <ProjectSelectorStateContext.Provider value={state}>
           <TimelineDispatchContext.Provider value={timelineDispatch}>
             <TimelineStateContext.Provider value={timelineState}>
               <ProjectSelector />
               <CardContainer>{children}</CardContainer>
             </TimelineStateContext.Provider>
           </TimelineDispatchContext.Provider>
-        </DashStateContext.Provider>
-      </DashDispatchContext.Provider>
+        </ProjectSelectorStateContext.Provider>
+      </ProjectSelectorDispatchContext.Provider>
     </Box>
   );
 };

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -7,7 +7,7 @@ import {
   DashDispatchContext,
   DashStateContext,
   TimelineStateContext,
-  TimelineUpdateContext,
+  TimelineDispatchContext,
 } from "./dash-hooks";
 import ProjectSelector from "./project-selector";
 import type { DashAction, DashState, TimelineAction, TimelineState } from "./types";
@@ -45,7 +45,7 @@ const timelineReducer = (state: TimelineState, action: TimelineAction): Timeline
   switch (action.type) {
     case "UPDATE": {
       // for now, clobber any existing data
-      const newState = state;
+      const newState = { ...state };
       newState.timeData[action.payload.key] = action.payload.points;
       return newState;
     }
@@ -61,12 +61,12 @@ const Dash = ({ children }) => {
     <Box display="flex" flex={1} minHeight="100%" maxHeight="100%">
       <DashDispatchContext.Provider value={dispatch}>
         <DashStateContext.Provider value={state}>
-          <TimelineUpdateContext.Provider value={timelineDispatch}>
+          <TimelineDispatchContext.Provider value={timelineDispatch}>
             <TimelineStateContext.Provider value={timelineState}>
               <ProjectSelector />
               <CardContainer>{children}</CardContainer>
             </TimelineStateContext.Provider>
-          </TimelineUpdateContext.Provider>
+          </TimelineDispatchContext.Provider>
         </DashStateContext.Provider>
       </DashDispatchContext.Provider>
     </Box>

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -56,7 +56,6 @@ const timelineReducer = (state: TimelineState, action: TimelineAction): Timeline
 
 const Dash = ({ children }) => {
   const [state, dispatch] = React.useReducer(dashReducer, initialState);
-  // TODO: should we use reducer instead of state here?
   const [timelineState, timelineDispatch] = React.useReducer(timelineReducer, initialTimelineState);
   return (
     <Box display="flex" flex={1} minHeight="100%" maxHeight="100%">

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -10,11 +10,15 @@ import {
   TimelineUpdateContext,
 } from "./dash-hooks";
 import ProjectSelector from "./project-selector";
-import type { DashAction, DashState } from "./types";
+import type { DashAction, DashState, TimelineAction, TimelineState } from "./types";
 
 const initialState = {
   selected: [],
   projectData: {},
+};
+
+const initialTimelineState = {
+  timeData: {},
 };
 
 const CardContainer = styled.div({
@@ -37,16 +41,29 @@ const dashReducer = (state: DashState, action: DashAction): DashState => {
   }
 };
 
+const timelineReducer = (state: TimelineState, action: TimelineAction): TimelineState => {
+  switch (action.type) {
+    case "UPDATE": {
+      // TODO: should disable lint for this? (no param assign)
+      // for now, clobber any existing data
+      state.timeData[action.payload.key] = action.payload.points;
+      return state;
+    }
+    default:
+      throw new Error("not implemented (should be unreachable)");
+  }
+};
+
 const Dash = ({ children }) => {
   const [state, dispatch] = React.useReducer(dashReducer, initialState);
   // TODO: should we use reducer instead of state here?
-  const [timeData, setTimeData] = React.useState<any>({});
+  const [timelineState, timelineDispatch] = React.useReducer(timelineReducer, initialTimelineState);
   return (
     <Box display="flex" flex={1} minHeight="100%" maxHeight="100%">
       <DashDispatchContext.Provider value={dispatch}>
         <DashStateContext.Provider value={state}>
-          <TimelineUpdateContext.Provider value={setTimeData}>
-            <TimelineStateContext.Provider value={timeData}>
+          <TimelineUpdateContext.Provider value={timelineDispatch}>
+            <TimelineStateContext.Provider value={timelineState}>
               <ProjectSelector />
               <CardContainer>{children}</CardContainer>
             </TimelineStateContext.Provider>

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -6,8 +6,8 @@ import _ from "lodash";
 import {
   DashDispatchContext,
   DashStateContext,
-  TimelineStateContext,
   TimelineDispatchContext,
+  TimelineStateContext,
 } from "./dash-hooks";
 import ProjectSelector from "./project-selector";
 import type { DashAction, DashState, TimelineAction, TimelineState } from "./types";

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -44,7 +44,6 @@ const dashReducer = (state: DashState, action: DashAction): DashState => {
 const timelineReducer = (state: TimelineState, action: TimelineAction): TimelineState => {
   switch (action.type) {
     case "UPDATE": {
-      // TODO: should disable lint for this? (no param assign)
       // for now, clobber any existing data
       const newState = state;
       newState.timeData[action.payload.key] = action.payload.points;

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -2,7 +2,7 @@ import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 
 import Card from "./card";
 import Dash from "./dash";
-import { useDashState, useTimelineState, useTimelineUpdate } from "./dash-hooks";
+import { useDashState, useTimelineState, useTimelineUpdater } from "./dash-hooks";
 
 export interface WorkflowProps extends BaseWorkflowProps {}
 
@@ -29,4 +29,4 @@ const register = (): WorkflowConfiguration => {
 export default register;
 
 export type { DashState, TimelineState } from "./types";
-export { Card, Dash, useDashState, useTimelineState, useTimelineUpdate };
+export { Card, Dash, useDashState, useTimelineState, useTimelineUpdater };

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -2,7 +2,7 @@ import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 
 import Card from "./card";
 import Dash from "./dash";
-import { useDashState } from "./dash-hooks";
+import { useDashState, useTimelineState, useTimelineUpdate } from "./dash-hooks";
 
 export interface WorkflowProps extends BaseWorkflowProps {}
 
@@ -28,5 +28,5 @@ const register = (): WorkflowConfiguration => {
 
 export default register;
 
-export type { DashState } from "./types";
-export { Card, Dash, useDashState };
+export type { DashState, TimelineState } from "./types";
+export { Card, Dash, useDashState, useTimelineState, useTimelineUpdate };

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -112,18 +112,26 @@ export interface DashAction {
   payload: DashState;
 }
 
+/**
+ * Contains a mapping of card names to their event time points
+ * See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
+ */
 export interface TimeData {
   [eventsKey: string]: IClutch.timeseries.v1.IPoint[];
 }
 
+/**
+ * Used by the reducer to update the time data in our context.
+ * @property key the name of the card or entity that is updating
+ * @property points the timeseries points that will be the value
+ *
+ */
 export interface TimeDataUpdate {
   key: string;
   points: IClutch.timeseries.v1.IPoint[];
 }
 
 export interface TimelineState {
-  // Contains a mapping of card names to their event time points
-  // See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
   timeData: TimeData;
 }
 

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -109,7 +109,7 @@ export interface DashState {
 export interface TimelineState {
   // Contains a mapping of card names to their event time points
   // See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
-  timeData: { [eventsKey: string]: IClutch.timeseries.v1.ITimePoint[] };
+  timeData: { [eventsKey: string]: IClutch.timeseries.v1.IPoint[] };
 }
 
 export type DashActionKind = "UPDATE_SELECTED";

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -106,6 +106,12 @@ export interface DashState {
   projectData: { [projectName: string]: IClutch.core.project.v1.IProject };
 }
 
+export interface TimelineState {
+  // Contains a mapping of card names to their event time points
+  // See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
+  timeData: { [eventsKey: string]: IClutch.timeseries.v1.ITimePoint[] };
+}
+
 export type DashActionKind = "UPDATE_SELECTED";
 
 export interface DashAction {

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -120,6 +120,7 @@ export interface TimeData {
   [eventsKey: string]: IClutch.timeseries.v1.IPoint[];
 }
 
+/** Used by the reducer to update the time data in our context. */
 export interface TimeDataUpdate {
   /** The name of the card or entity that is updating */
   key: string;

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -120,14 +120,10 @@ export interface TimeData {
   [eventsKey: string]: IClutch.timeseries.v1.IPoint[];
 }
 
-/**
- * Used by the reducer to update the time data in our context.
- * @property key    The name of the card or entity that is updating
- * @property points The timeseries points that will be the value
- *
- */
 export interface TimeDataUpdate {
+  /** The name of the card or entity that is updating */
   key: string;
+  /** The timeseries points that will be the value */
   points: IClutch.timeseries.v1.IPoint[];
 }
 

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -122,8 +122,8 @@ export interface TimeData {
 
 /**
  * Used by the reducer to update the time data in our context.
- * @property key the name of the card or entity that is updating
- * @property points the timeseries points that will be the value
+ * @property key    The name of the card or entity that is updating
+ * @property points The timeseries points that will be the value
  *
  */
 export interface TimeDataUpdate {

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -106,6 +106,12 @@ export interface DashState {
   projectData: { [projectName: string]: IClutch.core.project.v1.IProject };
 }
 
+export type DashActionKind = "UPDATE_SELECTED";
+export interface DashAction {
+  type: DashActionKind;
+  payload: DashState;
+}
+
 export interface TimeData {
   [eventsKey: string]: IClutch.timeseries.v1.IPoint[];
 }
@@ -119,12 +125,6 @@ export interface TimelineState {
   // Contains a mapping of card names to their event time points
   // See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
   timeData: TimeData;
-}
-
-export type DashActionKind = "UPDATE_SELECTED";
-export interface DashAction {
-  type: DashActionKind;
-  payload: DashState;
 }
 
 export type TimelineActionKindUpdate = "UPDATE";

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -106,17 +106,31 @@ export interface DashState {
   projectData: { [projectName: string]: IClutch.core.project.v1.IProject };
 }
 
+export interface TimeData {
+  [eventsKey: string]: IClutch.timeseries.v1.IPoint[];
+}
+
+export interface TimeDataUpdate {
+  key: string;
+  points: IClutch.timeseries.v1.IPoint[];
+}
+
 export interface TimelineState {
   // Contains a mapping of card names to their event time points
   // See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
-  timeData: { [eventsKey: string]: IClutch.timeseries.v1.IPoint[] };
+  timeData: TimeData;
 }
 
 export type DashActionKind = "UPDATE_SELECTED";
-
 export interface DashAction {
   type: DashActionKind;
   payload: DashState;
+}
+
+export type TimelineActionKindUpdate = "UPDATE";
+export interface TimelineAction {
+  type: TimelineActionKindUpdate;
+  payload: TimeDataUpdate;
 }
 
 export { isGroupState, isProjectState, isGlobalProjectState };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
I have attempted to implement functionality for a timeline state.
2 hooks are added: 
`useTimelineState` for reading the timeline data
`useTimelineUpdater` for writing to the timeline data

<!-- Reference previous related pull requests below. -->
PLT-1011
<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
- [x] Test - I successfully tested it by writing and reading data between 2 cards