### PR TITLE
ci: fix dockerbuild

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -1,18 +1,16 @@
-name: docker
+name: docker-dev
 on:
-  push:
+  pull_request:
     branches:
       - main
+    paths:
+      - Dockerfile
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-      - uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: determine tags
         id: tags
         run: |
@@ -25,5 +23,5 @@ jobs:
         uses: docker/build-push-action@v2.7.0
         with:
           tags: ${{ steps.tags.outputs.tags }}
-          push: true
+          push: false
           cache-from: type=registry,ref=lyft/clutch:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Dockerfile
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Frontend build.
-FROM node:14-buster as nodebuild
+FROM node:14.18-buster as nodebuild
 COPY ./frontend ./frontend
 COPY ./tools/install-yarn.sh ./tools/install-yarn.sh
 COPY ./tools/preflight-checks.sh ./tools/preflight-checks.sh
@@ -8,7 +8,7 @@ COPY Makefile .
 RUN make frontend
 
 # Backend build.
-FROM golang:1.17-buster as gobuild
+FROM golang:1.17.1-buster as gobuild
 WORKDIR /go/src/github.com/lyft/clutch
 COPY ./backend ./backend
 COPY ./tools/preflight-checks.sh ./tools/preflight-checks.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM node:14-buster as nodebuild
 COPY ./frontend ./frontend
 COPY ./tools/install-yarn.sh ./tools/install-yarn.sh
+COPY ./tools/preflight-checks.sh ./tools/preflight-checks.sh
 COPY Makefile .
 
 RUN make frontend
@@ -10,6 +11,7 @@ RUN make frontend
 FROM golang:1.17-buster as gobuild
 WORKDIR /go/src/github.com/lyft/clutch
 COPY ./backend ./backend
+COPY ./tools/preflight-checks.sh ./tools/preflight-checks.sh
 COPY Makefile .
 
 COPY --from=nodebuild ./frontend/packages/app/build ./frontend/packages/app/build/

--- a/tools/preflight-checks.sh
+++ b/tools/preflight-checks.sh
@@ -7,7 +7,7 @@ did_checks_pass=true
 # Minimum versions
 MIN_GO_VERSION="1.17"
 MIN_NODE_VERSION="14.0.0"
-MIN_YARN_VERSION="1.22.5"
+MIN_YARN_VERSION="1.22.0"
 
 # param 1 - required version
 # param 2 - current version

--- a/tools/preflight-checks.sh
+++ b/tools/preflight-checks.sh
@@ -7,7 +7,7 @@ did_checks_pass=true
 # Minimum versions
 MIN_GO_VERSION="1.17"
 MIN_NODE_VERSION="14.0.0"
-MIN_YARN_VERSION="1.22.11"
+MIN_YARN_VERSION="1.22.5"
 
 # param 1 - required version
 # param 2 - current version


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
https://github.com/lyft/clutch/pull/1764 introduced a preflight check script, and the `dockerfile` was not tested to include this.

Docker was failing to build previously as the yarn version in the node image is only `1.22.5`
> yarn version must be >= 1.22.11, current version 1.22.5

* bump dockerfile images to the latest patch
* fix CI so it builds dockerfile if its modified in a PR
* have the `preflight-checks.sh` script only enforce major and minor versions of a dep I dont think we need to require that a dep be up to a specific patch at the moment. Unless there is some important fix that im not aware of.

### Testing Performed
<!-- Describe how you tested this change below. -->
ci