### PR TITLE
add time selector hooks

### DIFF
--- a/frontend/workflows/projectSelector/src/dash-hooks.tsx
+++ b/frontend/workflows/projectSelector/src/dash-hooks.tsx
@@ -6,8 +6,8 @@ import type {
   TimeDataUpdate,
   TimelineAction,
   TimelineState,
-  TimeSelectorAction,
-  TimeSelectorState,
+  TimeRangeAction,
+  TimeRangeState,
 } from "./types";
 
 // Contexts for project selector
@@ -23,11 +23,9 @@ export const TimelineDispatchContext = React.createContext<
 >(undefined);
 
 // Contexts for time selector
-export const TimeSelectorStateContext = React.createContext<TimeSelectorState | undefined>(
-  undefined
-);
-export const TimeSelectorDispatchContext = React.createContext<
-  ((action: TimeSelectorAction) => void) | undefined
+export const TimeRangeStateContext = React.createContext<TimeRangeState | undefined>(undefined);
+export const TimeRangeDispatchContext = React.createContext<
+  ((action: TimeRangeAction) => void) | undefined
 >(undefined);
 
 // project selector hooks
@@ -83,27 +81,27 @@ export const useTimelineState = (): TimelineState => {
 };
 
 // timestamp selection hooks
-type useTimeSelectorReturn = {
-  updateTimeSelection: (state: TimeSelectorState) => void;
+type useTimeRangeReturn = {
+  updateTimeRange: (state: TimeRangeState) => void;
 };
 
 // hook for writing
-export const useTimeSelectorUpdater = (): useTimeSelectorReturn => {
-  const dispatch = React.useContext(TimeSelectorDispatchContext);
+export const useTimeRangeUpdater = (): useTimeRangeReturn => {
+  const dispatch = React.useContext(TimeRangeDispatchContext);
 
   return {
-    updateTimeSelection: (state: TimeSelectorState) => {
+    updateTimeRange: (state: TimeRangeState) => {
       dispatch && dispatch({ type: "UPDATE", payload: state });
     },
   };
 };
 
 // hook for reading
-export const useTimeSelectorState = (): TimeSelectorState => {
-  const value = React.useContext<TimeSelectorState | undefined>(TimeSelectorStateContext);
+export const useTimeRangeState = (): TimeRangeState => {
+  const value = React.useContext<TimeRangeState | undefined>(TimeRangeStateContext);
   if (!value) {
     throw new Error(
-      "useTimeSelectorState was invoked outside of a valid context, check that it is a child of the TimeSelector component"
+      "useTimeRangeState was invoked outside of a valid context, check that it is a child of the TimeRange component"
     );
   }
   return value;

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -8,21 +8,19 @@ import {
   ProjectSelectorStateContext,
   TimelineDispatchContext,
   TimelineStateContext,
-  TimeSelectorDispatchContext,
-  TimeSelectorStateContext,
+  TimeRangeDispatchContext,
+  TimeRangeStateContext,
 } from "./dash-hooks";
+import { hoursToMs } from "./helpers";
 import ProjectSelector from "./project-selector";
 import type {
   DashAction,
   DashState,
   TimelineAction,
   TimelineState,
-  TimeSelectorAction,
-  TimeSelectorState,
+  TimeRangeAction,
+  TimeRangeState,
 } from "./types";
-
-// Default look back is 2 hours for time selector
-const TWO_HOURS_MS = 7200000;
 
 const initialState: DashState = {
   selected: [],
@@ -33,9 +31,10 @@ const initialTimelineState: TimelineState = {
   timeData: {},
 };
 
-const initialTimeSelectorState: TimeSelectorState = {
-  startTimeMillis: Date.now() - TWO_HOURS_MS,
-  endTimeMillis: Date.now(),
+const initialTimeRangeState: TimeRangeState = {
+  // Default look back is 2 hours for time selector
+  startTimeMs: Date.now() - hoursToMs(2),
+  endTimeMs: Date.now(),
 };
 
 const CardContainer = styled.div({
@@ -72,15 +71,12 @@ const timelineReducer = (state: TimelineState, action: TimelineAction): Timeline
   }
 };
 
-const timeSelectorReducer = (
-  state: TimeSelectorState,
-  action: TimeSelectorAction
-): TimeSelectorState => {
+const timeRangeReducer = (state: TimeRangeState, action: TimeRangeAction): TimeRangeState => {
   switch (action.type) {
     case "UPDATE": {
       if (
-        !_.isEqual(state.startTimeMillis, action.payload.startTimeMillis) ||
-        !_.isEqual(state.endTimeMillis, action.payload.endTimeMillis)
+        !_.isEqual(state.startTimeMs, action.payload.startTimeMs) ||
+        !_.isEqual(state.endTimeMs, action.payload.endTimeMs)
       ) {
         return action.payload;
       }
@@ -94,25 +90,25 @@ const timeSelectorReducer = (
 const Dash = ({ children }) => {
   const [state, dispatch] = React.useReducer(dashReducer, initialState);
   const [timelineState, timelineDispatch] = React.useReducer(timelineReducer, initialTimelineState);
-  const [timeSelectorState, timeSelectorDispatch] = React.useReducer(
-    timeSelectorReducer,
-    initialTimeSelectorState
+  const [timeRangeState, timeRangeDispatch] = React.useReducer(
+    timeRangeReducer,
+    initialTimeRangeState
   );
   return (
     <Box display="flex" flex={1} minHeight="100%" maxHeight="100%">
       {/* TODO: Maybe in the future invert proj selector and timeline contexts */}
       <ProjectSelectorDispatchContext.Provider value={dispatch}>
         <ProjectSelectorStateContext.Provider value={state}>
-          <TimelineDispatchContext.Provider value={timelineDispatch}>
-            <TimelineStateContext.Provider value={timelineState}>
-              <TimeSelectorDispatchContext.Provider value={timeSelectorDispatch}>
-                <TimeSelectorStateContext.Provider value={timeSelectorState}>
+          <TimeRangeDispatchContext.Provider value={timeRangeDispatch}>
+            <TimeRangeStateContext.Provider value={timeRangeState}>
+              <TimelineDispatchContext.Provider value={timelineDispatch}>
+                <TimelineStateContext.Provider value={timelineState}>
                   <ProjectSelector />
                   <CardContainer>{children}</CardContainer>
-                </TimeSelectorStateContext.Provider>
-              </TimeSelectorDispatchContext.Provider>
-            </TimelineStateContext.Provider>
-          </TimelineDispatchContext.Provider>
+                </TimelineStateContext.Provider>
+              </TimelineDispatchContext.Provider>
+            </TimeRangeStateContext.Provider>
+          </TimeRangeDispatchContext.Provider>
         </ProjectSelectorStateContext.Provider>
       </ProjectSelectorDispatchContext.Provider>
     </Box>

--- a/frontend/workflows/projectSelector/src/helpers.tsx
+++ b/frontend/workflows/projectSelector/src/helpers.tsx
@@ -154,6 +154,10 @@ const deriveStateData = (state: State): State => {
   return newState;
 };
 
+const hoursToMs = (hours: number): number => {
+  return hours * 60 * 60 * 1000;
+};
+
 export {
   deriveStateData,
   deriveSwitchStatus,
@@ -164,4 +168,5 @@ export {
   updateGroupstate,
   useDispatch,
   useReducerState,
+  hoursToMs,
 };

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -6,8 +6,8 @@ import {
   useDashState,
   useTimelineState,
   useTimelineUpdater,
-  useTimeSelectorState,
-  useTimeSelectorUpdater,
+  useTimeRangeState,
+  useTimeRangeUpdater,
 } from "./dash-hooks";
 
 export interface WorkflowProps extends BaseWorkflowProps {}
@@ -40,7 +40,7 @@ export type {
   TimeData,
   TimeDataUpdate,
   ProjectToPointsMap,
-  TimeSelectorState,
+  TimeRangeState,
 } from "./types";
 export {
   Card,
@@ -48,6 +48,6 @@ export {
   useDashState,
   useTimelineState,
   useTimelineUpdater,
-  useTimeSelectorState,
-  useTimeSelectorUpdater,
+  useTimeRangeState,
+  useTimeRangeUpdater,
 };

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -142,18 +142,18 @@ export interface TimelineAction {
   type: TimelineActionKindUpdate;
   payload: TimeDataUpdate;
 }
-export interface TimeSelectorState {
-  /** The start of the time window the user has chosen */
-  startTimeMillis: number;
-  /** The end of time window the user has chosen */
-  endTimeMillis: number;
+export interface TimeRangeState {
+  /** The start of the time window the user has chosen in milliseconds */
+  startTimeMs: number;
+  /** The end of time window the user has chosen in milliseconds */
+  endTimeMs: number;
 }
 
-export type TimeSelectorActionUpdate = "UPDATE";
+export type TimeRangeActionUpdate = "UPDATE";
 
-export interface TimeSelectorAction {
-  type: TimeSelectorActionUpdate;
-  payload: TimeSelectorState;
+export interface TimeRangeAction {
+  type: TimeRangeActionUpdate;
+  payload: TimeRangeState;
 }
 
 export { isGroupState, isProjectState, isGlobalProjectState };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It is useful to have another context that handles time selection updates. This way there can be a time selector component that communicates with the timeline and related hierarchy.

An alternative approach to this is to put everything in the previously created "timeline data" contexts. The reason why I chose not to do that was because it seemed more cluttered and less organized.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
no

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
