### PR TITLE
feature: ShortLinks - Tooltip on Clipboard

### DIFF
--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -8,8 +8,8 @@ import { Button as MuiButton, Grid, IconButton as MuiIconButton } from "@materia
 import CheckCircleOutlinedIcon from "@material-ui/icons/CheckCircleOutlined";
 import FileCopyOutlinedIcon from "@material-ui/icons/FileCopyOutlined";
 
+import { Tooltip } from "./Feedback/tooltip";
 import styled from "./styled";
-import { Tooltip } from "./Feedback";
 
 interface ButtonPalette {
   /** A palette of background colors used for the various button states. */

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -9,6 +9,7 @@ import CheckCircleOutlinedIcon from "@material-ui/icons/CheckCircleOutlined";
 import FileCopyOutlinedIcon from "@material-ui/icons/FileCopyOutlined";
 
 import styled from "./styled";
+import { Tooltip } from "./Feedback";
 
 interface ButtonPalette {
   /** A palette of background colors used for the various button states. */
@@ -243,6 +244,7 @@ const StyledClipboardIconButton = styled(MuiIconButton)({
 export interface ClipboardButtonProps {
   /** Case-sensitive text to be copied. */
   text: string;
+  tooltip?: string;
 }
 
 /**
@@ -250,7 +252,7 @@ export interface ClipboardButtonProps {
  *
  * When clicked a checkmark is briefly displayed.
  */
-const ClipboardButton = ({ text }: ClipboardButtonProps) => {
+const ClipboardButton = ({ text, tooltip = "" }: ClipboardButtonProps) => {
   const [clicked, setClicked] = React.useState(false);
   React.useEffect(() => {
     if (clicked) {
@@ -264,14 +266,16 @@ const ClipboardButton = ({ text }: ClipboardButtonProps) => {
   }, [clicked]);
 
   return (
-    <StyledClipboardIconButton
-      onClick={() => {
-        setClicked(true);
-        navigator.clipboard.writeText(text);
-      }}
-    >
-      {clicked ? <CheckCircleOutlinedIcon /> : <FileCopyOutlinedIcon />}
-    </StyledClipboardIconButton>
+    <Tooltip title={tooltip}>
+      <StyledClipboardIconButton
+        onClick={() => {
+          setClicked(true);
+          navigator.clipboard.writeText(text);
+        }}
+      >
+        {clicked ? <CheckCircleOutlinedIcon /> : <FileCopyOutlinedIcon />}
+      </StyledClipboardIconButton>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
### Description
- PR [6/x] for ShortLinks
- No reliance on other PRs
- Modifies the Clipboard button to have an optional tooltip wrapped around it for ease of understanding

### Screenshots

#### Displayed
![Screen Shot 2022-03-10 at 1 55 34 PM](https://user-images.githubusercontent.com/8338893/157761492-cd88b884-13e9-41c3-a78a-0e4c2d269aab.png)

#### No tooltip provided
![Screen Shot 2022-03-10 at 2 03 23 PM](https://user-images.githubusercontent.com/8338893/157762340-785935ae-e206-4ede-a864-0bf199fbea3e.png)

### Testing Performed
manual