### PR TITLE
feedback: globally enable NPS wizard

### DIFF
--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -49,7 +49,6 @@ module.exports = {
     deletePod: {
       componentProps: {
         resolverType: "clutch.k8s.v1.Pod",
-        enableFeedback: true,
       },
     },
     resizeHPA: {

--- a/frontend/packages/core/src/Contexts/tests/testContext.tsx
+++ b/frontend/packages/core/src/Contexts/tests/testContext.tsx
@@ -85,7 +85,6 @@ const contextValues: { workflows: any[] } = {
           requiredConfigProps: ["resolverType"],
           componentProps: {
             resolverType: "clutch.k8s.v1.Pod",
-            enableFeedback: true,
           },
         },
         {

--- a/frontend/packages/wizard/src/index.tsx
+++ b/frontend/packages/wizard/src/index.tsx
@@ -1,5 +1,5 @@
 import WizardStep from "./step";
 import Wizard from "./wizard";
 
-export type { WizardChild, WizardConfigProps } from "./wizard";
+export type { WizardChild } from "./wizard";
 export { Wizard, WizardStep };

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -136,28 +136,26 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
           </WizardContext.Provider>
         </DataLayoutContext.Provider>
         <Grid container justify="center">
-          {((state.activeStep === lastStepIndex && !isLoading) || hasError) && (
+          {((state.activeStep === lastStepIndex && !isLoading && isMultistep) || hasError) && (
             <>
               <SimpleFeatureFlag feature="npsWizard">
                 <FeatureOn>
                   <NPSWizard />
                 </FeatureOn>
               </SimpleFeatureFlag>
-              {(isMultistep || hasError) && (
-                <ButtonGroup>
-                  <Button
-                    text="Start Over"
-                    onClick={() => {
-                      dataLayoutManager.reset();
-                      setSearchParams({});
-                      dispatch(WizardAction.RESET);
-                      if (origin) {
-                        navigate(origin);
-                      }
-                    }}
-                  />
-                </ButtonGroup>
-              )}
+              <ButtonGroup>
+                <Button
+                  text="Start Over"
+                  onClick={() => {
+                    dataLayoutManager.reset();
+                    setSearchParams({});
+                    dispatch(WizardAction.RESET);
+                    if (origin) {
+                      navigate(origin);
+                    }
+                  }}
+                />
+              </ButtonGroup>
             </>
           )}
         </Grid>

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -136,26 +136,28 @@ const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProp
           </WizardContext.Provider>
         </DataLayoutContext.Provider>
         <Grid container justify="center">
-          {((state.activeStep === lastStepIndex && !isLoading && isMultistep) || hasError) && (
+          {((state.activeStep === lastStepIndex && !isLoading) || hasError) && (
             <>
               <SimpleFeatureFlag feature="npsWizard">
                 <FeatureOn>
                   <NPSWizard />
                 </FeatureOn>
               </SimpleFeatureFlag>
-              <ButtonGroup>
-                <Button
-                  text="Start Over"
-                  onClick={() => {
-                    dataLayoutManager.reset();
-                    setSearchParams({});
-                    dispatch(WizardAction.RESET);
-                    if (origin) {
-                      navigate(origin);
-                    }
-                  }}
-                />
-              </ButtonGroup>
+              {(isMultistep || hasError) && (
+                <ButtonGroup>
+                  <Button
+                    text="Start Over"
+                    onClick={() => {
+                      dataLayoutManager.reset();
+                      setSearchParams({});
+                      dispatch(WizardAction.RESET);
+                      if (origin) {
+                        navigate(origin);
+                      }
+                    }}
+                  />
+                </ButtonGroup>
+              )}
             </>
           )}
         </Grid>

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -30,14 +30,7 @@ const Heading = styled(Typography)({
 interface WizardProps extends Pick<ContainerProps, "width"> {
   children: React.ReactElement<WizardStepProps> | React.ReactElement<WizardStepProps>[];
   dataLayout: ManagerLayout;
-  enableFeedback?: boolean;
   heading?: string;
-}
-
-// To be used in a workflow's configuration file
-export interface WizardConfigProps {
-  // If true and if the WizardStep is used, a feedback component will be added to a workflow's last step.
-  enableFeedback?: boolean;
 }
 
 export interface WizardChild {
@@ -71,13 +64,7 @@ const Paper = styled(MuiPaper)({
   padding: "32px",
 });
 
-const Wizard = ({
-  heading,
-  width = "default",
-  dataLayout,
-  children,
-  enableFeedback,
-}: WizardProps) => {
+const Wizard = ({ heading, width = "default", dataLayout, children }: WizardProps) => {
   const [state, dispatch] = useWizardState();
   const [wizardStepData, setWizardStepData] = React.useState<WizardStepData>({});
   const [globalWarnings, setGlobalWarnings] = React.useState<string[]>([]);
@@ -151,13 +138,11 @@ const Wizard = ({
         <Grid container justify="center">
           {((state.activeStep === lastStepIndex && !isLoading) || hasError) && (
             <>
-              {enableFeedback && (
-                <SimpleFeatureFlag feature="npsWizard">
-                  <FeatureOn>
-                    <NPSWizard />
-                  </FeatureOn>
-                </SimpleFeatureFlag>
-              )}
+              <SimpleFeatureFlag feature="npsWizard">
+                <FeatureOn>
+                  <NPSWizard />
+                </FeatureOn>
+              </SimpleFeatureFlag>
               {(isMultistep || hasError) && (
                 <ButtonGroup>
                   <Button

--- a/frontend/workflows/dynamodb/src/index.tsx
+++ b/frontend/workflows/dynamodb/src/index.tsx
@@ -1,5 +1,5 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
-import type { WizardChild, WizardConfigProps } from "@clutch-sh/wizard";
+import type { WizardChild } from "@clutch-sh/wizard";
 
 import UpdateCapacity from "./update-capacity";
 
@@ -11,11 +11,7 @@ interface TableDetailsProps {
   enableOverride?: boolean;
 }
 
-export interface WorkflowProps
-  extends BaseWorkflowProps,
-    ResolverConfigProps,
-    TableDetailsProps,
-    WizardConfigProps {}
+export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, TableDetailsProps {}
 export interface ResolverChild extends WizardChild, ResolverConfigProps {}
 export interface TableDetailsChild extends WizardChild, TableDetailsProps {}
 

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -201,12 +201,7 @@ const Confirm: React.FC<WizardChild> = () => {
   );
 };
 
-const UpdateCapacity: React.FC<WorkflowProps> = ({
-  resolverType,
-  enableOverride,
-  heading,
-  enableFeedback,
-}) => {
+const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, enableOverride, heading }) => {
   const dataLayout = {
     resourceData: {},
     capacityUpdates: {},
@@ -254,7 +249,7 @@ const UpdateCapacity: React.FC<WorkflowProps> = ({
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <TableIdentifier name="Lookup" resolverType={resolverType} />
       <TableDetails name="Modify" enableOverride={enableOverride} />
       <Confirm name="Results" />

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -1,5 +1,5 @@
 import type { BaseWorkflowProps, NoteConfig, WorkflowConfiguration } from "@clutch-sh/core";
-import type { WizardChild, WizardConfigProps } from "@clutch-sh/wizard";
+import type { WizardChild } from "@clutch-sh/wizard";
 
 import RebootInstance from "./reboot-instance";
 import ResizeAutoscalingGroup from "./resize-asg";
@@ -13,11 +13,7 @@ interface ConfirmConfigProps {
   notes?: NoteConfig[];
 }
 
-export interface WorkflowProps
-  extends BaseWorkflowProps,
-    ResolverConfigProps,
-    ConfirmConfigProps,
-    WizardConfigProps {}
+export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps {}
 export interface ResolverChild extends WizardChild, ResolverConfigProps {}
 export interface ConfirmChild extends WizardChild, ConfirmConfigProps {}
 

--- a/frontend/workflows/ec2/src/reboot-instance.tsx
+++ b/frontend/workflows/ec2/src/reboot-instance.tsx
@@ -73,12 +73,7 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
-const RebootInstance: React.FC<WorkflowProps> = ({
-  heading,
-  resolverType,
-  notes = [],
-  enableFeedback,
-}) => {
+const RebootInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     resourceData: {},
     rebootData: {
@@ -94,7 +89,7 @@ const RebootInstance: React.FC<WorkflowProps> = ({
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Verify" />
       <Confirm name="Confirmation" notes={notes} />

--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -117,12 +117,7 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
-const ResizeAutoscalingGroup: React.FC<WorkflowProps> = ({
-  heading,
-  resolverType,
-  notes = [],
-  enableFeedback,
-}) => {
+const ResizeAutoscalingGroup: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     groupData: {},
     resizeData: {
@@ -139,7 +134,7 @@ const ResizeAutoscalingGroup: React.FC<WorkflowProps> = ({
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <GroupIdentifier name="Lookup" resolverType={resolverType} />
       <GroupDetails name="Modify" />
       <Confirm name="Confirmation" notes={notes} />

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -92,12 +92,7 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
-const TerminateInstance: React.FC<WorkflowProps> = ({
-  heading,
-  resolverType,
-  notes = [],
-  enableFeedback,
-}) => {
+const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     resourceData: {},
     terminationData: {
@@ -113,7 +108,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Verify" />
       <Confirm name="Confirmation" notes={notes} />

--- a/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Resize Autoscaling Group workflow renders correctly 1`] = `
-"<Wizard dataLayout={{...}} heading={[undefined]} enableFeedback={[undefined]}>
+"<Wizard dataLayout={{...}} heading={[undefined]}>
   <GroupIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.ec2.v1.AutoscalingGroup\\" />
   <GroupDetails name=\\"Modify\\" />
   <Confirm name=\\"Confirmation\\" notes={{...}} />

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Terminate Instance workflow renders correctly 1`] = `
-"<Wizard dataLayout={{...}} heading={[undefined]} enableFeedback={[undefined]}>
+"<Wizard dataLayout={{...}} heading={[undefined]}>
   <InstanceIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.ec2.v1.Instance\\" />
   <InstanceDetails name=\\"Verify\\" />
   <Confirm name=\\"Confirmation\\" notes={{...}} />

--- a/frontend/workflows/envoy/src/index.tsx
+++ b/frontend/workflows/envoy/src/index.tsx
@@ -1,9 +1,8 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
-import type { WizardConfigProps } from "@clutch-sh/wizard";
 
 import RemoteTriage from "./remote-triage";
 
-export interface WorkflowProps extends BaseWorkflowProps, WizardConfigProps {}
+export interface WorkflowProps extends BaseWorkflowProps {}
 
 const register = (): WorkflowConfiguration => {
   return {

--- a/frontend/workflows/envoy/src/remote-triage/index.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/index.tsx
@@ -121,7 +121,7 @@ const TriageDetails: React.FC<WizardChild> = () => {
   );
 };
 
-const RemoteTriage: React.FC<WorkflowProps> = ({ heading, enableFeedback }) => {
+const RemoteTriage: React.FC<WorkflowProps> = ({ heading }) => {
   const dataLayout = {
     resourceData: {},
     remoteData: {
@@ -144,7 +144,7 @@ const RemoteTriage: React.FC<WorkflowProps> = ({ heading, enableFeedback }) => {
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <TriageIdentifier name="Lookup" />
       <TriageDetails name="Details" />
     </Wizard>

--- a/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
+++ b/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Remote Triage workflow renders correctly 1`] = `
-"<Wizard dataLayout={{...}} heading={[undefined]} enableFeedback={[undefined]}>
+"<Wizard dataLayout={{...}} heading={[undefined]}>
   <TriageIdentifier name=\\"Lookup\\" />
   <TriageDetails name=\\"Details\\" />
 </Wizard>"

--- a/frontend/workflows/k8s/src/cordon-node.tsx
+++ b/frontend/workflows/k8s/src/cordon-node.tsx
@@ -87,7 +87,7 @@ const Confirm: React.FC<ConfirmChild> = () => {
   );
 };
 
-const CordonNode: React.FC<WorkflowProps> = ({ heading, resolverType, enableFeedback }) => {
+const CordonNode: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
   const dataLayout = {
     resolverInput: {},
     resourceData: {},
@@ -106,7 +106,7 @@ const CordonNode: React.FC<WorkflowProps> = ({ heading, resolverType, enableFeed
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <NodeIdentifier name="Lookup" resolverType={resolverType} />
       <NodeDetails name="Verify" />
       <Confirm name="Confirmation" />

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -91,7 +91,7 @@ const Confirm: React.FC<ConfirmChild> = () => {
   );
 };
 
-const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, enableFeedback }) => {
+const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
   const dataLayout = {
     resolverInput: {},
     resourceData: {},
@@ -110,7 +110,7 @@ const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, enableFeedb
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <PodIdentifier name="Lookup" resolverType={resolverType} />
       <PodDetails name="Verify" />
       <Confirm name="Confirmation" />

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -1,5 +1,5 @@
 import type { BaseWorkflowProps, NoteConfig, WorkflowConfiguration } from "@clutch-sh/core";
-import type { WizardChild, WizardConfigProps } from "@clutch-sh/wizard";
+import type { WizardChild } from "@clutch-sh/wizard";
 
 import CordonNode from "./cordon-node";
 import DeletePod from "./delete-pod";
@@ -14,11 +14,7 @@ interface ConfirmConfigProps {
   notes?: NoteConfig[];
 }
 
-export interface WorkflowProps
-  extends BaseWorkflowProps,
-    ResolverConfigProps,
-    ConfirmConfigProps,
-    WizardConfigProps {}
+export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps {}
 export interface ResolverChild extends WizardChild, ResolverConfigProps {}
 export interface ConfirmChild extends WizardChild, ConfirmConfigProps {}
 

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -144,12 +144,7 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
-const ResizeHPA: React.FC<WorkflowProps> = ({
-  heading,
-  resolverType,
-  notes = [],
-  enableFeedback,
-}) => {
+const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     hpaData: {},
     inputData: {},
@@ -173,7 +168,7 @@ const ResizeHPA: React.FC<WorkflowProps> = ({
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <HPAIdentifier name="Lookup" resolverType={resolverType} />
       <HPADetails name="Modify" />
       <Confirm name="Confirmation" notes={notes} />

--- a/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Terminate Instance workflow renders correctly 1`] = `
-"<Wizard dataLayout={{...}} heading={[undefined]} enableFeedback={[undefined]}>
+"<Wizard dataLayout={{...}} heading={[undefined]}>
   <PodIdentifier name=\\"Lookup\\" resolverType=\\"clutch.k8s.v1.Pod\\" />
   <PodDetails name=\\"Verify\\" />
   <Confirm name=\\"Confirmation\\" />

--- a/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Resize Autoscaling Group workflow renders correctly 1`] = `
-"<Wizard dataLayout={{...}} heading={[undefined]} enableFeedback={[undefined]}>
+"<Wizard dataLayout={{...}} heading={[undefined]}>
   <HPAIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.k8s.v1.HPA\\" />
   <HPADetails name=\\"Modify\\" />
   <Confirm name=\\"Confirmation\\" notes={{...}} />

--- a/frontend/workflows/kinesis/src/index.tsx
+++ b/frontend/workflows/kinesis/src/index.tsx
@@ -1,5 +1,5 @@
 import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
-import type { WizardChild, WizardConfigProps } from "@clutch-sh/wizard";
+import type { WizardChild } from "@clutch-sh/wizard";
 
 import UpdateShardCount from "./update-shard-count";
 
@@ -7,7 +7,7 @@ interface ConfigurationProps {
   resolverType: string;
 }
 
-export interface WorkflowProps extends BaseWorkflowProps, ConfigurationProps, WizardConfigProps {}
+export interface WorkflowProps extends BaseWorkflowProps, ConfigurationProps {}
 export interface ResolverChild extends WizardChild, ConfigurationProps {}
 
 const register = (): WorkflowConfiguration => {

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -129,7 +129,7 @@ const Confirm: React.FC<WizardChild> = () => {
   );
 };
 
-const UpdateShardCount: React.FC<WorkflowProps> = ({ heading, resolverType, enableFeedback }) => {
+const UpdateShardCount: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
   const dataLayout = {
     resourceData: {},
     streamData: {
@@ -151,7 +151,7 @@ const UpdateShardCount: React.FC<WorkflowProps> = ({ heading, resolverType, enab
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading} enableFeedback={enableFeedback}>
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <StreamIdentifier name="Lookup" resolverType={resolverType} />
       <StreamDetails name="Modify" />
       <Confirm name="Confirmation" />


### PR DESCRIPTION
### Description
Follow up to: https://github.com/lyft/clutch/pull/1989#issuecomment-1023369994. We decided to globally enable the NPS Wizard placement as opposed to having it enabled per workflow given that users will most likely either want to enable it 100% or not at all. To enable it, users will need to turn the feature flag on.

Will follow up with docs for clutch.sh

### Testing Performed
manually tested all workflows

PR undoes the changes in
1) https://github.com/lyft/clutch/pull/1903
2) https://github.com/lyft/clutch/pull/1915

### GitHub Issue
https://github.com/lyft/clutch/issues/1797