### PR TITLE
BE: aws: add safety check when accessing accounts map

### DIFF
--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,6 +7,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -164,6 +165,9 @@ func (r *res) Resolve(ctx context.Context, wantTypeURL string, input proto.Messa
 func (r *res) Search(ctx context.Context, typeURL, query string, limit uint32) (*resolver.Results, error) {
 	switch typeURL {
 	case typeURLInstance:
+		fmt.Println(query)
+		fmt.Println(query)
+		fmt.Println(query)
 		patternValues, ok, err := meta.ExtractPatternValuesFromString((*ec2v1api.Instance)(nil), query)
 		if err != nil {
 			return nil, err

--- a/backend/resolver/aws/aws.go
+++ b/backend/resolver/aws/aws.go
@@ -7,7 +7,6 @@ package aws
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -165,9 +164,6 @@ func (r *res) Resolve(ctx context.Context, wantTypeURL string, input proto.Messa
 func (r *res) Search(ctx context.Context, typeURL, query string, limit uint32) (*resolver.Results, error) {
 	switch typeURL {
 	case typeURLInstance:
-		fmt.Println(query)
-		fmt.Println(query)
-		fmt.Println(query)
 		patternValues, ok, err := meta.ExtractPatternValuesFromString((*ec2v1api.Instance)(nil), query)
 		if err != nil {
 			return nil, err

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -227,7 +227,11 @@ func (c *client) InterceptError(e error) error {
 }
 
 func (c *client) getAccountRegionClient(account, region string) (*regionalClient, error) {
-	cl, ok := c.accounts[account].clients[region]
+	accountClients, ok := c.accounts[account]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "account %s not found", account)
+	}
+	cl, ok := accountClients.clients[region]
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "no client found for account '%s' in region '%s'", account, region)
 	}

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -228,7 +228,7 @@ func (c *client) InterceptError(e error) error {
 
 func (c *client) getAccountRegionClient(account, region string) (*regionalClient, error) {
 	accountClients, ok := c.accounts[account]
-	if !ok {
+	if !ok || accountClients == nil {
 		return nil, status.Errorf(codes.NotFound, "account %s not found", account)
 	}
 	cl, ok := accountClients.clients[region]

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -109,6 +109,32 @@ func TestConfigureAdditionalAccountClient(t *testing.T) {
 	}
 }
 
+func TestGetAccountRegionClient(t *testing.T) {
+	c := &client{
+		currentAccountAlias: "default",
+		accounts: map[string]*accountClients{
+			"default": {
+				clients: map[string]*regionalClient{
+					"us-east-1":  nil,
+					"us-west-2":  nil,
+					"us-north-5": nil,
+				},
+			},
+		},
+	}
+
+	_, err := c.getAccountRegionClient("default", "us-east-1")
+	assert.NoError(t, err)
+
+	_, err = c.getAccountRegionClient("aws://", "us-west-3")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	_, err = c.getAccountRegionClient("default", "us-west-3")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no client found")
+}
+
 func TestRegions(t *testing.T) {
 	c := &client{
 		currentAccountAlias: "default",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
If the user supplies a value that doesn't exist in the accounts map, there would be a panic.
This PR adds a safety check to prevent that.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local
### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
- [x] add some unit tests for this function
<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
