### PR TITLE
gateway: catching more signals for graceful shutdown

### DIFF
--- a/backend/gateway/gateway.go
+++ b/backend/gateway/gateway.go
@@ -345,9 +345,10 @@ func RunWithConfig(f *Flags, cfg *gatewayv1.Config, cf *ComponentFactory, assets
 	sc := make(chan os.Signal, 1)
 	signal.Notify(
 		sc,
-		os.Interrupt,
-		syscall.SIGTERM,
+		syscall.SIGHUP,
+		syscall.SIGINT,
 		syscall.SIGQUIT,
+		syscall.SIGTERM,
 	)
 
 	go func() {

--- a/backend/service/topology/topology.go
+++ b/backend/service/topology/topology.go
@@ -101,7 +101,13 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 
 	ctx, ctxCancelFunc := context.WithCancel(context.Background())
 	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(
+		sigc,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGQUIT,
+		syscall.SIGTERM,
+	)
 	go func() {
 		<-sigc
 		c.log.Info("Caught shutdown signal, shutting down topology caching and releasing advisory lock")


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Catching more signals for graceful shutdown. Adding `SIGHUP`, I also replaced the `os` signal with the syscall one (`SIGINT`) as it's simply a proxy for it, for consistency sake.