### PR TITLE
dynamodb: fix scaling limits

### DIFF
--- a/backend/service/aws/dynamodb.go
+++ b/backend/service/aws/dynamodb.go
@@ -180,10 +180,12 @@ func isValidIncrease(client *regionalClient, current *types.ProvisionedThroughpu
 	// override not enabled in config or override not set to true in args
 	if !client.dynamodbCfg.ScalingLimits.EnableOverride || !ignore_maximums {
 		// check for targets that exceed max limits
-		if *target.ReadCapacityUnits > client.dynamodbCfg.ScalingLimits.MaxReadCapacityUnits {
+		if *target.ReadCapacityUnits > client.dynamodbCfg.ScalingLimits.MaxReadCapacityUnits &&
+			*current.ReadCapacityUnits < client.dynamodbCfg.ScalingLimits.MaxReadCapacityUnits { // don't apply this check to tables with RCU already above max
 			return status.Errorf(codes.FailedPrecondition, "Target read capacity exceeds maximum allowed limits [%d]", client.dynamodbCfg.ScalingLimits.MaxReadCapacityUnits)
 		}
-		if *target.WriteCapacityUnits > client.dynamodbCfg.ScalingLimits.MaxWriteCapacityUnits {
+		if *target.WriteCapacityUnits > client.dynamodbCfg.ScalingLimits.MaxWriteCapacityUnits &&
+			*current.WriteCapacityUnits < client.dynamodbCfg.ScalingLimits.MaxWriteCapacityUnits { // don't apply this check to tables with WCU already above max
 			return status.Errorf(codes.FailedPrecondition, "Target write capacity exceeds maximum allowed limits [%d]", client.dynamodbCfg.ScalingLimits.MaxWriteCapacityUnits)
 		}
 

--- a/backend/service/aws/dynamodb_test.go
+++ b/backend/service/aws/dynamodb_test.go
@@ -456,7 +456,6 @@ func TestMaxTableUpdates(t *testing.T) {
 	for _, tt := range successTests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-
 			targetTableCapacity := &dynamodbv1.Throughput{
 				ReadCapacityUnits:  tt.targetRCU,
 				WriteCapacityUnits: tt.targetWCU,

--- a/backend/service/aws/dynamodb_test.go
+++ b/backend/service/aws/dynamodb_test.go
@@ -50,6 +50,50 @@ var testTableOutput = &dynamodbv1.Table{
 	BillingMode:            dynamodbv1.Table_BillingMode(2),
 }
 
+var testMaxDynamodbTable = &types.TableDescription{
+	TableName: aws.String("test-max-table"),
+	ProvisionedThroughput: &types.ProvisionedThroughputDescription{
+		ReadCapacityUnits:  aws.Int64(45000),
+		WriteCapacityUnits: aws.Int64(45000),
+	},
+	GlobalSecondaryIndexes: []types.GlobalSecondaryIndexDescription{
+		{IndexName: aws.String("test-gsi"),
+			KeySchema: []types.KeySchemaElement{},
+			ProvisionedThroughput: &types.ProvisionedThroughputDescription{
+				ReadCapacityUnits:  aws.Int64(45000),
+				WriteCapacityUnits: aws.Int64(45000),
+			},
+			IndexStatus: "ACTIVE",
+		},
+	},
+	TableStatus: "ACTIVE",
+	BillingModeSummary: &types.BillingModeSummary{
+		BillingMode: "PROVISIONED",
+	},
+}
+
+var testMaxDynamodbTableResponse = &types.TableDescription{
+	TableName: aws.String("test-max-table"),
+	ProvisionedThroughput: &types.ProvisionedThroughputDescription{
+		ReadCapacityUnits:  aws.Int64(45000),
+		WriteCapacityUnits: aws.Int64(45000),
+	},
+	GlobalSecondaryIndexes: []types.GlobalSecondaryIndexDescription{
+		{IndexName: aws.String("test-gsi"),
+			KeySchema: []types.KeySchemaElement{},
+			ProvisionedThroughput: &types.ProvisionedThroughputDescription{
+				ReadCapacityUnits:  aws.Int64(45000),
+				WriteCapacityUnits: aws.Int64(45000),
+			},
+			IndexStatus: "UPDATING",
+		},
+	},
+	TableStatus: "UPDATING",
+	BillingModeSummary: &types.BillingModeSummary{
+		BillingMode: "PROVISIONED",
+	},
+}
+
 var testDynamodbTableWithGSI = &types.TableDescription{
 	TableName: aws.String("test-gsi-table"),
 	ProvisionedThroughput: &types.ProvisionedThroughputDescription{
@@ -332,6 +376,108 @@ func TestIncreaseTableCapacityErrors(t *testing.T) {
 				t.Errorf("\nWant error msg: %s\nGot error msg: %s", tt.want, err)
 			}
 			assert.Nil(t, result)
+		})
+	}
+}
+
+// Case: table already above the maximum
+// These tests confirm the correct error messages are displayed if
+// attempting to provision capacities above the set scale factor (default 2x).
+// Capacity increases for tables already above the max limit
+// (but within the scale factor limit) should pass.
+func TestMaxTableUpdates(t *testing.T) {
+	errorTests := []struct {
+		name      string
+		targetRCU int64
+		targetWCU int64
+		want      string
+	}{
+		{"target table rcu lower than current", 44000, 45000, "rpc error: code = FailedPrecondition desc = Target read capacity [44000] is lower than current capacity [45000]"},
+		{"target table wcu lower than current", 45000, 44000, "rpc error: code = FailedPrecondition desc = Target write capacity [44000] is lower than current capacity [45000]"},
+		{"table rcu change scale too high", 200000, 45000, "rpc error: code = FailedPrecondition desc = Target read capacity exceeds the scale limit of [2.0]x current capacity"},
+		{"table wcu change scale too high", 45000, 200000, "rpc error: code = FailedPrecondition desc = Target write capacity exceeds the scale limit of [2.0]x current capacity"},
+	}
+
+	successTests := []struct {
+		name      string
+		targetRCU int64
+		targetWCU int64
+		status    int64
+	}{
+		{"target table rcu above limit", 46000, 45000, 3},
+		{"target table wcu above limit", 45000, 46000, 3},
+	}
+
+	m := &mockDynamodb{
+		table:  testMaxDynamodbTable,
+		update: testMaxDynamodbTableResponse,
+	}
+
+	ds := getScalingLimits(cfg)
+
+	d := &awsv1.DynamodbConfig{
+		ScalingLimits: &awsv1.ScalingLimits{
+			MaxReadCapacityUnits:  ds.MaxReadCapacityUnits,
+			MaxWriteCapacityUnits: ds.MaxWriteCapacityUnits,
+			MaxScaleFactor:        ds.MaxScaleFactor,
+			EnableOverride:        ds.EnableOverride,
+		},
+	}
+
+	c := &client{
+		currentAccountAlias: "default",
+		accounts: map[string]*accountClients{
+			"default": {
+				clients: map[string]*regionalClient{
+					"us-east-1": {region: "us-east-1", dynamodbCfg: d, dynamodb: m},
+				},
+			},
+		},
+	}
+
+	emptyIndexUpdates := make([]*dynamodbv1.IndexUpdateAction, 0)
+
+	for _, tt := range errorTests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			targetTableCapacity := &dynamodbv1.Throughput{
+				ReadCapacityUnits:  tt.targetRCU,
+				WriteCapacityUnits: tt.targetWCU,
+			}
+
+			result, err := c.UpdateCapacity(context.Background(), "default", "us-east-1", "test-max-table", targetTableCapacity, emptyIndexUpdates, false)
+			if err.Error() != tt.want {
+				t.Errorf("\nWant error msg: %s\nGot error msg: %s", tt.want, err)
+			}
+			assert.Nil(t, result)
+		})
+	}
+
+	for _, tt := range successTests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+
+			targetTableCapacity := &dynamodbv1.Throughput{
+				ReadCapacityUnits:  tt.targetRCU,
+				WriteCapacityUnits: tt.targetWCU,
+			}
+
+			targetIndexCapacity := &dynamodbv1.Throughput{
+				ReadCapacityUnits:  45000,
+				WriteCapacityUnits: 45000,
+			}
+
+			gsiUpdates := make([]*dynamodbv1.IndexUpdateAction, 0)
+			update := dynamodbv1.IndexUpdateAction{
+				Name:            "test-gsi",
+				IndexThroughput: targetIndexCapacity,
+			}
+			gsiUpdates = append(gsiUpdates, &update)
+
+			result, err := c.UpdateCapacity(context.Background(), "default", "us-east-1", "test-max-table", targetTableCapacity, gsiUpdates, false)
+			assert.Nil(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, result.Status, dynamodbv1.Table_Status(tt.status))
 		})
 	}
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
This PR fixes unintended behavior in the DynamoDB service's logic for enforcing AWS capacity provisioning limits. When scaling up a table that is already provisioned above the max capacity (40000 by default), requests are always erroneously blocked because the requested capacity exceeds the limit.

The fix is to ignore that max limit for tables that are already provisioned above the maximum, and only enforce the scale-factor limit instead (200% of current capacity by default) unless the ignore flag is passed.

### Testing Performed
<!-- Describe how you tested this change below. -->
Unit tests 