### PR TITLE
frontend: Handling displayName in workflow scaffolding and docs creation

### DIFF
--- a/docs/_website/src/components/FrontendWorkflow/index.tsx
+++ b/docs/_website/src/components/FrontendWorkflow/index.tsx
@@ -1,15 +1,20 @@
-import React from 'react';
+import React from "react";
 
-import Link from '@docusaurus/Link';
+import Link from "@docusaurus/Link";
 
-import './styles.css';
+import "./styles.css";
 
-const FrontendWorkflow = ({packageName, to, workflows}) => <Link to={to} className="fw-container">
+const FrontendWorkflow = ({ packageName, to, workflows }) => (
+  <Link to={to} className="fw-container">
     <div className="fw-title">{packageName}</div>
-    <div className="fw-workflow-list">
-        {workflows.map((v) => <li>{v}</li>)}
-    </div>
-
-</Link>
+    {workflows && (
+      <div className="fw-workflow-list">
+        {workflows.map((v) => (
+          <li>{v}</li>
+        ))}
+      </div>
+    )}
+  </Link>
+);
 
 export default FrontendWorkflow;

--- a/tools/scaffolding/templates/frontend/src/index.tsx
+++ b/tools/scaffolding/templates/frontend/src/index.tsx
@@ -16,6 +16,7 @@ const register = (): WorkflowConfiguration => {
     routes: {
       landing: {
         path: "{{ .URLPath }}",
+        displayName: "{{ .Name }}",
         description: "{{ .Description }}.",
         component: HelloWorld,
       },


### PR DESCRIPTION
### Description
- Documentation requires a displayName for each route, so adding it to the scaffolding template
- Modified the FrontendWorkflow component to not add the `fw-workflow-list` without any workflows

### Testing Performed
manual
