### PR TITLE
frontend: add fill support to chips

### DIFF
--- a/frontend/packages/core/src/chip.tsx
+++ b/frontend/packages/core/src/chip.tsx
@@ -26,6 +26,7 @@ export interface ChipProps extends Pick<MuiChipProps, "label"> {
    *  * success:   completion/succeeded
    */
   variant: typeof CHIP_VARIANTS[number];
+  filled?: boolean;
 }
 
 const CHIP_COLOR_MAP = {
@@ -37,7 +38,7 @@ const CHIP_COLOR_MAP = {
   warn: {
     background: "#FEF8E8",
     label: "#D87313",
-    borderColor: "##D87313",
+    borderColor: "#D87313",
   },
   attention: {
     background: "#E2E2E6",
@@ -66,7 +67,7 @@ const CHIP_COLOR_MAP = {
   },
 };
 
-const StyledChip = styled(MuiChip)(
+const StyledChip = styled(MuiChip)<{filled?: boolean}>(
   {
     height: "32px",
     cursor: "inherit",
@@ -80,8 +81,8 @@ const StyledChip = styled(MuiChip)(
     },
   },
   props => ({
-    background: CHIP_COLOR_MAP[props["data-variant"]].background,
-    color: CHIP_COLOR_MAP[props["data-variant"]].label,
+    background: props.filled ? CHIP_COLOR_MAP[props["data-variant"]].borderColor : CHIP_COLOR_MAP[props["data-variant"]].background,
+    color: props.filled ? "#FFFFFF" : CHIP_COLOR_MAP[props["data-variant"]].label,
     borderColor: CHIP_COLOR_MAP[props["data-variant"]].borderColor,
   })
 );

--- a/frontend/packages/core/src/chip.tsx
+++ b/frontend/packages/core/src/chip.tsx
@@ -67,7 +67,7 @@ const CHIP_COLOR_MAP = {
   },
 };
 
-const StyledChip = styled(MuiChip)<{filled?: boolean}>(
+const StyledChip = styled(MuiChip)<{ filled?: boolean }>(
   {
     height: "32px",
     cursor: "inherit",
@@ -81,7 +81,9 @@ const StyledChip = styled(MuiChip)<{filled?: boolean}>(
     },
   },
   props => ({
-    background: props.filled ? CHIP_COLOR_MAP[props["data-variant"]].borderColor : CHIP_COLOR_MAP[props["data-variant"]].background,
+    background: props.filled
+      ? CHIP_COLOR_MAP[props["data-variant"]].borderColor
+      : CHIP_COLOR_MAP[props["data-variant"]].background,
     color: props.filled ? "#FFFFFF" : CHIP_COLOR_MAP[props["data-variant"]].label,
     borderColor: CHIP_COLOR_MAP[props["data-variant"]].borderColor,
   })


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add support to fill chips.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
<img width="88" alt="Screen Shot 2021-11-15 at 3 45 49 PM" src="https://user-images.githubusercontent.com/1004789/141870435-5dcecd99-c6d7-4717-a009-db6b171cff0b.png">

<img width="82" alt="Screen Shot 2021-11-15 at 3 45 55 PM" src="https://user-images.githubusercontent.com/1004789/141870444-ddc39c5a-851f-4848-86f1-43e227af4883.png">

<img width="98" alt="Screen Shot 2021-11-15 at 3 46 02 PM" src="https://user-images.githubusercontent.com/1004789/141870459-228809a6-b396-4c53-a1df-3d701f9928b0.png">

<img width="101" alt="Screen Shot 2021-11-15 at 3 46 11 PM" src="https://user-images.githubusercontent.com/1004789/141870471-c31d654b-f8da-45d0-951f-776bd171df4a.png">

<img width="79" alt="Screen Shot 2021-11-15 at 3 46 20 PM" src="https://user-images.githubusercontent.com/1004789/141870477-5673ddaf-b74c-47dd-9e2d-3c1b6190dde3.png">

<img width="100" alt="Screen Shot 2021-11-15 at 3 46 27 PM" src="https://user-images.githubusercontent.com/1004789/141870494-8a984312-1650-40e0-8c9e-417270adad99.png">

<img width="88" alt="Screen Shot 2021-11-15 at 3 46 35 PM" src="https://user-images.githubusercontent.com/1004789/141870501-bd732d26-7fe5-4a66-8e02-a7b66538c875.png">

### Testing Performed
<!-- Describe how you tested this change below. -->
manual