### PR TITLE
proxy module: add helper for adding ignored headers to Request struct

### DIFF
--- a/backend/module/proxy/proxy.go
+++ b/backend/module/proxy/proxy.go
@@ -107,7 +107,7 @@ func (m *mod) RequestProxy(ctx context.Context, req *proxyv1.RequestProxyRequest
 		Header: headers,
 	}
 
-	request = addExcludedHeaders(request)
+	addExcludedHeaders(request)
 
 	if req.Request != nil {
 		requestJSON, err := protojson.Marshal(req.Request)
@@ -199,10 +199,9 @@ Context:
 	https://github.com/golang/go/blob/8c94aa40e6f5e61e8a570e9d20b7d0d4ad8c382d/src/net/http/request.go#L88
 */
 // TODO: add the other headers that get excluded from the request
-func addExcludedHeaders(request *http.Request) *http.Request {
+func addExcludedHeaders(request *http.Request) {
 	// Get() is case insensitive
 	if hostHeader := request.Header.Get(HostHeaderKey); hostHeader != "" {
 		request.Host = hostHeader
 	}
-	return request
 }

--- a/backend/module/proxy/proxy_test.go
+++ b/backend/module/proxy/proxy_test.go
@@ -252,7 +252,7 @@ func TestAddExcludedHeaders(t *testing.T) {
 			Header: headers,
 		}
 
-		updatedReq := addExcludedHeaders(req)
-		assert.Equal(t, test.expected, updatedReq.Host)
+		addExcludedHeaders(req)
+		assert.Equal(t, test.expected, req.Host)
 	}
 }


### PR DESCRIPTION
### Description

#### Background
Noticed that when we added the host to the header map, the host header wasn't getting sent in the request. Came across https://github.com/golang/go/issues/29865 which mentions that the host added in the header map gets ignored and should instead be added to the `Host` field in the request struct. https://github.com/golang/go/issues/29865

PR adds a new helper to check if the user's header list contains an ignored header. If it does, it get adds to the designated field on the Request struct. For now, PR adds this check for `host` with a TODO to add the other fields that get ignored.

### Testing Performed
Locally with internal repo. Tested the the new service we want to call and the existing pagerduty set up.

### TODOs
- [x] Write tests
- [x] Test internally
