### PR TITLE
FE: Text-field: prevent null onChange from breaking things

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -265,9 +265,11 @@ const TextField = ({
         renderOption={(option: AutocompleteResultProps) => (
           <AutocompleteResult id={option.id} label={option.label} />
         )}
-        onSelectCapture={e =>
-          onChange(e as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>)
-        }
+        onSelectCapture={e => {
+          if (onChange) {
+            onChange(e as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);
+          }
+        }}
         defaultValue={{ id: defaultVal, label: defaultVal }}
         renderInput={inputProps => (
           <StyledTextField


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
I noticed that if onChange is null or undefined that can cause an error here because there is an assumption that it is not.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
