### PR TITLE
docs: cleanup blog docs

### DIFF
--- a/docs/blog/2021-02-01-frontend-asset-passthrough.md
+++ b/docs/blog/2021-02-01-frontend-asset-passthrough.md
@@ -10,7 +10,7 @@ image: https://user-images.githubusercontent.com/2250844/106201558-7956e700-616d
 hide_table_of_contents: false
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
+import Image from '@site/src/components/Image';
 
 Ever wonder how Clutch handles serving frontend assets without a CDN in a distributed multi-version deployment?
 This article will touch on how Lyft deploys Clutch and some of the early problems we faced when rolling it out.
@@ -22,7 +22,7 @@ This article will touch on how Lyft deploys Clutch and some of the early problem
 During our deploys of Clutch at Lyft we noticed very early on that when a new version is deployed,
 a subset of users would fail to load the webpage (only seeing a blank page) as some of the frontend assets could not be resolved.
 
-<img style={ {border: "1px solid black"} } alt="Unable to Load" src="https://user-images.githubusercontent.com/2250844/106508379-2dfc4b80-6481-11eb-9c75-6b9f66407047.png" />
+<Image style={ {border: "1px solid black"} } alt="Unable to Load" src="https://user-images.githubusercontent.com/2250844/106508379-2dfc4b80-6481-11eb-9c75-6b9f66407047.png" />
 
 ```text
 Uncaught SyntaxError: Unexpected token '<'
@@ -43,7 +43,7 @@ Clutch uses webpack as the build system for the frontend,
 when building a new release [webpack templates the output filename](https://webpack.js.org/guides/caching/#output-filenames) to include a content hash eg: `main.[contenthash].chunk.js`.
 This uniqueness of this content hash allows Clutch to cache bust what the browser has locally allowing the new version to be requested.
 
-<img alt="Problem Diagram" src="https://user-images.githubusercontent.com/2250844/106201546-765bf680-616d-11eb-83d3-c70cf93ba252.png" />
+<Image alt="Problem Diagram" src="https://user-images.githubusercontent.com/2250844/106201546-765bf680-616d-11eb-83d3-c70cf93ba252.png" />
 
 The client makes a request to Clutch and a canary host responds with an `index.html` page with a script tag asking for `main.a3762de8.chunk.js`.
 Illustrated by the green and red arrows, there is only one host which has the correct asset the client is asking for, the canary.
@@ -111,7 +111,7 @@ In this example we have two Clutch versions deployed: `v1` and `v2`.
 Regardless of which version of the frontend a user might request, all versions of the frontend assets live in S3,
 so if a Clutch host does not have what the user is requesting, it can check S3.
 
-<img alt="Logical Architecture" src="https://user-images.githubusercontent.com/2250844/106201558-7956e700-616d-11eb-887d-28410b67d558.png" />
+<Image alt="Logical Architecture" src="https://user-images.githubusercontent.com/2250844/106201558-7956e700-616d-11eb-887d-28410b67d558.png" />
 
 
 ## Deploying
@@ -124,7 +124,7 @@ Below is a simplified version of our deployment process.
 Early on in the deployment pipeline assets are uploaded to S3,
 utilizing the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html) to `aws s3 sync` the new assets to the target bucket.
 
-<img alt="Deploying" src="https://user-images.githubusercontent.com/2250844/106201560-7956e700-616d-11eb-9f9d-a4b1345bcf41.png" />
+<Image alt="Deploying" src="https://user-images.githubusercontent.com/2250844/106201560-7956e700-616d-11eb-9f9d-a4b1345bcf41.png" />
 
 ## Conclusion
 

--- a/docs/blog/2021-04-05-great-design-is-transparent.md
+++ b/docs/blog/2021-04-05-great-design-is-transparent.md
@@ -10,6 +10,8 @@ image: https://user-images.githubusercontent.com/1004789/113597092-0eec7800-95f0
 hide_table_of_contents: false
 ---
 
+import Image from '@site/src/components/Image';
+
 Design is one of those things that is tricky but imperative to get right. While this may seem obvious, creating and implementing a great design is much harder than you might think.
 
 <!--truncate-->
@@ -25,7 +27,7 @@ A transparent design is one that results in a  user experience so intuitive and 
 
 The initial public release of Clutch was actually the third iteration of the frontend; we had previously built an internal proof of concept. This meant we weren’t starting entirely from scratch. However, both previous versions were using a deprecated component library. [Material UI](https://material-ui.com/) was chosen as the component library for Clutch because it offered a wide selection of pre-existing components along with design standards based on Google’s Material Design. This was especially important as the team was relatively small with no dedicated designers. Over the course of about six months our team built out something comparable to what the internal tool looked like but with the default material designs. Most workflows were primarily using the Material UI components directly, with a few additional custom components. We decided that was sufficient for our MVP and shipped what we had.
 
-<img alt="Clutch V1 Landing Page" src="https://user-images.githubusercontent.com/1004789/113597561-bec1e580-95f0-11eb-8893-788fc4545a32.png" />
+<Image alt="Clutch V1 Landing Page" src="https://user-images.githubusercontent.com/1004789/113597561-bec1e580-95f0-11eb-8893-788fc4545a32.png" />
 
 ## Release Early and Often
 
@@ -35,7 +37,7 @@ After launching, the team onboarded a dedicated designer who, over the next few 
 
 Simultaneously we worked to tackle the component isolation problem. Up until this point any changes to the existing components were tested within the Clutch app. New components would be added as needed and tested within the application. This was problematic since other factors, including sibling and parent components, could impact how the individual components rendered or functioned. Solving this problem now was especially important as we knew that implementing the new component designs would be much easier with a solution for this in place. We leveraged [Storybook](https://storybook.js.org/), which is designed specifically for this use case, to create the bones of what would become [our current component library](https://storybook.clutch.sh/). For those who are unfamiliar with Storybook, it’s an open source tool that provides a component library and documentation site. It offers end users an easy interface to interact with components and modify their props by utilizing what they call stories. A story is a snippet of code that renders an individual component in a particular state. For example in the screenshot below you can see an accordion group story with one accordion expanded by default. Development and code reviews were now much easier, as each new or redesigned component was accompanied with a story demonstrating every variant of the component.
 
-<img alt="Clutch Storybook Accordion" src="https://user-images.githubusercontent.com/1004789/113596886-c634bf00-95ef-11eb-9743-bd20fae758a6.png" />
+<Image alt="Clutch Storybook Accordion" src="https://user-images.githubusercontent.com/1004789/113596886-c634bf00-95ef-11eb-9743-bd20fae758a6.png" />
 
 ## Decisions, Decisions...
 
@@ -63,13 +65,13 @@ There were numerous pros and cons to each of these solutions but emotion ended u
 
 Now that the tough decisions were out of the way, we were able to start implementation of the new designs. It took three engineers from our team just over two months to finish redesigning the Clutch frontend. Thus far the response has been overwhelmingly positive. The expanded component library has made development of new workflows faster and our maintenance has been reduced drastically.
 
-<img alt="Clutch V2 Landing Page" src="https://user-images.githubusercontent.com/1004789/113597092-0eec7800-95f0-11eb-8f94-b953dd790c23.png" />
+<Image alt="Clutch V2 Landing Page" src="https://user-images.githubusercontent.com/1004789/113597092-0eec7800-95f0-11eb-8f94-b953dd790c23.png" />
 
 ## Iteration is Key
 
 Design is ever-changing. While we feel that we have a great foundation, we are still finding ways to improve different pieces of the design throughout Clutch, both in the frontend and backend. (Stay posted for an upcoming blog on how we revamped error handling!) We continue to invest resources in ensuring that new features and workflows deliver the intuitive and exceptional experience users have come to expect.
 
-<img alt="Clutch Design Process" src="https://user-images.githubusercontent.com/1004789/113596372-119a9d80-95ef-11eb-96cc-e829c905592f.png" />
+<Image alt="Clutch Design Process" src="https://user-images.githubusercontent.com/1004789/113596372-119a9d80-95ef-11eb-96cc-e829c905592f.png" />
 
 ## Interested in Getting Involved?
 

--- a/docs/blog/2021-05-18-chaos-experimentation.md
+++ b/docs/blog/2021-05-18-chaos-experimentation.md
@@ -10,9 +10,7 @@ image: https://miro.medium.com/max/1400/1*Xi46XIWByMV7PUePnUIZsg.png
 hide_table_of_contents: false
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
-Services are bound to degrade. It’s a matter of when, not if. In a distributed system where there are many interdependent microservices, it is increasingly difficult to know what will happen when a service is unavailable, latency goes up, or when the success rate drops. Usually, companies find out the hard way when it happens in production and it affects their customers. This is where [Chaos Engineering](https://principlesofchaos.org/) helps us.
+Services are bound to degrade. It’s a matter of when, not if. In a distributed system where there are many interdependent microservices, it is increasingly difficult to know what will happen when a service is unavailable, latency goes up,   or when the success rate drops. Usually, companies find out the hard way when it happens in production and it affects their customers. This is where [Chaos Engineering](https://principlesofchaos.org/) helps us.
 
 <!--truncate-->
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Minor cleanup of blogs.
* Removes unused imports
* Uses `Image` over `img`

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual