### PR TITLE
proxy: add stats to the proxy module

### DIFF
--- a/backend/module/proxy/proxy.go
+++ b/backend/module/proxy/proxy.go
@@ -118,8 +118,7 @@ func (m *mod) RequestProxy(ctx context.Context, req *proxyv1.RequestProxyRequest
 	response, err := m.client.Do(request)
 	if err != nil {
 		m.scope.Tagged(map[string]string{
-			"service":     service.Name,
-			"status_code": fmt.Sprintf("%d", response.StatusCode),
+			"service": service.Name,
 		}).Counter("request.error").Inc(1)
 		m.logger.Error("proxy request error", zap.Error(err))
 		return nil, err
@@ -128,7 +127,7 @@ func (m *mod) RequestProxy(ctx context.Context, req *proxyv1.RequestProxyRequest
 	m.scope.Tagged(map[string]string{
 		"service":     service.Name,
 		"status_code": fmt.Sprintf("%d", response.StatusCode),
-	}).Counter("request.success").Inc(1)
+	}).Counter("request").Inc(1)
 
 	// Extract headers from response
 	// TODO: It might make sense to provide a list of allowed headers, as there can be a lot.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Adding two new stats to the proxy module for better visibility.

* `clutch.module.proxy.request`- this will emit whenever a request is successful (note this does not mean a successful response from the server), it will tag the `service` we are communicating with and the `status_code` of the response.

* `clutch.module.proxy.request.error` - this will emit if the request errors out for any reason. on error, any response can be ignored.

Some examples:
```
counter	{"kv": {"name": "clutch.module.proxy.request", "value": 1, "tags": {"service":"pagerduty","status_code":"200"}, "type": "counter"}}
counter	{"kv": {"name": "clutch.module.proxy.request", "value": 1, "tags": {"service":"google","status_code":"405"}, "type": "counter"}}
```

### Testing Performed
Locally
