### PR TITLE
frontend: Adjust spacing for welcome image

### DIFF
--- a/frontend/packages/core/src/landing.tsx
+++ b/frontend/packages/core/src/landing.tsx
@@ -23,7 +23,7 @@ const StyledLanding = styled.div({
 
   "& .welcome svg": {
     flex: "0 0 auto",
-    marginRight: "24px",
+    margin: "auto 24px auto 0",
   },
 
   "& .welcome .welcomeText": {


### PR DESCRIPTION
### Description
SVG for welcome monster wasn't aligned with the text, so this adjusts that.

#### Before
![WelcomeImg margin-before](https://user-images.githubusercontent.com/8338893/148133715-de0532a6-c39d-4eb3-aa5f-6f091d7b6a22.png)

#### After
![WelcomeImg margin-after](https://user-images.githubusercontent.com/8338893/148133723-4ff94066-0f18-45f5-8766-58972c7cdc26.png)

### Testing Performed
Manual
