### PR TITLE
k8s: do not force delete pods

### DIFF
--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -40,11 +40,7 @@ func (s *svc) DeletePod(ctx context.Context, clientset, cluster, namespace, name
 		return err
 	}
 
-	var gracePeriod int64
-	opts := metav1.DeleteOptions{}
-	opts.GracePeriodSeconds = &gracePeriod
-
-	return cs.CoreV1().Pods(cs.Namespace()).Delete(ctx, name, opts)
+	return cs.CoreV1().Pods(cs.Namespace()).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func (s *svc) ListPods(ctx context.Context, clientset, cluster, namespace string, listOpts *k8sapiv1.ListOptions) ([]*k8sapiv1.Pod, error) {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
We were setting `GracePeriodSeconds` to zero by default, because of this we were "force" deleting pods which removes the pod from etcd state which can result in rogue resources. As there is zero guarantee that the resource will be deleted, the kubectl docs call this out [here](https://github.com/kubernetes/kubernetes/blob/438c3a51e6ee98fe3f318de1a2dddeafc0a0ec98/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go#L60-L68). By removing this override we will respect the default grace period.

### Testing Performed
unit