### PR TITLE
FE: Input: Change Input Textfield to be fullWidth from small

### DIFF
--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -263,7 +263,7 @@ const SearchField: React.FC = () => {
           <Autocomplete
             autoComplete
             selectOnFocus
-            fullWidth
+            size="small"
             inputValue={inputValue}
             renderInput={Input}
             renderOption={renderResult}

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -263,7 +263,7 @@ const SearchField: React.FC = () => {
           <Autocomplete
             autoComplete
             selectOnFocus
-            size="small"
+            fullWidth
             inputValue={inputValue}
             renderInput={Input}
             renderOption={renderResult}

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -163,6 +163,7 @@ export interface TextFieldProps
       | "defaultValue"
       | "disabled"
       | "error"
+      | "fullWidth"
       | "helperText"
       | "id"
       | "inputRef"
@@ -180,7 +181,6 @@ export interface TextFieldProps
     Pick<MuiInputProps, "readOnly" | "endAdornment"> {
   onReturn?: () => void;
   autocompleteCallback?: (v: string) => Promise<{ results: { id?: string; label: string }[] }>;
-  autocompleteFullWidth?: boolean;
 }
 
 const TextField = ({
@@ -192,7 +192,7 @@ const TextField = ({
   endAdornment,
   autocompleteCallback,
   defaultValue,
-  autocompleteFullWidth = true,
+  fullWidth = true,
   value,
   ...props
 }: TextFieldProps) => {
@@ -256,7 +256,7 @@ const TextField = ({
       <Autocomplete
         freeSolo
         size="small"
-        fullWidth={autocompleteFullWidth}
+        fullWidth={fullWidth}
         options={autoCompleteOptions}
         PopperComponent={Popper}
         getOptionLabel={(option: string | any) =>

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -252,7 +252,7 @@ const TextField = ({
     return (
       <Autocomplete
         freeSolo
-        size="small"
+        fullWidth
         options={autoCompleteOptions}
         PopperComponent={Popper}
         getOptionLabel={option =>

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -180,6 +180,7 @@ export interface TextFieldProps
     Pick<MuiInputProps, "readOnly" | "endAdornment"> {
   onReturn?: () => void;
   autocompleteCallback?: (v: string) => Promise<{ results: { id?: string; label: string }[] }>;
+  autocompleteFullWidth?: boolean;
 }
 
 const TextField = ({
@@ -191,6 +192,7 @@ const TextField = ({
   endAdornment,
   autocompleteCallback,
   defaultValue,
+  autocompleteFullWidth = true,
   ...props
 }: TextFieldProps) => {
   const onKeyDown = (
@@ -252,7 +254,8 @@ const TextField = ({
     return (
       <Autocomplete
         freeSolo
-        fullWidth
+        size="small"
+        fullWidth={autocompleteFullWidth}
         options={autoCompleteOptions}
         PopperComponent={Popper}
         getOptionLabel={option =>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
When using `small` the size doesn't fill up containers, so we can change it to `fullWidth` to get the behavior we want.
Note this is only for autocomplete. Without this, if you added autocomplete to a text field that previously did not have autocomplete, the size might change.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
