### PR TITLE
FE: charting: change dashed grid lines to solid ones

### DIFF
--- a/frontend/packages/core/src/Charts/helpers.tsx
+++ b/frontend/packages/core/src/Charts/helpers.tsx
@@ -1,6 +1,13 @@
-// TODO: add more formatting funcs
 export const localTimeFormatter = (timestamp: number) => {
   return new Date(timestamp).toLocaleTimeString();
+};
+
+export const isoTimeFormatter = (timestamp: number) => {
+  return new Date(timestamp).toISOString();
+};
+
+export const dateTimeFormatter = (timestamp: number) => {
+  return new Date(timestamp).toDateString();
 };
 
 const getMinAndMaxOfRangeUsingKey = (data: any, key: string) => {

--- a/frontend/packages/core/src/Charts/linearTimeline.tsx
+++ b/frontend/packages/core/src/Charts/linearTimeline.tsx
@@ -109,7 +109,7 @@ const LinearTimeline = ({
   return (
     <ResponsiveContainer width="100%" height="100%">
       <ScatterChart>
-        <CartesianGrid strokeDasharray="3 3" />
+        <CartesianGrid />
         <XAxis
           dataKey={xAxisDataKey}
           type="number"

--- a/frontend/packages/core/src/stories/timeseries.stories.tsx
+++ b/frontend/packages/core/src/stories/timeseries.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import styled from "@emotion/styled";
 import type { Meta } from "@storybook/react";
 
+import { dateTimeFormatter, isoTimeFormatter } from "../Charts/helpers";
 import TimeseriesChart, { TimeseriesReferenceLineProps } from "../Charts/timeseries";
 
 export default {
@@ -66,6 +67,26 @@ export const SingleDataLine = () => {
         xDomainSpread={0.3}
         yDomainSpread={0.3}
         regularIntervalTicks
+      />
+      <TimeseriesChart
+        data={mockDataSingleLine}
+        xAxisDataKey="timestamp"
+        yAxisDataKey="value"
+        lines={mockLines}
+        xDomainSpread={0.3}
+        yDomainSpread={0.3}
+        regularIntervalTicks
+        tickFormatterFunc={isoTimeFormatter}
+      />
+      <TimeseriesChart
+        data={mockDataSingleLine}
+        xAxisDataKey="timestamp"
+        yAxisDataKey="value"
+        lines={mockLines}
+        xDomainSpread={0.3}
+        yDomainSpread={0.3}
+        regularIntervalTicks
+        tickFormatterFunc={dateTimeFormatter}
       />
     </ChartContainer>
   );


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
The goal of the charting library is that defaults should lead to an appearance similar to Grafana. This is the 1st of many that will change the appearance.

Also added more time formatting funcs for users into the stories.
before:
<img width="925" alt="Screen Shot 2022-03-19 at 11 36 43 PM" src="https://user-images.githubusercontent.com/66325812/159151211-39738aef-d90f-4090-8d60-2f1d1074872b.png">
after:
<img width="965" alt="Screen Shot 2022-03-19 at 11 35 39 PM" src="https://user-images.githubusercontent.com/66325812/159151214-f3820322-e391-45ff-b803-26ce21b4a9bb.png">

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
