### PR TITLE
change feedback max length to 280 from 180

### DIFF
--- a/frontend/packages/core/src/NPS/feedback.tsx
+++ b/frontend/packages/core/src/NPS/feedback.tsx
@@ -85,7 +85,7 @@ const FeedbackAlert = () => {
     </Alert>
   );
 };
-
+export const FEEDBACK_MAX_LENGTH = 360;
 /**
  * NPS feedback component which is the base for both Wizard and Anytime.
  * Will fetch given survey options from the server based on the given origin
@@ -102,7 +102,7 @@ const NPSFeedback = ({ origin = "HEADER", onSubmit, feedbackTypes }: FeedbackOpt
   const [survey, setSurvey] = useState<IClutch.feedback.v1.ISurvey>({});
   const [feedbackType, setFeedbackType] = useState<string>(null);
   const [requestId, setRequestId] = useState<string>("");
-  const maxLength = 180;
+  const maxLength = FEEDBACK_MAX_LENGTH;
   const debounceTimer = 500;
   const wizardOrigin = origin === "WIZARD";
 

--- a/frontend/packages/core/src/NPS/feedback.tsx
+++ b/frontend/packages/core/src/NPS/feedback.tsx
@@ -85,7 +85,7 @@ const FeedbackAlert = () => {
     </Alert>
   );
 };
-export const FEEDBACK_MAX_LENGTH = 360;
+export const FEEDBACK_MAX_LENGTH = 280;
 /**
  * NPS feedback component which is the base for both Wizard and Anytime.
  * Will fetch given survey options from the server based on the given origin

--- a/frontend/packages/core/src/NPS/tests/feedback.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/feedback.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from "enzyme";
 
 import contextValues from "../../Contexts/tests/testContext";
 import { client } from "../../Network";
-import NPSFeedback, { defaults } from "../feedback";
+import NPSFeedback, { defaults, FEEDBACK_MAX_LENGTH } from "../feedback";
 import { generateFeedbackTypes } from "../header";
 
 // Adds the custom matchers provided by '@emotion/jest'
@@ -137,7 +137,7 @@ describe("<NPSFeedback />", () => {
   });
 
   describe("basic rendering", () => {
-    const maxLength = 180;
+    const maxLength = FEEDBACK_MAX_LENGTH;
     let wrapper;
     let useEffect;
 

--- a/frontend/packages/core/src/NPS/tests/feedback.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/feedback.test.tsx
@@ -219,7 +219,7 @@ describe("<NPSFeedback />", () => {
     it("will display an error on feedback if more input is given than maxLength", () => {
       clickEmoji(wrapper);
 
-      const testValue = generateRandomString(200);
+      const testValue = generateRandomString(FEEDBACK_MAX_LENGTH * 2);
 
       let textField = wrapper.find("Styled(TextField)");
 
@@ -244,7 +244,7 @@ describe("<NPSFeedback />", () => {
       expect(submitButton.prop("disabled")).toBeFalsy();
 
       wrapper.find("Styled(TextField)").prop("onChange")({
-        target: { value: generateRandomString(181) },
+        target: { value: generateRandomString(FEEDBACK_MAX_LENGTH + 1) },
       });
 
       wrapper.update();


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
We received feedback that 180 characters was not sufficient, so it has been bumped to 280. I thought about making it 500 or 360 but wanted to keep it as short as possible.
edit: Thanks to dschaller's suggestion of tweet length of 280

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
unit
### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
