### PR TITLE
move error boundary

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -94,26 +94,31 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
               <Route path="/*" element={<AppLayout isLoading={isLoading} />}>
                 <Route key="landing" path="" element={<Landing />} />
                 {workflows.map((workflow: Workflow) => (
-                  <ErrorBoundary workflow={workflow} key={workflow.path.split("/")[0]}>
-                    <Route path={`${workflow.path}/*`} element={<Outlet />}>
-                      {workflow.routes.map(route => {
-                        const heading = route.displayName
-                          ? `${workflow.displayName}: ${route.displayName}`
-                          : workflow.displayName;
-                        return (
-                          <Route
-                            key={workflow.path}
-                            path={`${route.path}`}
-                            element={React.cloneElement(<route.component />, {
-                              ...route.componentProps,
-                              heading,
-                            })}
-                          />
-                        );
-                      })}
-                      <Route key={`${workflow.path}/notFound`} path="*" element={<NotFound />} />
-                    </Route>
-                  </ErrorBoundary>
+                  <Route
+                    path={`${workflow.path}/*`}
+                    element={
+                      <ErrorBoundary workflow={workflow} key={workflow.path.split("/")[0]}>
+                        <Outlet />
+                      </ErrorBoundary>
+                    }
+                  >
+                    {workflow.routes.map(route => {
+                      const heading = route.displayName
+                        ? `${workflow.displayName}: ${route.displayName}`
+                        : workflow.displayName;
+                      return (
+                        <Route
+                          key={workflow.path}
+                          path={`${route.path}`}
+                          element={React.cloneElement(<route.component />, {
+                            ...route.componentProps,
+                            heading,
+                          })}
+                        />
+                      );
+                    })}
+                    <Route key={`${workflow.path}/notFound`} path="*" element={<NotFound />} />
+                  </Route>
                 ))}
                 <Route key="notFound" path="*" element={<NotFound />} />
               </Route>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Moving error boundary inside Route element instead of outside, similar to https://github.com/lyft/clutch/pull/1981/files#diff-4327e2aff12665e532737317ff7aeb684fe579812690ed68f83a175fb989e768

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local - same behavior as current functionality

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
