### PR TITLE
frontend: fix typography color override

### DIFF
--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -136,7 +136,8 @@ type TextVariant =
   | "overline"
   | "input";
 
-const StyledTypography = styled("div")<{ $variant: TypographyProps["variant"] }>(props => ({
+const StyledTypography = styled("div")<{ $variant: TypographyProps["variant"], $color: TypographyProps["color"] }>(props => ({
+  color: props.$color, 
   fontSize: `${STYLE_MAP[props.$variant].size}px`,
   fontWeight: STYLE_MAP[props.$variant].weight,
   lineHeight: `${STYLE_MAP[props.$variant].lineHeight}px`,
@@ -150,7 +151,7 @@ export interface TypographyProps {
 }
 
 const Typography = ({ variant, children, color = "#0D1030" }: TypographyProps) => (
-  <StyledTypography $variant={variant} color={color}>
+  <StyledTypography $variant={variant} $color={color}>
     {children}
   </StyledTypography>
 );

--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -136,8 +136,11 @@ type TextVariant =
   | "overline"
   | "input";
 
-const StyledTypography = styled("div")<{ $variant: TypographyProps["variant"], $color: TypographyProps["color"] }>(props => ({
-  color: props.$color, 
+const StyledTypography = styled("div")<{
+  $variant: TypographyProps["variant"];
+  $color: TypographyProps["color"];
+}>(props => ({
+  color: props.$color,
   fontSize: `${STYLE_MAP[props.$variant].size}px`,
   fontWeight: STYLE_MAP[props.$variant].weight,
   lineHeight: `${STYLE_MAP[props.$variant].lineHeight}px`,


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix propagation of color override to typography component.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screenshot from 2022-02-23 23-05-25](https://user-images.githubusercontent.com/1004789/155475088-fabb0d59-2f72-457a-84cd-7673e8611065.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
