### PR TITLE
dash: removing usage of local storage temporarily

### DIFF
--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -12,7 +12,7 @@ import { useDashUpdater } from "./dash-hooks";
 import { deriveStateData, DispatchContext, StateContext } from "./helpers";
 import ProjectGroup from "./project-group";
 import selectorReducer from "./selector-reducer";
-import { loadStoredState, storeState } from "./storage";
+import { storeState } from "./storage";
 import type { Action, DashState, State } from "./types";
 import { Group } from "./types";
 
@@ -93,7 +93,12 @@ const hydrateProjects = (state: State, dispatch: React.Dispatch<Action>) => {
       projects: string[];
     };
 
-    requestParams.projects = Object.keys(state[Group.PROJECTS]);
+    _.forEach(Object.keys(state[Group.PROJECTS]), p => {
+      // if the project is custom
+      if (state[Group.PROJECTS][p].custom) {
+        requestParams.projects.push(p);
+      }
+    });
 
     client
       .post("/v1/project/getProjects", requestParams as IClutch.project.v1.GetProjectsRequest)

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -92,12 +92,8 @@ const hydrateProjects = (state: State, dispatch: React.Dispatch<Action>) => {
       users: string[];
       projects: string[];
     };
-    _.forEach(Object.keys(state[Group.PROJECTS]), p => {
-      // if the project is custom
-      if (state[Group.PROJECTS][p].custom) {
-        requestParams.projects.push(p);
-      }
-    });
+
+    requestParams.projects = Object.keys(state[Group.PROJECTS]);
 
     client
       .post("/v1/project/getProjects", requestParams as IClutch.project.v1.GetProjectsRequest)
@@ -118,7 +114,8 @@ const ProjectSelector = () => {
 
   const [customProject, setCustomProject] = React.useState("");
   const { updateSelected } = useDashUpdater();
-  const [state, dispatch] = React.useReducer(selectorReducer, loadStoredState(initialState));
+  // TODO: restore usage of loadStoredState once we fix the issue with deprecated projects
+  const [state, dispatch] = React.useReducer(selectorReducer, initialState);
 
   React.useEffect(() => {
     const interval = setInterval(() => hydrateProjects(state, dispatch), 30000);


### PR DESCRIPTION
### Description
Issue with deprecated projects is causing alarms with attempting to load from the stored state. To get around this we are temporarily bypassing the loading of the stored state and instead will just start fresh.

### Testing Performed
Manual