### PR TITLE
update timeline interfaces to include project names

### DIFF
--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -114,14 +114,14 @@ export interface DashAction {
 
 export interface TimeData {
   /** eventsKey corresponds to entity owning the data - i.e. cards */
-  [eventsKey: string]: projectToPointsMap;
+  [eventsKey: string]: ProjectToPointsMap;
 }
 
 /**
  * Contains a mapping of project names to their event time points
  * See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
  */
-export interface projectToPointsMap {
+export interface ProjectToPointsMap {
   [projectName: string]: IClutch.timeseries.v1.IPoint[];
 }
 
@@ -130,7 +130,7 @@ export interface TimeDataUpdate {
   /** The name of the card or entity that is updating */
   key: string;
   /** The projects and their timeseries */
-  points: projectToPointsMap;
+  points: ProjectToPointsMap;
 }
 
 export interface TimelineState {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
We need to keep the project names so that we can reuse them later when marshalling the point data around.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
