### PR TITLE
frontend: reduce autocomplete debouce to 250ms

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -245,7 +245,7 @@ const TextField = ({
             helpText = err;
           });
       }
-    }, 500)
+    }, 250)
   ).current;
   if (autocompleteCallback !== undefined) {
     // TODO (mcutalo): support option.label in the renderOption


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->
### Description
There are times where I felt auto complete was not firing fast enough to provide a good user experience. Reducing this value by half seems like a good place to start.

### Testing Performed
n/a