### PR TITLE
frontend: Toast - adjusting onDismiss

### DIFF
--- a/frontend/packages/core/src/Feedback/toast.tsx
+++ b/frontend/packages/core/src/Feedback/toast.tsx
@@ -32,12 +32,11 @@ const Toast: React.FC<ToastProps> = ({
     <Snackbar
       open={open}
       autoHideDuration={autoHideDuration}
-      onExiting={onDismiss}
       anchorOrigin={anchorOrigin}
       onClose={(_, reason: SnackbarCloseReason) => {
         // This way it will not auto close when clicking in the window, will instead wait on the timeout or onClose
         if (reason !== "clickaway") {
-          setOpen(false);
+          onDismiss();
         }
       }}
     >


### PR DESCRIPTION
### Description
- onExiting for snackbar was deprecated, so I've removed it and only utilize onClose
- Modified onClose to call onDismiss instead of setOpen

When the toast was closing with the duration and the implementing component had an onClose handler to clear an error, it was not being called because `setOpen(false)` was being used instead of `onDismiss`

### Testing Performed
manual
