### PR TITLE
backend: add graceful shutdown handling

### DIFF
--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -359,6 +359,8 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 
 	<-sc
 
+	signal.Stop(sc)
+
 	// Shutdown timeout should be max request timeout (with 1s buffer).
 	ctxShutDown, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add graceful shutdown handling to server.

```bash
2021-10-05T15:28:54.310-0700	INFO	gateway/gateway.go:322	listening	{"tcp": {"addr": "0.0.0.0:8080"}}
2021-10-05T15:28:55.300-0700	DEBUG	stats/debug_reporter.go:41	counter	{"name": "clutch.gateway.start", "value": 1, "tags": {}, "type": "counter"}
```

```bash
 > kill -15 9531
```

```bash
2021-10-05T15:29:00.648-0700	DEBUG	gateway/gateway.go:367	server shutdown gracefully
```

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #12
