### PR TITLE
frontend: nps - defaulting displayName

### DIFF
--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -58,7 +58,7 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
       label: workflow.group,
       group: sortBy(
         workflow.routes.map(route => ({
-          label: route.displayName,
+          label: route.displayName || workflow.displayName,
           value: `/${workflow.path}/${route.path}`,
         })),
         ["label"]


### PR DESCRIPTION
### Description
If a workflow route does not have a display name it would be blank, in this case we will default to the workflows display name.

### Testing Performed
Manual

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->
