### PR TITLE
frontend: Locking esbuild to 0.12.16

### DIFF
--- a/frontend/packages/tools/package.json
+++ b/frontend/packages/tools/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "cypress": "8.7.0",
     "enzyme": "^3.11.0",
-    "esbuild": "^0.12.0",
+    "esbuild": "0.12.16",
     "eslint": "^7.24.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^8.2.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10350,10 +10350,10 @@ esbuild-loader@^2.10.0:
     type-fest "^0.21.3"
     webpack-sources "^2.2.0"
 
-esbuild@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.0.tgz#84f49105994f437c2fe307daa5b32e8885c3d10d"
-  integrity sha512-vUKQ6TiMWGCtI7jLSrMmBVY4aj4As9J6NsFnrS9insd2F5KKD3mr1jUe+SB4KsMACkQIGtTtkksPpRmmqgxDHw==
+esbuild@0.12.16:
+  version "0.12.16"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.16.tgz#c397144ce13b445a6ead9c1f747da11f79ec5e67"
+  integrity sha512-XqI9cXP2bmQ6MREIqrYBb13KfYFSERsV1+e5jSVWps8dNlLZK+hln7d0mznzDIpfISsg/AgQW0DW3kSInXWhrg==
 
 esbuild@^0.9.2:
   version "0.9.2"


### PR DESCRIPTION
### Description
Some variability is happening with esbuild, locking to 0.12.16 for now as 0.12.17 introduces the breaking change.
