### PR TITLE
frontend: ensure dash has fetched project data

### DIFF
--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -79,7 +79,7 @@ const allPresent = (state: State): boolean => {
   return ret;
 };
 
-const updateProjects = (state: State, dispatch: React.Dispatch<Action>) => {
+const hydrateProjects = (state: State, dispatch: React.Dispatch<Action>) => {
   // Determine if any hydration is required.
   // - Are any services missing from state.projectdata?
   // - Are projects empty (first load)?
@@ -121,12 +121,12 @@ const ProjectSelector = () => {
   const [state, dispatch] = React.useReducer(selectorReducer, loadStoredState(initialState));
 
   React.useEffect(() => {
-    const interval = setInterval(() => updateProjects(state, dispatch), 30000);
+    const interval = setInterval(() => hydrateProjects(state, dispatch), 30000);
     return () => clearInterval(interval);
   }, []);
 
   React.useEffect(() => {
-    updateProjects(state, dispatch)
+    hydrateProjects(state, dispatch);
   }, [state[Group.PROJECTS]]);
 
   // computes the final state for rendering across other components

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -71,7 +71,7 @@ const allPresent = (state: State): boolean => {
     ...Object.keys(state[Group.DOWNSTREAM]),
   ]);
   allProjects.forEach(p => {
-    if (!(p in state.projectData)) {
+    if (!(p in state.projectData) || _.isEmpty(state.projectData?.[p])) {
       ret = false;
     }
     return ret; // Will stop iteration early if false encountered.
@@ -91,14 +91,12 @@ const ProjectSelector = () => {
   const [state, dispatch] = React.useReducer(selectorReducer, loadStoredState(initialState));
 
   React.useEffect(() => {
-    console.log("effect"); // eslint-disable-line
     // Determine if any hydration is required.
     // - Are any services missing from state.projectdata?
     // - Are projects empty (first load)?
     // - Is loading not already in progress?
 
     if (!state.loading && (Object.keys(state[Group.PROJECTS]).length === 0 || !allPresent(state))) {
-      console.log("calling API!", state.loading); // eslint-disable-line
       dispatch({ type: "HYDRATE_START" });
 
       // TODO: have userId check be server driven


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
If for some reason project data failed to populate during initial render users would be stuck in a screen where cards could not populate data. This PR adds an additional check to the `allPresent` function to ensure that project data has come back and runs the check on a 30 second interval to make sure if a request has failed on initial render this is eventually fixed on it's own.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual