### PR TITLE
frontend: Remove feature flag setup from NPS wizard placement

### DIFF
--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -49,7 +49,6 @@ module.exports = {
     deletePod: {
       componentProps: {
         resolverType: "clutch.k8s.v1.Pod",
-        enableFeedback: true,
       },
     },
     resizeHPA: {

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -2,9 +2,7 @@ import React from "react";
 import {
   Button,
   ButtonGroup,
-  FeatureOn,
   NPSWizard,
-  SimpleFeatureFlag,
   Step,
   Stepper,
   styled,
@@ -151,13 +149,7 @@ const Wizard = ({
         <Grid container justify="center">
           {((state.activeStep === lastStepIndex && !isLoading) || hasError) && (
             <>
-              {enableFeedback && (
-                <SimpleFeatureFlag feature="npsWizard">
-                  <FeatureOn>
-                    <NPSWizard />
-                  </FeatureOn>
-                </SimpleFeatureFlag>
-              )}
+              {enableFeedback && <NPSWizard />}
               {(isMultistep || hasError) && (
                 <ButtonGroup>
                   <Button


### PR DESCRIPTION
### Description
We've fully launched the feature internally and monitored it for a few weeks to make sure it's feature ready, so PR removes the feature flag setup in the Wizard.

### Testing Performed
manually