### PR TITLE
k8s: implement backend api's for node

### DIFF
--- a/backend/mock/service/k8smock/k8smock.go
+++ b/backend/mock/service/k8smock/k8smock.go
@@ -339,6 +339,18 @@ func (s *svc) ListEvents(_ context.Context, clientset, cluster, namespace, name 
 	}, nil
 }
 
+func (s *svc) DescribeNode(_ context.Context, clientset, cluster, name string) (*k8sv1.Node, error) {
+	return &k8sv1.Node{
+		Cluster:       "fake-cluster-name",
+		Name:          name,
+		Unschedulable: false,
+	}, nil
+}
+
+func (s *svc) UpdateNode(_ context.Context, clientset, cluster, name string, unschedulable bool) error {
+	return nil
+}
+
 func (*svc) Clientsets(ctx context.Context) ([]string, error) {
 	return []string{"fake-user@fake-cluster"}, nil
 }

--- a/backend/module/k8s/node.go
+++ b/backend/module/k8s/node.go
@@ -2,15 +2,22 @@ package k8s
 
 import (
 	"context"
-	"errors"
 
 	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
 )
 
 func (a *k8sAPI) DescribeNode(ctx context.Context, req *k8sapiv1.DescribeNodeRequest) (*k8sapiv1.DescribeNodeResponse, error) {
-	return nil, errors.New("not implemented")
+	node, err := a.k8s.DescribeNode(ctx, req.Clientset, req.Cluster, req.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &k8sapiv1.DescribeNodeResponse{Node: node}, nil
 }
 
 func (a *k8sAPI) UpdateNode(ctx context.Context, req *k8sapiv1.UpdateNodeRequest) (*k8sapiv1.UpdateNodeResponse, error) {
-	return nil, errors.New("not implemented")
+	err := a.k8s.UpdateNode(ctx, req.Clientset, req.Cluster, req.Name, req.Unschedulable)
+	if err != nil {
+		return nil, err
+	}
+	return &k8sapiv1.UpdateNodeResponse{}, nil
 }

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -101,6 +101,10 @@ type Service interface {
 
 	// Event management functions.
 	ListEvents(ctx context.Context, clientset, cluster, namespace, object string, kind k8sapiv1.ObjectKind) ([]*k8sapiv1.Event, error)
+
+	// Node management functions.
+	DescribeNode(ctx context.Context, clientset, cluster, name string) (*k8sapiv1.Node, error)
+	UpdateNode(ctx context.Context, clientset, cluster, name string, unschedulable bool) error
 }
 
 type svc struct {

--- a/backend/service/k8s/node.go
+++ b/backend/service/k8s/node.go
@@ -1,0 +1,70 @@
+package k8s
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
+)
+
+func (s *svc) DescribeNode(ctx context.Context, clientset, cluster, name string) (*k8sapiv1.Node, error) {
+	// Node is a cluster level object, so namespace should be ""
+	cs, err := s.manager.GetK8sClientset(ctx, clientset, cluster, metav1.NamespaceAll)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + name,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nodes.Items) == 1 {
+		return ProtoForNode(cs.Cluster(), &nodes.Items[0]), nil
+	} else if len(nodes.Items) > 1 {
+		return nil, status.Error(codes.FailedPrecondition, "located multiple nodes")
+	}
+	return nil, status.Error(codes.NotFound, "unable to locate node")
+}
+
+func ProtoForNode(cluster string, k8snode *corev1.Node) *k8sapiv1.Node {
+	clusterName := k8snode.ClusterName
+	if clusterName == "" {
+		clusterName = cluster
+	}
+	return &k8sapiv1.Node{
+		Cluster:       clusterName,
+		Name:          k8snode.Name,
+		Unschedulable: k8snode.Spec.Unschedulable,
+	}
+}
+
+func (s *svc) UpdateNode(ctx context.Context, clientset, cluster, name string, unschedulable bool) error {
+	// Node is a cluster level object, so namespace should be ""
+	cs, err := s.manager.GetK8sClientset(ctx, clientset, cluster, metav1.NamespaceAll)
+	if err != nil {
+		return err
+	}
+
+	node, err := cs.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if node.Spec.Unschedulable == unschedulable {
+		// node schedulabliliy is already in desired state
+		return nil
+	}
+
+	node.Spec.Unschedulable = unschedulable
+
+	_, err = cs.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	return err
+}

