### PR TITLE
aws: autocomplete for dynamodb

### DIFF
--- a/backend/service/aws/iface.go
+++ b/backend/service/aws/iface.go
@@ -43,4 +43,5 @@ type autoscalingClient interface {
 type dynamodbClient interface {
 	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
 	UpdateTable(ctx context.Context, params *dynamodb.UpdateTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateTableOutput, error)
+	ListTables(ctx context.Context, params *dynamodb.ListTablesInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error)
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Cache all dyamodb resources so autocomplete can work.

```
clutch=# select resolver_type_url, count(*) as count from topology_cache group by resolver_type_url;
                   resolver_type_url                    | count
--------------------------------------------------------+-------
 type.googleapis.com/clutch.aws.dynamodb.v1.Table       |  10
 ```

### Testing Performed
Locally.
