### PR TITLE
core card: check more scenarios for the "see more" hook

### DIFF
--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -216,8 +216,8 @@ const CardContent = ({
   }, [maxHeight, children]);
 
   return (
-    <BaseCardContent {...props} ref={ref}>
-      <StyledCardContentContainer maxHeight={expanded ? "none" : maxHeight}>
+    <BaseCardContent {...props}>
+      <StyledCardContentContainer maxHeight={expanded ? "none" : maxHeight} ref={ref}>
         {children}
       </StyledCardContentContainer>
       {collapsible && showExpand && (


### PR DESCRIPTION
### Description

Because data can be changing dynamically within `CardContent` (i.e. an API call is made to fetch more or less data), the hook needs to check if `scrollHeight` is now less than the `maxHeight`. PR updates the hook to make this the first check it does. Everything else remains the same.

### Testing Performed
Locally with internal cards