### PR TITLE
feedback: add wizard feedback prop to workflow configuration

### DIFF
--- a/frontend/workflows/dynamodb/src/index.tsx
+++ b/frontend/workflows/dynamodb/src/index.tsx
@@ -11,7 +11,11 @@ interface TableDetailsProps {
   enableOverride?: boolean;
 }
 
-export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, TableDetailsProps {}
+interface WizardFeedbackProps {
+  enableFeedback?: boolean;
+}
+
+export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, TableDetailsProps, WizardFeedbackProps {}
 export interface ResolverChild extends WizardChild, ResolverConfigProps {}
 export interface TableDetailsChild extends WizardChild, TableDetailsProps {}
 

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -13,7 +13,11 @@ interface ConfirmConfigProps {
   notes?: NoteConfig[];
 }
 
-export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps {}
+interface WizardFeedbackProps {
+  enableFeedback?: boolean;
+}
+
+export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps, WizardFeedbackProps {}
 export interface ResolverChild extends WizardChild, ResolverConfigProps {}
 export interface ConfirmChild extends WizardChild, ConfirmConfigProps {}
 

--- a/frontend/workflows/envoy/src/index.tsx
+++ b/frontend/workflows/envoy/src/index.tsx
@@ -1,6 +1,12 @@
-import type { WorkflowConfiguration } from "@clutch-sh/core";
+import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
 
 import RemoteTriage from "./remote-triage";
+
+interface WizardFeedbackProps {
+  enableFeedback?: boolean;
+}
+
+export interface WorkflowProps extends BaseWorkflowProps, WizardFeedbackProps {}
 
 const register = (): WorkflowConfiguration => {
   return {

--- a/frontend/workflows/envoy/src/remote-triage/index.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import type { BaseWorkflowProps } from "@clutch-sh/core";
 import {
   Button,
   ButtonGroup,
@@ -15,6 +14,7 @@ import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
 
+import type { WorkflowProps } from "../index";
 import Clusters from "./clusters";
 import Dashboard from "./dashboard";
 import Listeners from "./listeners";
@@ -120,7 +120,7 @@ const TriageDetails: React.FC<WizardChild> = () => {
   );
 };
 
-const RemoteTriage: React.FC<BaseWorkflowProps> = ({ heading }) => {
+const RemoteTriage: React.FC<WorkflowProps> = ({ heading }) => {
   const dataLayout = {
     resourceData: {},
     remoteData: {

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -13,7 +13,11 @@ interface ConfirmConfigProps {
   notes?: NoteConfig[];
 }
 
-export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps {}
+interface WizardFeedbackProps {
+  enableFeedback?: boolean;
+}
+
+export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps, WizardFeedbackProps {}
 export interface ResolverChild extends WizardChild, ResolverConfigProps {}
 export interface ConfirmChild extends WizardChild, ConfirmConfigProps {}
 

--- a/frontend/workflows/kinesis/src/index.tsx
+++ b/frontend/workflows/kinesis/src/index.tsx
@@ -7,7 +7,11 @@ interface ConfigurationProps {
   resolverType: string;
 }
 
-export interface WorkflowProps extends BaseWorkflowProps, ConfigurationProps {}
+interface WizardFeedbackProps {
+  enableFeedback?: boolean;
+}
+
+export interface WorkflowProps extends BaseWorkflowProps, ConfigurationProps, WizardFeedbackProps {}
 export interface ResolverChild extends WizardChild, ConfigurationProps {}
 
 const register = (): WorkflowConfiguration => {


### PR DESCRIPTION
### Description
PR adds a new interface to workflows' configuration so that users can choose to enable the Wizard feedback placement via the `clutch.config.js`. Reasons for not globally enabling the feedback placement is that feedback placement requires a backend setup and users may not want to opt-in their workflow for feedback.

### Testing Performed
locally

example of prop being adding in the `clutch.config.js`

```
  "@clutch-sh/kinesis": {
    updateShardCount: {
      componentProps: {
        resolverType: "clutch.aws.kinesis.v1.Stream",
        enableFeedback: true,
      },
    },
  },
  "@clutch-sh/dynamodb": {
    updateCapacity: {
      componentProps: {
        resolverType: "clutch.aws.dynamodb.v1.Table",
        enableOverride: true,
        enableFeedback: true,
      },
    },
  },
```

I commented out all the other components to just show the workflow's last step.
<img width="842" alt="Screen Shot 2021-12-01 at 9 39 14 AM" src="https://user-images.githubusercontent.com/39421794/144254377-94f5202e-c952-43ef-a2bd-d9c9abb2e01e.png">


### GitHub Issue
https://github.com/lyft/clutch/issues/1797