### PR TITLE
github: add author information to branch creation

### DIFF
--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -861,5 +861,4 @@ func TestCommitAuthorFromContext(t *testing.T) {
 	result = commitOptionsFromClaims(ctx)
 	assert.Equal(t, "daniel123 via Clutch", result.Author.Name)
 	assert.Equal(t, "<>", result.Author.Email)
-
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Commits would fail in the absence of a global git config due to missing author information. Instead we embed the author information directly, using authn claims to populate user information.