### PR TITLE
backend: ensure unique config services, modules, resolvers

### DIFF
--- a/backend/gateway/config.go
+++ b/backend/gateway/config.go
@@ -107,12 +107,15 @@ func ensureUnique(cfg *gatewayv1.Config) error {
 		if _, seen := mods[m.GetName()]; seen {
 			return fmt.Errorf("duplicate module found: %s", m.GetName())
 		}
+		mods[m.GetName()] = true
 	}
+
 	rlvs := make(map[string]bool)
 	for _, r := range cfg.GetResolvers() {
 		if _, seen := rlvs[r.GetName()]; seen {
 			return fmt.Errorf("duplicate resolver found: %s", r.GetName())
 		}
+		rlvs[r.GetName()] = true
 	}
 	return nil
 }

--- a/backend/gateway/config_test.go
+++ b/backend/gateway/config_test.go
@@ -19,6 +19,58 @@ import (
 	"github.com/lyft/clutch/backend/middleware/timeouts"
 )
 
+func TestEnsureUnique(t *testing.T) {
+	tests := []struct {
+		c   *gatewayv1.Config
+		err error
+	}{
+		{
+			c: &gatewayv1.Config{
+				Services: []*gatewayv1.Service{
+					{Name: "foo"},
+					{Name: "foo"},
+				},
+			},
+			err: fmt.Errorf("duplicate service found: foo"),
+		},
+		{
+			c: &gatewayv1.Config{
+				Modules: []*gatewayv1.Module{
+					{Name: "foo"},
+					{Name: "foo"},
+				},
+			},
+			err: fmt.Errorf("duplicate module found: foo"),
+		},
+		{
+			c: &gatewayv1.Config{
+				Resolvers: []*gatewayv1.Resolver{
+					{Name: "foo"},
+					{Name: "foo"},
+				},
+			},
+			err: fmt.Errorf("duplicate resolver found: foo"),
+		},
+		{
+			c: &gatewayv1.Config{
+				Services:  []*gatewayv1.Service{{Name: "foo"}},
+				Modules:   []*gatewayv1.Module{{Name: "foo"}},
+				Resolvers: []*gatewayv1.Resolver{{Name: "foo"}},
+			},
+			err: nil,
+		},
+	}
+
+	for idx, tt := range tests {
+		tc := tt // Pin!
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			t.Parallel()
+			err := ensureUnique(tc.c)
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}
+
 func tmpFile(filename, content string) *os.File {
 	f, err := ioutil.TempFile(".", filename)
 	if err != nil {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR adds logic to the config validate flag to ensure unique services, modules, and resolvers within the consolidated configuration.

It would be ideal if this could be done within the proto but PGV does not support repeated message type validation: https://github.com/envoyproxy/protoc-gen-validate#repeated.

```bash
cd backend && go run main.go -template -validate -c clutch-config.yaml
{"level":"fatal","ts":1634607907.796306,"caller":"gateway/config.go:76","msg":"configuration validation failed","file":"clutch-config.yaml","error":"duplicate module found: lyft.module.project"}
```

```bash
cd backend && go run main.go -template -validate -c clutch-config.yaml
{"level":"info","ts":1634608129.6055639,"caller":"gateway/config.go:79","msg":"configuration validation was successful","file":"clutch-config.yaml"}
```

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual