### PR TITLE
backend: add debug flag for gateway config

### DIFF
--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/yaml.v3"
 
-	"github.com/golang/protobuf/jsonpb"
 	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
 	"github.com/lyft/clutch/backend/middleware/timeouts"
 )
@@ -78,12 +77,11 @@ func MustReadOrValidateConfig(f *Flags) *gatewayv1.Config {
 	}
 
 	if f.Debug {
-		m := jsonpb.Marshaler{}
-		json, err := m.MarshalToString(&cfg)
+		json, err := protojson.Marshal(&cfg)
 		if err != nil {
 			tmpLogger.Fatal("failed to cast configuration file to json", zap.Error(err))
 		}
-		fmt.Println(json)
+		fmt.Println(string(json))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add a debug flag to the gateway config to print the final consolidated configuration to stdout if present.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual