### PR TITLE
frontend: rename emoji to icon in project selector

### DIFF
--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -123,8 +123,8 @@ export interface EventData {
    * See https://github.com/lyft/clutch/blob/main/api/timeseries/v1/timeseries.proto
    */
   points: { [name: string]: IClutch.timeseries.v1.IPoint[] };
-  /** The emoji that will be used for this event series on the event timeline */
-  emoji: string;
+  /** The icon that will be used for this event series on the event timeline */
+  icon: React.ReactElement<any> | string;
 }
 
 /** Used by the reducer to update the time data in our context. */


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Rename emoji to icon and support additional types in project selector events. This is to make the prop more flexible if you want to use a custom icon.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
