### PR TITLE
make single choice drawers go directly to the link

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -103,6 +103,34 @@ const Group = ({ heading, open = false, updateOpenGroup, closeGroup, children }:
   if (React.Children.count(children) === 0) {
     return null;
   }
+  
+  // If there is only 1 child, we can go straight to that item instead of popping
+  // open a drawer and displaying the only choice.
+  // TODO: Make sure this is the optimal way to do this - yes it works, but it
+  // might be the wrong way.
+  if (React.Children.count(children) === 1) {
+    return (
+      <GroupList data-qa="workflowGroup">
+        <GroupListItem
+          button
+          selected={open}
+          ref={anchorRef}
+          aria-controls={open ? "workflow-options" : undefined}
+          aria-haspopup="true"
+          onClick={() => {
+            window.location.href = window.location.origin + "/" + children[0]?.props?.to;
+          }}
+        >
+          <Avatar>{heading.charAt(0)}</Avatar>
+          <GroupHeading align="center">{heading}</GroupHeading>
+          <Popper open={open} onClickAway={closeGroup} anchorRef={anchorRef} id="workflow-options">
+            {children}
+          </Popper>
+        </GroupListItem>
+      </GroupList>
+    );
+  }
+
   // TODO (dschaller): revisit how we handle long groups once we have designs.
   // n.b. this is a stop-gap solution to prevent long groups from looking unreadable.
   return (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
When a user clicks on a workflow group that only has one choice inside of it, we will now take the user directly there instead of them having to do 2 clicks.

https://github.com/lyft/clutch/issues/1789

One potential downside of this approach is that there is not a lot of info space in the side bar. "Envoy Triage" communicates a lot more to the user than just "Envoy" does. However, writing "Envoy Triage" in the little space can make things look squished.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
- [ ] Put it in a different component or add a prop so that tests pass and its more reusable
<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
