### PR TITLE
tools: fix yarn install when lockfile not present

### DIFF
--- a/.github/workflows/scaffolding.yml
+++ b/.github/workflows/scaffolding.yml
@@ -27,5 +27,5 @@ jobs:
         run: yes | go run scaffolder.go -m gateway -p ${{ github.sha }} -o ${{ github.repository_owner }}
         working-directory: ${{ env.PACKAGEPATH }}/tools/scaffolding
       - name: build scaffolding
-        run: make yarn-lock && make
+        run: make
         working-directory: ${{ github.workspace }}/go/src/github.com/runner/clutch-custom-gateway

--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -616,7 +616,6 @@ That's it! You should be able to remove all the remaining generated code.
 
 Run the frontend with the new workflow:
 ```bash
-make yarn-lock
 make frontend-dev
 ```
 

--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -38,13 +38,13 @@ backend-with-assets: frontend
 frontend: yarn-install
 	$(YARN) --cwd frontend build
 
-.PHONY: yarn-lock
-yarn-lock: yarn-ensure
-	$(YARN) --cwd frontend install
-
 .PHONY: yarn-install
 yarn-install: yarn-ensure
+ifneq ("$(wildcard frontend/yarn.lock)","")
 	$(YARN) --cwd frontend install --frozen-lockfile
+else
+	$(YARN) --cwd frontend install
+endif 
 
 .PHONY: yarn-ensure
 yarn-ensure:


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix gateway scaffolding to run yarn install even when lockfile not present.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual