### PR TITLE
[feedback] FE: add support for inputTransformers in term instance

### DIFF
--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -92,16 +92,15 @@ const Resolver: React.FC<ResolverProps> = ({
     // Copy incoming data, trimming whitespace from any string values (usually artifact of cut and paste into tool).
     // If a inputTransformer function is defined, then use it after trimming.
     const inputData = _.mapValues(data, v => {
-      if(_.isString(v)) {
+      if (_.isString(v)) {
         if (inputTransformer) {
           return inputTransformer(_.trim(v));
-        } else {
-          return _.trim(v);
         }
+        return _.trim(v);
       }
       return v;
     });
-    
+
     // Resolve!
     resolveResource(
       type,

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -7,7 +7,7 @@ import TerminateInstance from "./terminate-instance";
 
 interface ResolverConfigProps {
   resolverType: string;
-  ipnutTransformer?: (input: string) => string;
+  inputTransformer?: (input: string) => string;
 }
 
 interface ConfirmConfigProps {

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -7,7 +7,7 @@ import TerminateInstance from "./terminate-instance";
 
 interface ResolverConfigProps {
   resolverType: string;
-  ipnutTransformer: (input: string) => string;
+  ipnutTransformer?: (input: string) => string;
 }
 
 interface ConfirmConfigProps {

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -7,6 +7,7 @@ import TerminateInstance from "./terminate-instance";
 
 interface ResolverConfigProps {
   resolverType: string;
+  ipnutTransformer: (input: string) => string;
 }
 
 interface ConfirmConfigProps {

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -18,7 +18,7 @@ import { Wizard, WizardStep } from "@clutch-sh/wizard";
 
 import type { ConfirmChild, ResolverChild, WorkflowProps } from ".";
 
-const InstanceIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
+const InstanceIdentifier: React.FC<ResolverChild> = ({ resolverType, inputTransformer }) => {
   const { onSubmit } = useWizardContext();
   const resolvedResourceData = useDataLayout("resourceData");
 
@@ -28,7 +28,7 @@ const InstanceIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
     onSubmit();
   };
 
-  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} />;
+  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} inputTransformer={inputTransformer} />;
 };
 
 const InstanceDetails: React.FC<WizardChild> = () => {
@@ -92,7 +92,7 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
-const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
+const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [], inputTransformer }) => {
   const dataLayout = {
     resourceData: {},
     terminationData: {
@@ -109,7 +109,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, not
 
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
-      <InstanceIdentifier name="Lookup" resolverType={resolverType} />
+      <InstanceIdentifier name="Lookup" resolverType={resolverType} inputTransformer={inputTransformer}/>
       <InstanceDetails name="Verify" />
       <Confirm name="Confirmation" notes={notes} />
     </Wizard>

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -28,7 +28,14 @@ const InstanceIdentifier: React.FC<ResolverChild> = ({ resolverType, inputTransf
     onSubmit();
   };
 
-  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} inputTransformer={inputTransformer} />;
+  return (
+    <Resolver
+      type={resolverType}
+      searchLimit={1}
+      onResolve={onResolve}
+      inputTransformer={inputTransformer}
+    />
+  );
 };
 
 const InstanceDetails: React.FC<WizardChild> = () => {
@@ -92,7 +99,12 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
-const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [], inputTransformer }) => {
+const TerminateInstance: React.FC<WorkflowProps> = ({
+  heading,
+  resolverType,
+  notes = [],
+  inputTransformer,
+}) => {
   const dataLayout = {
     resourceData: {},
     terminationData: {
@@ -109,7 +121,11 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, not
 
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
-      <InstanceIdentifier name="Lookup" resolverType={resolverType} inputTransformer={inputTransformer}/>
+      <InstanceIdentifier
+        name="Lookup"
+        resolverType={resolverType}
+        inputTransformer={inputTransformer}
+      />
       <InstanceDetails name="Verify" />
       <Confirm name="Confirmation" notes={notes} />
     </Wizard>

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Terminate Instance workflow renders correctly 1`] = `
 "<Wizard dataLayout={{...}} heading={[undefined]}>
-  <InstanceIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.ec2.v1.Instance\\" />
+  <InstanceIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.ec2.v1.Instance\\" inputTransformer={[undefined]} />
   <InstanceDetails name=\\"Verify\\" />
   <Confirm name=\\"Confirmation\\" notes={{...}} />
 </Wizard>"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It is useful to be able to specify transformation functions in the config to be able to transform the input for aws instance termination.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
