### PR TITLE
backend: centralize sourcegraph query data

### DIFF
--- a/backend/service/sourcegraph/sourcegraph.go
+++ b/backend/service/sourcegraph/sourcegraph.go
@@ -88,14 +88,16 @@ func (c *client) CompareCommits(ctx context.Context, req *sourcegraphv1.CompareC
 		"head": graphql.String(req.Head),
 	}
 
-	err := c.gqlClient.Query(ctx, &compareCommitsQuery, variables)
+	query := &compareCommitsQuery
+	err := c.gqlClient.Query(ctx, query, variables)
 	if err != nil {
 		c.log.Error("unsuccessful response from sourcegraph", zap.Error(err))
 		return nil, errors.New("unsuccessful response from sourcegraph")
 	}
 
-	commits := make([]*sourcegraphv1.Commit, len(compareCommitsQuery.Repository.Comparison.Commits.Nodes))
-	for i, v := range compareCommitsQuery.Repository.Comparison.Commits.Nodes {
+	nodes := query.Repository.Comparison.Commits.Nodes
+	commits := make([]*sourcegraphv1.Commit, len(nodes))
+	for i, v := range nodes {
 		commits[i] = &sourcegraphv1.Commit{
 			Oid:         string(v.Oid),
 			Message:     string(v.Message),


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
The sourcegraph service currently hits a panic if left running for too long now:
```bash
panic: runtime error: index out of range [1] with length 1

goroutine 2986 [running]:
github.com/lyft/clutch/backend/service/sourcegraph.(*client).CompareCommits(0xc000e9c180, {0x7b3fd20, 0xc001845890}, 0xc001a6e420)
	.../backend/service/sourcegraph/sourcegraph.go:99 +0x525
.../backend/service/lyftdeploys.(*client).getCommitRange(0xc000e9c360, {0x7b3fd20, 0xc001845890}, 0xc001dcad70, {0xc0018c2720, 0x4}, {0xc00167ca20, 0x28})
	.../backend/service/lyftdeploys/lyftdeploys.go:229 +0x23f
.../backend/service/lyftdeploys.(*client).GetProjectEvents.func1(0xc0026f4a50)
	.../backend/service/lyftdeploys/lyftdeploys.go:164 +0x6e9
created by .../backend/service/lyftdeploys.(*client).GetProjectEvents
	.../backend/service/lyftdeploys/lyftdeploys.go:114 +0xa5
```

This fix prevents a race condition where the query resolves to a different node value after the slice has been created.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
