### PR TITLE
frontend: enable video for cypress runs

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -19,7 +19,8 @@ package-lock.json
 
 # testing
 /coverage
-**/screenshots
+**/cypress/screenshots
+**/cypress/videos
 
 # production
 **/build

--- a/frontend/packages/app/cypress.json
+++ b/frontend/packages/app/cypress.json
@@ -6,5 +6,5 @@
   "blockHosts": ["*google-analytics.com", "*googletagmanager.com"],
   "fixturesFolder": false,
   "pluginsFile": false,
-  "video": false
+  "video": true
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
There appears to be a bug in Cypress where failing tests hang when attempting to screenshot the client. Even on the latest version (^9.4.1) this appears to be the case.

See https://github.com/cypress-io/cypress/issues/5016 for more context.
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local