### PR TITLE
frontend: extending select to add grouping option

### DIFF
--- a/frontend/packages/core/src/Input/index.tsx
+++ b/frontend/packages/core/src/Input/index.tsx
@@ -5,3 +5,4 @@ export { default as RadioGroup } from "./radio-group";
 export { default as Select } from "./select";
 export { default as Switch } from "./switchToggle";
 export { default as TextField } from "./text-field";
+export type { SelectOption } from "./select";

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -179,6 +179,8 @@ const StyledSelect = styled(BaseSelect)({
 
   ".MuiListSubheader-root": {
     color: "#939495",
+    cursor: "default",
+    "pointer-events": "none", // disables the select from closing on clicking the subheader
   },
 });
 

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -11,6 +11,7 @@ import {
 } from "@material-ui/core";
 import ErrorIcon from "@material-ui/icons/Error";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { flatten } from "lodash";
 
 const StyledFormControl = styled(MuiFormControl)({
   "label + .MuiInput-formControl": {
@@ -214,9 +215,11 @@ const Select = ({
   const [selectedIdx, setSelectedIdx] = React.useState(defaultIdx);
 
   // Flattens all options and sub grouped options for easier retrieval
-  const flatOptions: SelectOption[] = options
-    .map(option => (option.group ? option.group.map(groupOption => groupOption) : option))
-    .reduce((pre: any, cur: any) => pre.concat(cur), []);
+  const flatOptions: BaseSelectOptions[] = flatten(
+    options.map((option: SelectOption) =>
+      option.group ? option.group.map(groupOption => groupOption) : option
+    )
+  );
 
   React.useEffect(() => {
     if (flatOptions.length !== 0) {
@@ -234,7 +237,7 @@ const Select = ({
     onChange && onChange(value);
   };
 
-  if (options.length === 0) {
+  if (flatOptions.length === 0) {
     return null;
   }
 

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -5,6 +5,7 @@ import {
   FormControl as MuiFormControl,
   FormHelperText as MuiFormHelperText,
   InputLabel as MuiInputLabel,
+  ListSubheader,
   MenuItem,
   Select as MuiSelect,
 } from "@material-ui/core";
@@ -174,12 +175,20 @@ const StyledSelect = styled(BaseSelect)({
   ".MuiSelect-select:focus": {
     backgroundColor: "inherit",
   },
+
+  ".MuiListSubheader-root": {
+    color: "#939495",
+  },
 });
 
-interface SelectOption {
+interface BaseSelectOptions {
   label: string;
   value?: string;
   startAdornment?: React.ReactElement;
+}
+
+export interface SelectOption extends BaseSelectOptions {
+  group?: BaseSelectOptions[];
 }
 
 export interface SelectProps extends Pick<MuiSelectProps, "disabled" | "error"> {
@@ -204,16 +213,24 @@ const Select = ({
   const defaultIdx = defaultOption < options.length && defaultOption > 0 ? defaultOption : 0;
   const [selectedIdx, setSelectedIdx] = React.useState(defaultIdx);
 
+  // Flattens all options and sub grouped options for easier retrieval
+  const flatOptions: SelectOption[] = options
+    .map(option => (option.group ? option.group.map(groupOption => groupOption) : option))
+    .reduce((pre: any, cur: any) => pre.concat(cur), []);
+
   React.useEffect(() => {
-    if (options.length !== 0) {
-      onChange && onChange(options[selectedIdx]?.value || options[selectedIdx].label);
+    if (flatOptions.length !== 0) {
+      onChange && onChange(flatOptions[selectedIdx]?.value || flatOptions[selectedIdx].label);
     }
   }, []);
 
   const updateSelectedOption = (event: React.ChangeEvent<{ name?: string; value: string }>) => {
     const { value } = event.target;
-    const optionValues = options.map(o => o?.value || o.label);
-    setSelectedIdx(optionValues.indexOf(value));
+    // handle if selecting a header option
+    if (!value) {
+      return;
+    }
+    setSelectedIdx(flatOptions.findIndex(opt => opt?.value === value || opt?.label === value));
     onChange && onChange(value);
   };
 
@@ -221,24 +238,38 @@ const Select = ({
     return null;
   }
 
+  const menuItem = option => (
+    <MenuItem key={option.label} value={option?.value || option.label}>
+      {option?.startAdornment &&
+        React.cloneElement(option.startAdornment, {
+          style: { height: "100%", marginRight: "8px", ...option.startAdornment.props.style },
+        })}
+      {option.label}
+    </MenuItem>
+  );
+
+  const renderSelectItems = option => {
+    if (option.group) {
+      return [
+        <ListSubheader>{option.label}</ListSubheader>,
+        option.group.map(opt => menuItem(opt)),
+      ];
+    }
+    return menuItem(option);
+  };
+
   return (
     <StyledFormControl id={name} key={name} fullWidth disabled={disabled} error={error}>
       {label && <StyledInputLabel>{label}</StyledInputLabel>}
-      <StyledSelect
-        id={`${name}-select`}
-        value={options[selectedIdx]?.value || options[selectedIdx].label}
-        onChange={updateSelectedOption}
-      >
-        {options.map(option => (
-          <MenuItem key={option.label} value={option?.value || option.label}>
-            {option?.startAdornment &&
-              React.cloneElement(option.startAdornment, {
-                style: { height: "100%", marginRight: "8px", ...option.startAdornment.props.style },
-              })}
-            {option.label}
-          </MenuItem>
-        ))}
-      </StyledSelect>
+      {flatOptions.length && (
+        <StyledSelect
+          id={`${name}-select`}
+          value={flatOptions[selectedIdx]?.value || flatOptions[selectedIdx].label}
+          onChange={updateSelectedOption}
+        >
+          {options?.map(option => renderSelectItems(option))}
+        </StyledSelect>
+      )}
       {helperText && (
         <StyledFormHelperText>
           {error && <ErrorIcon />}

--- a/frontend/packages/core/src/Input/stories/select.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/select.stories.tsx
@@ -72,3 +72,38 @@ WithStartAdornment.args = {
     },
   ],
 };
+
+export const WithGrouping = Template.bind({});
+WithGrouping.args = {
+  ...Primary.args,
+  options: [
+    {
+      label: "Option 1",
+    },
+    {
+      label: "Group 1",
+      group: [
+        {
+          label: "Sub Option 1",
+        },
+        {
+          label: "Sub Option 2",
+        },
+      ],
+    },
+    {
+      label: "Group 2",
+      group: [
+        {
+          label: "Sub Option 3",
+        },
+        {
+          label: "Sub Option 4",
+        },
+      ],
+    },
+    {
+      label: "Option 2",
+    },
+  ],
+};


### PR DESCRIPTION
### Description
For anytime NPS component, needed to extend the select component to more clearly separate workflows. Added a grouping option.

#### Without Grouping (Storybook)
![Screen Shot 2022-01-19 at 11 59 57 AM](https://user-images.githubusercontent.com/8338893/150205154-c46f6912-4434-474f-b8ad-d641f2cd9628.png)


#### With Grouping (Storybook)
![Screen Shot 2022-01-19 at 11 59 52 AM](https://user-images.githubusercontent.com/8338893/150205174-2910e862-83f1-4fed-b8fc-4326c8c2d08a.png)


#### In Action (NPS Header)
![Screen Shot 2022-01-19 at 11 50 17 AM](https://user-images.githubusercontent.com/8338893/150205204-197ce8af-4c4e-4573-a026-3c3e086db50e.png)


### Testing Performed
Manual