### PR TITLE
FE: core: packages: Wrapper for time series chart from recharts 

### DIFF
--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -50,6 +50,7 @@
     "react-router": "^6.0.0-beta",
     "react-router-dom": "^6.0.0-beta",
     "react-test-renderer": "^17.0.2",
+    "recharts": "^2.1.9",
     "superstruct": "~0.15.0",
     "uuid": "^8.3.2",
     "yup": "^0.32.8"

--- a/frontend/packages/core/src/Charts/timeseries-chart.tsx
+++ b/frontend/packages/core/src/Charts/timeseries-chart.tsx
@@ -19,6 +19,8 @@ export interface ReferenceLineProps {
 export interface LineProps {
   dataKey: string;
   color: string;
+  strokeWidth?: number;
+  animationDuration?: number;
 }
 export interface TimeseriesChartProps {
   data: any;
@@ -26,7 +28,7 @@ export interface TimeseriesChartProps {
   yAxisDataKey?: string;
   lines: LineProps[];
   refLines?: ReferenceLineProps[];
-  // To add: ref dots, ref areas, zoom enabled, auto colors, legend enabled, cartesian grid options
+  // TODO: add ref dots, ref areas, zoom enabled, auto colors, legend enabled, cartesian grid options
 }
 
 /*
@@ -59,8 +61,13 @@ const TimeseriesChart = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart data={data}>
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey={xAxisDataKey} type="number" scale="time" />
-        <YAxis dataKey={yAxisDataKey} />
+        <XAxis
+          dataKey={xAxisDataKey}
+          type="number"
+          scale="time"
+          domain={["dataMin - 1000", "dataMax + 1000"]}
+        />
+        <YAxis dataKey={yAxisDataKey} domain={["dataMin", "dataMax"]} />
         <Tooltip />
         <Legend />
         {lines
@@ -71,6 +78,7 @@ const TimeseriesChart = ({
                   type="linear"
                   dataKey={line.dataKey}
                   stroke={line.color}
+                  animationDuration={line.animationDuration !== null ? line.animationDuration : 500}
                 />
               );
             })

--- a/frontend/packages/core/src/Charts/timeseries-chart.tsx
+++ b/frontend/packages/core/src/Charts/timeseries-chart.tsx
@@ -1,15 +1,24 @@
-import React, { useEffect } from "react";
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from 'recharts';
+import React from "react";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
-  
 export interface ReferenceLineProps {
   axis: "x" | "y";
   coordinate: number;
   label?: string;
 }
 export interface LineProps {
-    dataKey: string;
-    color: string;
+  dataKey: string;
+  color: string;
 }
 export interface TimeseriesChartProps {
   data: any;
@@ -18,7 +27,7 @@ export interface TimeseriesChartProps {
   lines: LineProps[];
   refLines?: ReferenceLineProps[];
   // To add: ref dots, ref areas, zoom enabled, auto colors, legend enabled, cartesian grid options
-};
+}
 
 /*
   For the lines, use the `dataKey` property to denote which data points belong to that line. Make sure that
@@ -39,34 +48,53 @@ export interface TimeseriesChartProps {
   }
   For reference lines, you can set the `axis` property to "x" or "y" to denote which axis the line is on.
 */
-const TimeseriesChart = ({data, xAxisDataKey, yAxisDataKey, lines, refLines }: TimeseriesChartProps) => {
-    return (
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart
-            data={data}
-          >
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey={xAxisDataKey} type="number" scale="time" />
-            <YAxis dataKey={yAxisDataKey} />
-            <Tooltip />
-            <Legend />
-            {
-              lines.map((line, index) => {
-                return (
-                  <Line key={index} type="linear" dataKey={line.dataKey} stroke={line.color} />
-                )
-              })
-            }
-            {
-              refLines.map(refLine => {
-                return (refLine.axis === "x" ? 
-                <ReferenceLine x={refLine.coordinate} label={refLine.label}  /> : <ReferenceLine y={refLine.coordinate} label={refLine.label} />)
-              })
-            }
-          </LineChart>
-        </ResponsiveContainer>
-      );
-  };
-  
-  export default TimeseriesChart;
-  
+const TimeseriesChart = ({
+  data,
+  xAxisDataKey,
+  yAxisDataKey,
+  lines,
+  refLines,
+}: TimeseriesChartProps) => {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey={xAxisDataKey} type="number" scale="time" />
+        <YAxis dataKey={yAxisDataKey} />
+        <Tooltip />
+        <Legend />
+        {lines
+          ? lines.map((line, index) => {
+              return (
+                <Line
+                  key={index.toString() + line.dataKey + line.color}
+                  type="linear"
+                  dataKey={line.dataKey}
+                  stroke={line.color}
+                />
+              );
+            })
+          : null}
+        {refLines
+          ? refLines.map((refLine, index) => {
+              return refLine.axis === "x" ? (
+                <ReferenceLine
+                  key={index.toString() + refLine.axis + refLine.coordinate.toString()}
+                  x={refLine.coordinate}
+                  label={refLine.label}
+                />
+              ) : (
+                <ReferenceLine
+                  key={index.toString() + refLine.axis + refLine.coordinate.toString()}
+                  y={refLine.coordinate}
+                  label={refLine.label}
+                />
+              );
+            })
+          : null}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default TimeseriesChart;

--- a/frontend/packages/core/src/Charts/timeseries-chart.tsx
+++ b/frontend/packages/core/src/Charts/timeseries-chart.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect } from "react";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine } from 'recharts';
+
+  
+export interface ReferenceLineProps {
+  axis: "x" | "y";
+  coordinate: number;
+  label?: string;
+}
+export interface LineProps {
+    dataKey: string;
+    color: string;
+}
+export interface TimeseriesChartProps {
+  data: any;
+  xAxisDataKey?: string;
+  yAxisDataKey?: string;
+  lines: LineProps[];
+  refLines?: ReferenceLineProps[];
+  // To add: ref dots, ref areas, zoom enabled, auto colors, legend enabled, cartesian grid options
+};
+
+/*
+  For the lines, use the `dataKey` property to denote which data points belong to that line. Make sure that
+  all the dataKeys match appropriately (the XAxis datakey should correspond to the data that is graphed along
+  the XAxis, and same for Y. Note that we currently set the XAxis to be a time scale, hence the name
+  Timeseries Chart).
+  
+  *** VERY IMPORTANT ***
+  It is very important that the data is sorted in ascending order by the XAxis. Otherwise the lines will go
+  backwards and have problems.
+  *** END VERY IMPORTANT ***
+
+  Suggested data format:
+  {
+    lineName: string
+    timestamp: number
+    value: number
+  }
+  For reference lines, you can set the `axis` property to "x" or "y" to denote which axis the line is on.
+*/
+const TimeseriesChart = ({data, xAxisDataKey, yAxisDataKey, lines, refLines }: TimeseriesChartProps) => {
+    return (
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={data}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey={xAxisDataKey} type="number" scale="time" />
+            <YAxis dataKey={yAxisDataKey} />
+            <Tooltip />
+            <Legend />
+            {
+              lines.map((line, index) => {
+                return (
+                  <Line key={index} type="linear" dataKey={line.dataKey} stroke={line.color} />
+                )
+              })
+            }
+            {
+              refLines.map(refLine => {
+                return (refLine.axis === "x" ? 
+                <ReferenceLine x={refLine.coordinate} label={refLine.label}  /> : <ReferenceLine y={refLine.coordinate} label={refLine.label} />)
+              })
+            }
+          </LineChart>
+        </ResponsiveContainer>
+      );
+  };
+  
+  export default TimeseriesChart;
+  

--- a/frontend/packages/core/src/stories/charts.stories.tsx
+++ b/frontend/packages/core/src/stories/charts.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { styled } from "@clutch-sh/core";
 import type { Meta } from "@storybook/react";
 
 import TimeseriesChart from "../Charts/timeseries-chart";
@@ -7,6 +8,11 @@ export default {
   title: "Core/TimeseriesChart",
   component: TimeseriesChart,
 } as Meta;
+
+const ChartContainer = styled("div")({
+  width: 600,
+  height: 400,
+});
 
 export const Primary = () => {
   const mockData = [
@@ -29,7 +35,7 @@ export const Primary = () => {
 
   const mockLines = [
     {
-      dataKey: "",
+      dataKey: "value",
       color: "red",
     },
   ];
@@ -38,11 +44,13 @@ export const Primary = () => {
   // TimeseriesChart
   // const TimeseriesChart = ({data, xAxisDataKey, yAxisDataKey, lines, refLines }: TimeseriesChartProps) => {
   return (
-    <TimeseriesChart
-      data={mockData}
-      xAxisDataKey="timestamp"
-      yAxisDataKey="value"
-      lines={mockLines}
-    />
+    <ChartContainer>
+      <TimeseriesChart
+        data={mockData}
+        xAxisDataKey="timestamp"
+        yAxisDataKey="value"
+        lines={mockLines}
+      />
+    </ChartContainer>
   );
 };

--- a/frontend/packages/core/src/stories/charts.stories.tsx
+++ b/frontend/packages/core/src/stories/charts.stories.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import type { Meta } from "@storybook/react";
+
+import TimeseriesChart from "../Charts/timeseries-chart";
+
+export default {
+  title: "Core/TimeseriesChart",
+  component: TimeseriesChart,
+} as Meta;
+
+export const Primary = () => {
+
+  const mockData = [
+    {
+        lineName: "line1",
+        timestamp: 1546300800000,
+        value: 10
+    },
+    {
+        lineName: "line1",
+        timestamp: 1546300900000,
+        value: 20
+    },
+    {
+        lineName: "line1",
+        timestamp: 1546301000000,
+        value: 30
+    },
+  ]
+
+  const mockLines = [
+    {
+        dataKey: "",
+        color: "red"
+    }
+
+  ]
+  //data
+  // reference lines
+  // TimeseriesChart
+  // const TimeseriesChart = ({data, xAxisDataKey, yAxisDataKey, lines, refLines }: TimeseriesChartProps) => {
+  return <TimeseriesChart data={mockData} xAxisDataKey={"timestamp"} yAxisDataKey={"value"} lines={mockLines} />;
+};

--- a/frontend/packages/core/src/stories/charts.stories.tsx
+++ b/frontend/packages/core/src/stories/charts.stories.tsx
@@ -9,35 +9,40 @@ export default {
 } as Meta;
 
 export const Primary = () => {
-
   const mockData = [
     {
-        lineName: "line1",
-        timestamp: 1546300800000,
-        value: 10
+      lineName: "line1",
+      timestamp: 1546300800000,
+      value: 10,
     },
     {
-        lineName: "line1",
-        timestamp: 1546300900000,
-        value: 20
+      lineName: "line1",
+      timestamp: 1546300900000,
+      value: 20,
     },
     {
-        lineName: "line1",
-        timestamp: 1546301000000,
-        value: 30
+      lineName: "line1",
+      timestamp: 1546301000000,
+      value: 30,
     },
-  ]
+  ];
 
   const mockLines = [
     {
-        dataKey: "",
-        color: "red"
-    }
-
-  ]
-  //data
+      dataKey: "",
+      color: "red",
+    },
+  ];
+  // data
   // reference lines
   // TimeseriesChart
   // const TimeseriesChart = ({data, xAxisDataKey, yAxisDataKey, lines, refLines }: TimeseriesChartProps) => {
-  return <TimeseriesChart data={mockData} xAxisDataKey={"timestamp"} yAxisDataKey={"value"} lines={mockLines} />;
+  return (
+    <TimeseriesChart
+      data={mockData}
+      xAxisDataKey="timestamp"
+      yAxisDataKey="value"
+      lines={mockLines}
+    />
+  );
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

We add a component to use the recharts line chart as a time series chart. Note that there are more charts coming later like scatter plots (also useful for timelines). This line chart is used in a situation when the user wants a Y-Axis. If they do not care about the Y-Axis, they should use the scatter plot alternative.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local
storybook

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
