### PR TITLE
Adding STS and S3 Policy getter API's to consume later on

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.14.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.7.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/bufbuild/buf v0.37.0

--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -7,14 +7,13 @@ import (
 	"math/rand"
 
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/uber-go/tally"
-	"go.uber.org/zap"
-
 	dynamodbv1 "github.com/lyft/clutch/backend/api/aws/dynamodb/v1"
 	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
 	kinesisv1 "github.com/lyft/clutch/backend/api/aws/kinesis/v1"
 	"github.com/lyft/clutch/backend/service"
 	"github.com/lyft/clutch/backend/service/aws"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 type svc struct{}

--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -7,13 +7,14 @@ import (
 	"math/rand"
 
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+
 	dynamodbv1 "github.com/lyft/clutch/backend/api/aws/dynamodb/v1"
 	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
 	kinesisv1 "github.com/lyft/clutch/backend/api/aws/kinesis/v1"
 	"github.com/lyft/clutch/backend/service"
 	"github.com/lyft/clutch/backend/service/aws"
-	"github.com/uber-go/tally"
-	"go.uber.org/zap"
 )
 
 type svc struct{}

--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"math/rand"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
@@ -14,7 +16,7 @@ import (
 	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
 	kinesisv1 "github.com/lyft/clutch/backend/api/aws/kinesis/v1"
 	"github.com/lyft/clutch/backend/service"
-	"github.com/lyft/clutch/backend/service/aws"
+	clutch_aws_client "github.com/lyft/clutch/backend/service/aws"
 )
 
 type svc struct{}
@@ -102,6 +104,10 @@ func (s *svc) S3StreamingGet(ctx context.Context, region string, bucket string, 
 	panic("implement me")
 }
 
+func (s *svc) S3GetBucketPolicy(ctx context.Context, region string, bucket string, accountID string) (*string, error) {
+	return aws.String("{}"), nil
+}
+
 func (s *svc) DescribeTable(ctx context.Context, region string, tableName string) (*dynamodbv1.Table, error) {
 	currentThroughput := &dynamodbv1.Throughput{
 		ReadCapacityUnits:  100,
@@ -158,7 +164,15 @@ func (s *svc) Regions() []string {
 	return []string{"us-mock-1"}
 }
 
-func New() aws.Client {
+func (s *svc) GetCallerIdentity(ctx context.Context, region string) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: aws.String("000000000000"),
+		Arn:     aws.String("arn:aws:sts::000000000000:fake-role"),
+		UserId:  aws.String("some_special_id"),
+	}, nil
+}
+
+func New() clutch_aws_client.Client {
 	return &svc{}
 }
 

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,6 +7,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -62,6 +63,9 @@ func makeRegionOptions(regions []string) []*resolverv1.Option {
 
 func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (resolver.Resolver, error) {
 	awsClient, ok := service.Registry["clutch.service.aws"]
+
+	logger.Info(fmt.Sprint("+%v",awsClient.(aws.Client)))
+
 	if !ok {
 		return nil, errors.New("could not find service")
 	}

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,7 +7,6 @@ package aws
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -63,9 +62,6 @@ func makeRegionOptions(regions []string) []*resolverv1.Option {
 
 func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (resolver.Resolver, error) {
 	awsClient, ok := service.Registry["clutch.service.aws"]
-
-	logger.Info(fmt.Sprint("+%v",awsClient.(aws.Client)))
-
 	if !ok {
 		return nil, errors.New("could not find service")
 	}

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -6,7 +6,6 @@ package aws
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"io"
 	"net/http"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/iancoleman/strcase"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
@@ -96,7 +96,7 @@ func New(cfg *anypb.Any, logger *zap.Logger, scope tally.Scope) (service.Service
 			ec2:         ec2.NewFromConfig(regionCfg),
 			autoscaling: autoscaling.NewFromConfig(regionCfg),
 			dynamodb:    dynamodb.NewFromConfig(regionCfg),
-			sts: sts.NewFromConfig(regionCfg),
+			sts:         sts.NewFromConfig(regionCfg),
 		}
 	}
 
@@ -114,9 +114,8 @@ type Client interface {
 	DescribeKinesisStream(ctx context.Context, region string, streamName string) (*kinesisv1.Stream, error)
 	UpdateKinesisShardCount(ctx context.Context, region string, streamName string, targetShardCount int32) error
 
-	S3GetBucketPolicy(ctx context.Context, region string, bucket string, accountID string)(*string, error)
+	S3GetBucketPolicy(ctx context.Context, region string, bucket string, accountID string) (*string, error)
 	S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error)
-
 
 	DescribeTable(ctx context.Context, region string, tableName string) (*dynamodbv1.Table, error)
 	UpdateCapacity(ctx context.Context, region string, tableName string, targetTableCapacity *dynamodbv1.Throughput, indexUpdates []*dynamodbv1.IndexUpdateAction, ignoreMaximums bool) (*dynamodbv1.Table, error)
@@ -144,7 +143,7 @@ type regionalClient struct {
 	ec2         ec2Client
 	autoscaling autoscalingClient
 	dynamodb    dynamodbClient
-	sts 		stsClient
+	sts         stsClient
 }
 
 // Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.
@@ -349,5 +348,3 @@ func newProtoForInstance(i ec2types.Instance) *ec2v1.Instance {
 
 	return ret
 }
-
-

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -114,8 +114,9 @@ type Client interface {
 	DescribeKinesisStream(ctx context.Context, region string, streamName string) (*kinesisv1.Stream, error)
 	UpdateKinesisShardCount(ctx context.Context, region string, streamName string, targetShardCount int32) error
 
+	S3GetBucketPolicy(ctx context.Context, region string, bucket string)(*string, error)
 	S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error)
-	S3GetBucketPolicy(ctx context.Context, region string, bucket string, accountID string)(*string, error)
+
 
 	DescribeTable(ctx context.Context, region string, tableName string) (*dynamodbv1.Table, error)
 	UpdateCapacity(ctx context.Context, region string, tableName string, targetTableCapacity *dynamodbv1.Throughput, indexUpdates []*dynamodbv1.IndexUpdateAction, ignoreMaximums bool) (*dynamodbv1.Table, error)
@@ -348,3 +349,5 @@ func newProtoForInstance(i ec2types.Instance) *ec2v1.Instance {
 
 	return ret
 }
+
+

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -114,7 +114,7 @@ type Client interface {
 	DescribeKinesisStream(ctx context.Context, region string, streamName string) (*kinesisv1.Stream, error)
 	UpdateKinesisShardCount(ctx context.Context, region string, streamName string, targetShardCount int32) error
 
-	S3GetBucketPolicy(ctx context.Context, region string, bucket string)(*string, error)
+	S3GetBucketPolicy(ctx context.Context, region string, bucket string, accountID string)(*string, error)
 	S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error)
 
 

--- a/backend/service/aws/iface.go
+++ b/backend/service/aws/iface.go
@@ -5,13 +5,12 @@ package aws
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 type s3Client interface {

--- a/backend/service/aws/iface.go
+++ b/backend/service/aws/iface.go
@@ -5,6 +5,7 @@ package aws
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -15,6 +16,11 @@ import (
 
 type s3Client interface {
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	GetBucketPolicy(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
+}
+
+type stsClient interface {
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
 }
 
 type kinesisClient interface {

--- a/backend/service/aws/s3.go
+++ b/backend/service/aws/s3.go
@@ -2,18 +2,17 @@ package aws
 
 import (
 	"context"
+	"io"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"io"
 )
-
 
 func (c *client) S3GetBucketPolicy(ctx context.Context, region string, bucket string, accountID string) (*string, error) {
 	rc, err := c.getRegionalClient(region)
 	if err != nil {
 		return nil, err
 	}
-
 
 	in := &s3.GetBucketPolicyInput{
 		ExpectedBucketOwner: aws.String(accountID),
@@ -22,15 +21,12 @@ func (c *client) S3GetBucketPolicy(ctx context.Context, region string, bucket st
 
 	bucketPolicy, err := rc.s3.GetBucketPolicy(ctx, in)
 
-
 	if err != nil {
 		return nil, err
 	}
 
 	return bucketPolicy.Policy, nil
 }
-
-
 
 func (c *client) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
 	rc, err := c.getRegionalClient(region)
@@ -50,4 +46,3 @@ func (c *client) S3StreamingGet(ctx context.Context, region string, bucket strin
 
 	return out.Body, nil
 }
-

--- a/backend/service/aws/s3.go
+++ b/backend/service/aws/s3.go
@@ -8,24 +8,6 @@ import (
 	"io"
 )
 
-func (c *client) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
-	rc, err := c.getRegionalClient(region)
-	if err != nil {
-		return nil, err
-	}
-
-	in := &s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	}
-
-	out, err := rc.s3.GetObject(ctx, in)
-	if err != nil {
-		return nil, err
-	}
-
-	return out.Body, nil
-}
 
 func (c *client) S3GetBucketPolicy(ctx context.Context, region string, bucket string) (*string, error) {
 	rc, err := c.getRegionalClient(region)
@@ -54,3 +36,25 @@ func (c *client) S3GetBucketPolicy(ctx context.Context, region string, bucket st
 
 	return bucketPolicy.Policy, nil
 }
+
+
+
+func (c *client) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
+	rc, err := c.getRegionalClient(region)
+	if err != nil {
+		return nil, err
+	}
+
+	in := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	out, err := rc.s3.GetObject(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Body, nil
+}
+

--- a/backend/service/aws/s3.go
+++ b/backend/service/aws/s3.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"context"
-	"io"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"io"
 )
 
 func (c *client) S3StreamingGet(ctx context.Context, region string, bucket string, key string) (io.ReadCloser, error) {
@@ -25,4 +25,32 @@ func (c *client) S3StreamingGet(ctx context.Context, region string, bucket strin
 	}
 
 	return out.Body, nil
+}
+
+func (c *client) S3GetBucketPolicy(ctx context.Context, region string, bucket string) (*string, error) {
+	rc, err := c.getRegionalClient(region)
+	if err != nil {
+		return nil, err
+	}
+
+	currentAccountInfo, err := rc.sts.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+
+	if err != nil {
+		return nil, err
+	}
+
+
+	in := &s3.GetBucketPolicyInput{
+		ExpectedBucketOwner: currentAccountInfo.Account,
+		Bucket:              aws.String(bucket),
+	}
+
+	bucketPolicy, err := rc.s3.GetBucketPolicy(ctx, in)
+
+
+	if err != nil {
+		return nil, err
+	}
+
+	return bucketPolicy.Policy, nil
 }

--- a/backend/service/aws/s3.go
+++ b/backend/service/aws/s3.go
@@ -4,26 +4,19 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"io"
 )
 
 
-func (c *client) S3GetBucketPolicy(ctx context.Context, region string, bucket string) (*string, error) {
+func (c *client) S3GetBucketPolicy(ctx context.Context, region string, bucket string, accountID string) (*string, error) {
 	rc, err := c.getRegionalClient(region)
-	if err != nil {
-		return nil, err
-	}
-
-	currentAccountInfo, err := rc.sts.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-
 	if err != nil {
 		return nil, err
 	}
 
 
 	in := &s3.GetBucketPolicyInput{
-		ExpectedBucketOwner: currentAccountInfo.Account,
+		ExpectedBucketOwner: aws.String(accountID),
 		Bucket:              aws.String(bucket),
 	}
 

--- a/backend/service/aws/s3_test.go
+++ b/backend/service/aws/s3_test.go
@@ -3,11 +3,11 @@ package aws
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"io/ioutil"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
 )
@@ -45,7 +45,6 @@ func TestS3StreamGetErrorHandling(t *testing.T) {
 	assert.Error(t, err2)
 }
 
-
 func TestS3GetBucketPolicy(t *testing.T) {
 	s3Client := &mockS3{
 		getObjectPolicyOutput: &s3.GetBucketPolicyOutput{
@@ -78,7 +77,6 @@ func TestS3GetBucketPolicyErrorHandling(t *testing.T) {
 	assert.Nil(t, output2)
 	assert.Error(t, err2)
 }
-
 
 type mockS3 struct {
 	s3Client

--- a/backend/service/aws/sts.go
+++ b/backend/service/aws/sts.go
@@ -1,0 +1,23 @@
+package aws
+
+import (
+"context"
+"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+func (c *client) GetCallerIdentity(ctx context.Context, region string) (*sts.GetCallerIdentityOutput, error) {
+	rc, err := c.getRegionalClient(region)
+	if err != nil {
+		return nil, err
+	}
+
+	in := &sts.GetCallerIdentityInput{}
+
+
+	out, err := rc.sts.GetCallerIdentity(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/backend/service/aws/sts.go
+++ b/backend/service/aws/sts.go
@@ -1,8 +1,9 @@
 package aws
 
 import (
-"context"
-"github.com/aws/aws-sdk-go-v2/service/sts"
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 func (c *client) GetCallerIdentity(ctx context.Context, region string) (*sts.GetCallerIdentityOutput, error) {
@@ -12,7 +13,6 @@ func (c *client) GetCallerIdentity(ctx context.Context, region string) (*sts.Get
 	}
 
 	in := &sts.GetCallerIdentityInput{}
-
 
 	out, err := rc.sts.GetCallerIdentity(ctx, in)
 	if err != nil {

--- a/backend/service/aws/sts_test.go
+++ b/backend/service/aws/sts_test.go
@@ -3,33 +3,31 @@ package aws
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/stretchr/testify/assert"
 )
-
-
 
 func TestSTSGetCallerIdentity(t *testing.T) {
 	stsClient := &mockSTS{
 		getIdentityOutput: &sts.GetCallerIdentityOutput{
-			Account : aws.String("000000000000"),
-			Arn: aws.String("arn:aws:sts::000000000000:fake-role"),
-			UserId: aws.String("some_special_id"),
+			Account: aws.String("000000000000"),
+			Arn:     aws.String("arn:aws:sts::000000000000:fake-role"),
+			UserId:  aws.String("some_special_id"),
 		},
 	}
 	c := &client{
 		clients: map[string]*regionalClient{"us-east-1": {region: "us-east-1", sts: stsClient}},
 	}
 
-	output, err := c.GetCallerIdentity(context.Background(),"us-east-1")
+	output, err := c.GetCallerIdentity(context.Background(), "us-east-1")
 	assert.NoError(t, err)
 	assert.Equal(t, output, &sts.GetCallerIdentityOutput{
-		Account : aws.String("000000000000"),
-		Arn: aws.String("arn:aws:sts::000000000000:fake-role"),
-		UserId: aws.String("some_special_id"),
+		Account: aws.String("000000000000"),
+		Arn:     aws.String("arn:aws:sts::000000000000:fake-role"),
+		UserId:  aws.String("some_special_id"),
 	})
 }
 
@@ -51,27 +49,17 @@ func TestSTSGetCallerIdentityErrorHandling(t *testing.T) {
 	assert.Error(t, err2)
 }
 
-
 type mockSTS struct {
 	stsClient
 
 	getIdentityErr    error
 	getIdentityOutput *sts.GetCallerIdentityOutput
-
 }
 
-
-func (m *mockSTS) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error){
+func (m *mockSTS) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
 	if m.getIdentityErr != nil {
 		return nil, m.getIdentityErr
 	}
 
 	return m.getIdentityOutput, nil
 }
-
-
-
-
-
-
-

--- a/backend/service/aws/sts_test.go
+++ b/backend/service/aws/sts_test.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+
+
+func TestSTSGetCallerIdentity(t *testing.T) {
+	stsClient := &mockSTS{
+		getIdentityOutput: &sts.GetCallerIdentityOutput{
+			Account : aws.String("000000000000"),
+			Arn: aws.String("arn:aws:sts::000000000000:fake-role"),
+			UserId: aws.String("some_special_id"),
+		},
+	}
+	c := &client{
+		clients: map[string]*regionalClient{"us-east-1": {region: "us-east-1", sts: stsClient}},
+	}
+
+	output, err := c.GetCallerIdentity(context.Background(),"us-east-1")
+	assert.NoError(t, err)
+	assert.Equal(t, output, &sts.GetCallerIdentityOutput{
+		Account : aws.String("000000000000"),
+		Arn: aws.String("arn:aws:sts::000000000000:fake-role"),
+		UserId: aws.String("some_special_id"),
+	})
+}
+
+func TestSTSGetCallerIdentityErrorHandling(t *testing.T) {
+	stsClient := &mockSTS{
+		getIdentityErr: fmt.Errorf("error"),
+	}
+	c := &client{
+		clients: map[string]*regionalClient{"us-east-1": {region: "us-east-1", sts: stsClient}},
+	}
+
+	output1, err1 := c.GetCallerIdentity(context.Background(), "us-east-1")
+	assert.Nil(t, output1)
+	assert.Error(t, err1)
+
+	// Test unknown region
+	output2, err2 := c.GetCallerIdentity(context.Background(), "choice-region-1")
+	assert.Nil(t, output2)
+	assert.Error(t, err2)
+}
+
+
+type mockSTS struct {
+	stsClient
+
+	getIdentityErr    error
+	getIdentityOutput *sts.GetCallerIdentityOutput
+
+}
+
+
+func (m *mockSTS) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error){
+	if m.getIdentityErr != nil {
+		return nil, m.getIdentityErr
+	}
+
+	return m.getIdentityOutput, nil
+}
+
+
+
+
+
+
+

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3913,6 +3913,16 @@
     csstype "^2.5.2"
     prop-types "^15.7.2"
 
+"@material-ui/system@^4.11.4":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
 "@material-ui/types@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"


### PR DESCRIPTION
STS client introduction + adding GetBucketPolicy API's to Clutch

### Description
<!-- Describe your change below. -->

Adding STS client (that allows users to programmatically get their aws identity) as well as adding an S3 bucket policy fetching API to Clutch's internal AWS client.

### Testing Performed
<!-- Describe how you tested this change below. -->
Unit tests + Manual Tests (consuming API's in another clutch instance)
