### PR TITLE
docs: fix import path for feature dev

### DIFF
--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -344,8 +344,8 @@ import (
     "github.com/lyft/clutch/backend/cmd/assets"
     "github.com/lyft/clutch/backend/gateway"
     // highlight-start
-    amiibomod "github.com/{path_to_gateway}/module/amiibo"
-    amiiboservice "github.com/{path_to_gateway}/service/amiibo"
+    amiibomod "github.com/{path_to_gateway}/backend/module/amiibo"
+    amiiboservice "github.com/{path_to_gateway}/backend/service/amiibo"
     // highlight-end
 )
 


### PR DESCRIPTION
### Description
`backend` path missing in the example

### Testing Performed


### GitHub Issue


Fixes #

### TODOs
