### PR TITLE
add null type to PopperProps

### DIFF
--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -89,7 +89,7 @@ export interface PopperProps
   extends Pick<ClickAwayListenerProps, "onClickAway">,
     Pick<MuiPopperProps, "placement"> {
   open: boolean;
-  anchorRef: React.MutableRefObject<HTMLElement>;
+  anchorRef: React.MutableRefObject<HTMLElement> | null;
   children?: React.ReactElement<PopperItemProps> | React.ReactElement<PopperItemProps>[];
   id?: string;
 }

--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -102,7 +102,7 @@ const Popper = ({
   id,
 }: PopperProps) => (
   <Collapse in={open} timeout="auto" unmountOnExit>
-    <StyledPopper open={open} anchorEl={anchorRef.current} transition placement={placement}>
+    <StyledPopper open={open} anchorEl={anchorRef?.current} transition placement={placement}>
       <Paper>
         <ClickAwayListener onClickAway={onClickAway}>
           <List component="div" disablePadding id={id}>

--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -89,7 +89,7 @@ export interface PopperProps
   extends Pick<ClickAwayListenerProps, "onClickAway">,
     Pick<MuiPopperProps, "placement"> {
   open: boolean;
-  anchorRef: React.MutableRefObject<HTMLElement> | null;
+  anchorRef?: React.MutableRefObject<HTMLElement> | null;
   children?: React.ReactElement<PopperItemProps> | React.ReactElement<PopperItemProps>[];
   id?: string;
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This is useful to be more like the material-ui popper

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
