### PR TITLE
frontend: remove default landing 404 for workflows

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -106,7 +106,6 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
                         </ErrorBoundary>
                       }
                     >
-                      <Route key={`${workflow.path}/landing`} path="" element={<NotFound />} />
                       {workflow.routes.map(route => {
                         const heading = route.displayName
                           ? `${workflow.displayName}: ${route.displayName}`


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Remove default 404 component for landing as some workflows intentionally set this.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