--- a/backend/service/k8s/node_test.go
+++ b/backend/service/k8s/node_test.go
@@ -1,0 +1,121 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func testNodeClientset() *fake.Clientset {
+	nodes := &corev1.NodeList{
+		Items: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: false,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "already-cordoned-node",
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: true,
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset([]runtime.Object{nodes}...)
+	return fakeClient
+}
+
+func testListNodesClientSet() *fake.Clientset {
+	nodes := &corev1.NodeList{
+		Items: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: false,
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset([]runtime.Object{nodes}...)
+	fakeClient.AddReactor("list", "nodes",
+		func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nodes, nil
+		})
+	return fakeClient
+}
+
+func TestDescribeNode(t *testing.T) {
+	s := &svc{
+		manager: &managerImpl{
+			clientsets: map[string]*ctxClientsetImpl{
+				"test": {
+					Interface: testListNodesClientSet(),
+					namespace: metav1.NamespaceAll,
+					cluster:   "boba9000",
+				},
+				"test-with-duplicates": {
+					Interface: testNodeClientset(),
+					namespace: metav1.NamespaceAll,
+					cluster:   "boba9000",
+				},
+			},
+		},
+	}
+
+	// Found 1 node
+	node, err := s.DescribeNode(context.Background(), "test", "boba9000", "test-node")
+	assert.NoError(t, err)
+	assert.Equal(t, "test-node", node.Name)
+	assert.False(t, node.Unschedulable)
+
+	// Found >1 node
+	node, err = s.DescribeNode(context.Background(), "test-with-duplicates", "boba9000", "test-node")
+	assert.Error(t, err)
+	assert.Nil(t, node)
+
+	// Node not found
+	node, err = s.DescribeNode(context.Background(), "", "boba9000", "")
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}
+
+func TestCordonNode(t *testing.T) {
+	cs := testNodeClientset()
+	s := &svc{
+		manager: &managerImpl{
+			clientsets: map[string]*ctxClientsetImpl{"test": {
+				Interface: cs,
+				namespace: metav1.NamespaceAll,
+				cluster:   "boba9000",
+			}},
+		},
+	}
+
+	err := s.UpdateNode(context.Background(), "test", "boba9000", "test-node", true)
+	assert.NoError(t, err)
+
+	node, _ := cs.CoreV1().Nodes().Get(context.Background(), "test-node", metav1.GetOptions{})
+	assert.Equal(t, true, node.Spec.Unschedulable)
+
+	err = s.UpdateNode(context.Background(), "test", "boba9000", "already-cordoned-node", true)
+	assert.NoError(t, err)
+
+	node, _ = cs.CoreV1().Nodes().Get(context.Background(), "already-cordoned-node", metav1.GetOptions{})
+	assert.Equal(t, true, node.Spec.Unschedulable)
+}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

Follow up to https://github.com/lyft/clutch/pull/1906

Implement api's for DescribeNode & UpdateNode. Currently supports updating NodeSpec.Unschedulable field only (cordon node).

Updating schedulablity on a node that is already in the desired schedulabiltiy state (i.e. cordoning a node that is already cordoned) should succeed as this is the desired result for the end user.

### Testing Performed
Tested via curl against a remote kube cluster:

DescribeNode:

```
$ curl --location --request POST 'http://localhost:8080/v1/k8s/describeNode' \
--header 'Content-Type: application/json' \
--data-raw '{
    "clientset": "testcontext",
    "cluster": "test",
    "name": "test-node-name"
}'
{"node":{"name":"test-node-name","cluster":"test","unschedulable":false}}%
```

UpdateNode:

```
$ curl --location --request POST 'http://localhost:8080/v1/k8s/updateNode' \
--header 'Content-Type: application/json' \
--data-raw '{
    "clientset": "test-context",
    "cluster": "test",
    "name": "test-node-name",
    "unschedulable": true
}'
{}%

# this correctly updates the node status to SchedulingDisabled (cordoned)

$ kubectl get node test-node-name
NAME                          STATUS                     ROLES    AGE   VERSION
test-node-name  Ready,SchedulingDisabled   <none>   51d   v1.21.1
```
