### PR TITLE
github: App auth token refresh

### DIFF
--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -359,7 +359,7 @@ func newService(config *githubv1.Config, scope tally.Scope, logger *zap.Logger) 
 
 	var httpClient *http.Client
 
-	switch config.GetAuth().(type) {
+	switch auth := config.GetAuth().(type) {
 	case *githubv1.Config_AccessToken:
 		token := config.GetAccessToken()
 		ret.personalAccessToken = token
@@ -389,6 +389,8 @@ func newService(config *githubv1.Config, scope tally.Scope, logger *zap.Logger) 
 		ret.appTransport = itr
 
 		httpClient = &http.Client{Transport: itr}
+	default:
+		return nil, fmt.Errorf("did not recognize auth config type '%T'", auth)
 	}
 	httpClient.Transport = &StatsRoundTripper{Wrapped: httpClient.Transport, scope: scope}
 

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -2,6 +2,10 @@ package github
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +17,10 @@ import (
 	githubv3 "github.com/google/go-github/v37/github"
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally/v4"
+	"go.uber.org/zap"
 
+	githubconfigv1 "github.com/lyft/clutch/backend/api/config/service/github/v1"
 	githubv1 "github.com/lyft/clutch/backend/api/sourcecontrol/github/v1"
 	sourcecontrolv1 "github.com/lyft/clutch/backend/api/sourcecontrol/v1"
 )
@@ -788,4 +795,40 @@ func TestListPullRequestsWithCommit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewService(t *testing.T) {
+	cfg := &githubconfigv1.Config{}
+	_, err := newService(cfg, tally.NoopScope, zap.NewNop())
+	assert.Error(t, err)
+
+	cfg.Auth = &githubconfigv1.Config_AccessToken{AccessToken: "aaa"}
+	s, err := newService(cfg, tally.NoopScope, zap.NewNop())
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+
+	assert.Nil(t, s.(*svc).appTransport)
+	assert.Equal(t, s.(*svc).personalAccessToken, "aaa")
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+
+	kk, _ := x509.MarshalPKCS8PrivateKey(pk)
+
+	cfg.Auth = &githubconfigv1.Config_AppConfig{
+		AppConfig: &githubconfigv1.AppConfig{
+			AppId:          123456,
+			InstallationId: 789,
+			Pem: &githubconfigv1.AppConfig_KeyPem{
+				KeyPem: string(pem.EncodeToMemory(&pem.Block{Type: "RSA_PRIVATE_KEY", Bytes: kk})),
+			},
+		},
+	}
+	s, err = newService(cfg, tally.NoopScope, zap.NewNop())
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+
+	assert.Empty(t, s.(*svc).personalAccessToken)
+	assert.NotNil(t, s.(*svc).appTransport)
+
 }

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -830,5 +830,4 @@ func TestNewService(t *testing.T) {
 
 	assert.Empty(t, s.(*svc).personalAccessToken)
 	assert.NotNil(t, s.(*svc).appTransport)
-
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
When using an application for authentication (vs a personal access token), the token will expire and needs to be refreshed. Prior to this change we were storing the token once on boot and never refreshing it.

### Testing Performed
Unit.