### PR TITLE
housekeeping: Updating renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,9 +18,25 @@
   "rebaseWhen": "conflicted",
   "labels": ["dependencies"],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "packageRules": [
+    {
+      "matchDatasources": ["npm", "node"],
+      "stabilityDays": 14,
+      "schedule": ["every 2 week on monday"]
+    },
+    {
+      "matchPackagePatterns": ["^eslint"],
+      "groupName": "eslint",
+      "postUpgradeTasks": {
+        "commands": ["make frontend-lint-fix"]
+      }
+    },
+    {
+      "matchPackagePatterns": ["^jest|^enzyme"],
+      "groupName": "unittest"
+    },
     {
       "extends": ["schedule:weekly"],
       "matchPackagePatterns": ["^github.com/aws/"]
@@ -36,5 +52,6 @@
     }
   ],
   "postUpdateOptions": ["gomodTidy"],
-  "ignoreDeps": ["@date-io/core", "babel-jest", "eslint", "jest", "esbuild"]
+  "allowedPostUpgradeCommands": ["make frontend-lint-fix"],
+  "ignoreDeps": ["@date-io/core", "babel-jest", "esbuild"]
 }


### PR DESCRIPTION
### Description
Updated renovate configuration:

- Turning off lockFileMaintenance for the moment, the large amount of updates at one point is rough to test and causes too many breaking changes, better to have these split separately. Can be re-evaluated.
- Added a rule for npm/node to not update until packages have been out for 2 weeks as well as reducing frequency of updates to bi-weekly instead of weekly
- Added eslint pattern rule which should group all eslint dependencies together and try to run the lint fix to hopefully reduce work
- Added a pattern to group jest/enzyme packages under a unittest heading
- Removing eslint and jest from ignoreDeps