### PR TITLE
shortlink: fix test json assert

### DIFF
--- a/backend/service/shortlink/shortlink_test.go
+++ b/backend/service/shortlink/shortlink_test.go
@@ -206,7 +206,7 @@ func TestProtoAnyForState(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			marshal, err := marshalShareableState(test.input)
 			assert.NoError(t, err)
-			assert.Equal(t, test.expect, string(marshal))
+			assert.JSONEq(t, test.expect, string(marshal))
 		})
 	}
 }

--- a/backend/service/shortlink/shortlink_test.go
+++ b/backend/service/shortlink/shortlink_test.go
@@ -163,6 +163,18 @@ func TestProtoAnyForState(t *testing.T) {
 			},
 		},
 		{
+			name:   "assert with json string spaces",
+			expect: `{"state":[ { "key": "mock",  "state":  "mock string" }]}`,
+			input: []*shortlinkv1.ShareableState{
+				{
+					Key: "mock",
+					State: &structpb.Value{
+						Kind: &structpb.Value_StringValue{StringValue: "mock string"},
+					},
+				},
+			},
+		},
+		{
 			name:   "numbers",
 			expect: `{"state":[{"key":"mock","state":{"key":123,"key1":345}}]}`,
 			input: []*shortlinkv1.ShareableState{


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Fixing weak assertion for json string compare, https://github.com/golang/protobuf/issues/1082 as this is discouraged. Switching to `assert.JSONEq()` which unmarshals into interfaces and then compares.
