### PR TITLE
FE: Project Catalog: Quicklinks with images

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Card, Grid } from "@clutch-sh/core";
+import { Card, Grid, Tooltip, Link } from "@clutch-sh/core";
 
 const QuickLinksCard = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
   return (
@@ -17,10 +16,12 @@ const QuickLinksCard = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
         {linkGroups?.map(linkGroup => {
           return linkGroup.links?.map(link => {
             return (
-              <Grid item key={link.name}>
-                <Link to={link.url}>
-                  <img width="29px" height="29px" src={linkGroup.imagePath} alt={link.name} />
-                </Link>
+              <Grid item key={link.name} >
+                <Tooltip title={linkGroup.name}>
+                  <Link href={link.url}>
+                    <img width="29px" height="29px" src={linkGroup.imagePath} alt={link.name} />
+                  </Link>
+                </Tooltip>
               </Grid>
             );
           });

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -11,13 +11,14 @@ import {
   Typography,
 } from "@clutch-sh/core";
 
+const ICON_SIZE = "32px";
 // If only a single link, then no popper is necessary
 const QuickLink = ({ link, linkGroupName, linkGroupImage }) => (
   <Grid item key={link.name}>
     <Tooltip title={linkGroupName}>
       <TooltipContainer>
         <Link href={link.url}>
-          <img width="32px" height="32px" src={linkGroupImage} alt={link.name} />
+          <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={link.name} />
         </Link>
       </TooltipContainer>
     </Tooltip>
@@ -33,67 +34,73 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
     <Grid item key={linkGroupName}>
       <Tooltip title={linkGroupName}>
         <TooltipContainer>
+          {/* 
+            We are disabling lint here until we come up with a better solution than putting the onClic() inside the <img> 
+
+            error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
+            error  Non-interactive elements should not be assigned mouse or keyboard event listeners               jsx-a11y/no-noninteractive-element-interactions
+
+            TODO: don't disable it.
+          */}
           {/* eslint-disable */}
           <img
-            width="32px"
-            height="32px"
+            width={ICON_SIZE}
+            height={ICON_SIZE}
             src={linkGroupImage}
             alt={linkGroupName}
             onClick={() => setOpen(true)}
             ref={anchorRef}
           />
           <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
-            {links.map(link => {
-              return (
-                <PopperItem key={link.name}>
-                  <Link href={link.url}>
-                    <Typography color="inherit" variant="body4">
-                      {link.name}
-                    </Typography>
-                  </Link>
-                </PopperItem>
-              );
-            })}
+            {links.map(link => (
+              <PopperItem key={link.name}>
+                <Link href={link.url}>
+                  <Typography color="inherit" variant="body4">
+                    {link.name}
+                  </Typography>
+                </Link>
+              </PopperItem>
+            ))}
           </Popper>
-          </TooltipContainer>
+        </TooltipContainer>
       </Tooltip>
     </Grid>
   );
 };
-export interface QuickLinksCardInput {
+export interface QuickLinksProps {
   linkGroups: IClutch.core.project.v1.ILinkGroup[];
 }
 
-const QuickLinksCard = ({ linkGroups }: QuickLinksCardInput) => (
-    <Card>
-      <Grid
-        container
-        item
-        direction="column"
-        alignItems="center"
-        spacing={1}
-        style={{ padding: "7px 0" }}
-      >
-        {linkGroups?.map(linkGroup => {
-          if (linkGroup.links?.length === 1) {
-            return (
-              <QuickLink
-                link={linkGroup.links[0]}
-                linkGroupName={linkGroup.name}
-                linkGroupImage={linkGroup.imagePath}
-              />
-            );
-          }
+const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => (
+  <Card>
+    <Grid
+      container
+      item
+      direction="column"
+      alignItems="center"
+      spacing={1}
+      style={{ padding: "10px 0" }}
+    >
+      {linkGroups?.map(linkGroup => {
+        if (linkGroup.links?.length === 1) {
           return (
-            <QuickLinkGroup
+            <QuickLink
+              link={linkGroup.links[0]}
               linkGroupName={linkGroup.name}
               linkGroupImage={linkGroup.imagePath}
-              links={linkGroup.links}
             />
           );
-        })}
-      </Grid>
-    </Card>
+        }
+        return (
+          <QuickLinkGroup
+            linkGroupName={linkGroup.name}
+            linkGroupImage={linkGroup.imagePath}
+            links={linkGroup.links}
+          />
+        );
+      })}
+    </Grid>
+  </Card>
 );
 
 export default QuickLinksCard;

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -1,8 +1,59 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Card, Grid, Tooltip, Link } from "@clutch-sh/core";
+import { Card, Grid, Link, Popper, PopperItem, Tooltip, Typography } from "@clutch-sh/core";
 
-const QuickLinksCard = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
+// If only a single link, then no popper is necessary
+const QuickLink = ({ link, linkGroupName, linkGroupImage }) => {
+  return (
+    <Grid item key={link.name}>
+      <Tooltip title={linkGroupName}>
+        <Link href={link.url}>
+          <img width="32px" height="32px" src={linkGroupImage} alt={link.name} />
+        </Link>
+      </Tooltip>
+    </Grid>
+  );
+};
+
+// Have a popper in the case of multiple links per group
+const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
+  const anchorRef = React.useRef(null);
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Grid item key={linkGroupName}>
+      <Tooltip title={linkGroupName}>
+        <>
+          <img
+            width="32px"
+            height="32px"
+            src={linkGroupImage}
+            alt={linkGroupName}
+            ref={anchorRef}
+          />
+          <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
+            {links.map(link => {
+              return (
+                <PopperItem key={link.name}>
+                  <Link href={link.url}>
+                    <Typography color="inherit" variant="body4">
+                      {link.name}
+                    </Typography>
+                  </Link>
+                </PopperItem>
+              );
+            })}
+          </Popper>
+        </>
+      </Tooltip>
+    </Grid>
+  );
+};
+export interface QuickLinksCardInput {
+  linkGroups: IClutch.core.project.v1.ILinkGroup[];
+}
+
+const QuickLinksCard = ({ linkGroups }: QuickLinksCardInput) => {
   return (
     <Card>
       <Grid
@@ -14,17 +65,22 @@ const QuickLinksCard = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
         style={{ padding: "7px 0" }}
       >
         {linkGroups?.map(linkGroup => {
-          return linkGroup.links?.map(link => {
+          if (linkGroup.links?.length === 1) {
             return (
-              <Grid item key={link.name} >
-                <Tooltip title={linkGroup.name}>
-                  <Link href={link.url}>
-                    <img width="29px" height="29px" src={linkGroup.imagePath} alt={link.name} />
-                  </Link>
-                </Tooltip>
-              </Grid>
+              <QuickLink
+                link={linkGroup.links[0]}
+                linkGroupName={linkGroup.name}
+                linkGroupImage={linkGroup.imagePath}
+              />
             );
-          });
+          }
+          return (
+            <QuickLinkGroup
+              linkGroupName={linkGroup.name}
+              linkGroupImage={linkGroup.imagePath}
+              links={linkGroup.links}
+            />
+          );
         })}
       </Grid>
     </Card>

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { Card, Grid } from "@clutch-sh/core";
 
-const QuickLinks = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
+const QuickLinksCard = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
   return (
     <Card>
       <Grid
@@ -30,4 +30,4 @@ const QuickLinks = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
   );
 };
 
-export default QuickLinks;
+export default QuickLinksCard;

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -25,8 +25,13 @@ const QuickLink = ({ link, linkGroupName, linkGroupImage }) => (
   </Grid>
 );
 
+interface QuickLinkGroupProps {
+  linkGroupName: string;
+  linkGroupImage: string;
+  links: IClutch.core.project.v1.ILink[];
+}
 // Have a popper in the case of multiple links per group
-const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
+const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroupProps) => {
   const anchorRef = React.useRef(null);
   const [open, setOpen] = React.useState(false);
 
@@ -35,12 +40,13 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
       <Tooltip title={linkGroupName}>
         <TooltipContainer>
           <button
-            style={{ background: `url${linkGroupImage}` }}
+            type="button"
+            style={{ padding: 0, background: "transparent", border: "0", cursor: "pointer" }}
             ref={anchorRef}
             onClick={() => setOpen(true)}
-            type="button"
-            aria-label="expand link group"
-          />
+          >
+            <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
+          </button>
           <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
             {links.map(link => (
               <PopperItem key={link.name}>

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -1,15 +1,26 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Card, Grid, Link, Popper, PopperItem, Tooltip, Typography } from "@clutch-sh/core";
+import {
+  Card,
+  Grid,
+  Link,
+  Popper,
+  PopperItem,
+  Tooltip,
+  TooltipContainer,
+  Typography,
+} from "@clutch-sh/core";
 
 // If only a single link, then no popper is necessary
 const QuickLink = ({ link, linkGroupName, linkGroupImage }) => {
   return (
     <Grid item key={link.name}>
       <Tooltip title={linkGroupName}>
-        <Link href={link.url}>
-          <img width="32px" height="32px" src={linkGroupImage} alt={link.name} />
-        </Link>
+        <TooltipContainer>
+          <Link href={link.url}>
+            <img width="32px" height="32px" src={linkGroupImage} alt={link.name} />
+          </Link>
+        </TooltipContainer>
       </Tooltip>
     </Grid>
   );
@@ -23,7 +34,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
   return (
     <Grid item key={linkGroupName}>
       <Tooltip title={linkGroupName}>
-        <span>
+        <TooltipContainer>
           {/* eslint-disable */}
           <img
             width="32px"
@@ -46,7 +57,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
               );
             })}
           </Popper>
-        </span>
+          </TooltipContainer>
       </Tooltip>
     </Grid>
   );

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -12,7 +12,7 @@ import {
 } from "@clutch-sh/core";
 
 // If only a single link, then no popper is necessary
-const QuickLink = ({ link, linkGroupName, linkGroupImage }) => {
+const QuickLink = ({ link, linkGroupName, linkGroupImage }) => (
   <Grid item key={link.name}>
     <Tooltip title={linkGroupName}>
       <TooltipContainer>
@@ -21,8 +21,8 @@ const QuickLink = ({ link, linkGroupName, linkGroupImage }) => {
         </Link>
       </TooltipContainer>
     </Tooltip>
-  </Grid>;
-};
+  </Grid>
+);
 
 // Have a popper in the case of multiple links per group
 const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
@@ -64,8 +64,7 @@ export interface QuickLinksCardInput {
   linkGroups: IClutch.core.project.v1.ILinkGroup[];
 }
 
-const QuickLinksCard = ({ linkGroups }: QuickLinksCardInput) => {
-  return (
+const QuickLinksCard = ({ linkGroups }: QuickLinksCardInput) => (
     <Card>
       <Grid
         container
@@ -95,7 +94,6 @@ const QuickLinksCard = ({ linkGroups }: QuickLinksCardInput) => {
         })}
       </Grid>
     </Card>
-  );
-};
+);
 
 export default QuickLinksCard;

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -24,7 +24,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
     <Grid item key={linkGroupName}>
       <Tooltip title={linkGroupName}>
         <span>
-          {/* @ts-ignore */}
+          {/* eslint-disable */}
           <img
             width="32px"
             height="32px"
@@ -32,7 +32,6 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
             alt={linkGroupName}
             onClick={() => setOpen(true)}
             ref={anchorRef}
-            role="button"
           />
           <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
             {links.map(link => {

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -13,7 +13,6 @@ import {
 
 // If only a single link, then no popper is necessary
 const QuickLink = ({ link, linkGroupName, linkGroupImage }) => {
-  return (
     <Grid item key={link.name}>
       <Tooltip title={linkGroupName}>
         <TooltipContainer>
@@ -23,7 +22,6 @@ const QuickLink = ({ link, linkGroupName, linkGroupImage }) => {
         </TooltipContainer>
       </Tooltip>
     </Grid>
-  );
 };
 
 // Have a popper in the case of multiple links per group

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -23,13 +23,16 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
   return (
     <Grid item key={linkGroupName}>
       <Tooltip title={linkGroupName}>
-        <>
+        <span>
+          {/* @ts-ignore */}
           <img
             width="32px"
             height="32px"
             src={linkGroupImage}
             alt={linkGroupName}
+            onClick={() => setOpen(true)}
             ref={anchorRef}
+            role="button"
           />
           <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
             {links.map(link => {
@@ -44,7 +47,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
               );
             })}
           </Popper>
-        </>
+        </span>
       </Tooltip>
     </Grid>
   );

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -13,15 +13,15 @@ import {
 
 // If only a single link, then no popper is necessary
 const QuickLink = ({ link, linkGroupName, linkGroupImage }) => {
-    <Grid item key={link.name}>
-      <Tooltip title={linkGroupName}>
-        <TooltipContainer>
-          <Link href={link.url}>
-            <img width="32px" height="32px" src={linkGroupImage} alt={link.name} />
-          </Link>
-        </TooltipContainer>
-      </Tooltip>
-    </Grid>
+  <Grid item key={link.name}>
+    <Tooltip title={linkGroupName}>
+      <TooltipContainer>
+        <Link href={link.url}>
+          <img width="32px" height="32px" src={linkGroupImage} alt={link.name} />
+        </Link>
+      </TooltipContainer>
+    </Tooltip>
+  </Grid>;
 };
 
 // Have a popper in the case of multiple links per group

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -34,22 +34,12 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }) => {
     <Grid item key={linkGroupName}>
       <Tooltip title={linkGroupName}>
         <TooltipContainer>
-          {/* 
-            We are disabling lint here until we come up with a better solution than putting the onClic() inside the <img> 
-
-            error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
-            error  Non-interactive elements should not be assigned mouse or keyboard event listeners               jsx-a11y/no-noninteractive-element-interactions
-
-            TODO: don't disable it.
-          */}
-          {/* eslint-disable */}
-          <img
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-            src={linkGroupImage}
-            alt={linkGroupName}
-            onClick={() => setOpen(true)}
+          <button
+            style={{ background: `url${linkGroupImage}` }}
             ref={anchorRef}
+            onClick={() => setOpen(true)}
+            type="button"
+            aria-label="expand link group"
           />
           <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
             {links.map(link => (
@@ -79,7 +69,7 @@ const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => (
       direction="column"
       alignItems="center"
       spacing={1}
-      style={{ padding: "10px 0" }}
+      style={{ padding: "8px" }}
     >
       {linkGroups?.map(linkGroup => {
         if (linkGroup.links?.length === 1) {

--- a/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
@@ -17,7 +17,7 @@ const QuickLinks = (project: IClutch.core.project.v1.IProject) => {
         {project?.linkGroups?.map(linkGroup => {
           return linkGroup.links?.map(link => {
             return (
-              <Grid item key={link.id}>
+              <Grid item key={link.name}>
                 <Link
                   to={link.url}
                   style={{
@@ -25,7 +25,7 @@ const QuickLinks = (project: IClutch.core.project.v1.IProject) => {
                     color: "inherit",
                   }}
                 >
-                  <img src={link.imagePath} alt={link.name} />
+                  <img src={linkGroup.imagePath} alt={link.name} />
                 </Link>
               </Grid>
             );

--- a/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
@@ -25,7 +25,7 @@ const QuickLinks = (project: IClutch.core.project.v1.IProject) => {
                     color: "inherit",
                   }}
                 >
-                  <img src={linkGroup.imagePath} alt={link.name} />
+                  <img width="29px" height="29px" src={linkGroup.imagePath} alt={link.name} />
                 </Link>
               </Grid>
             );

--- a/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { Card, Grid } from "@clutch-sh/core";
+
+const QuickLinks = (project: IClutch.core.project.v1.IProject) => {
+  return (
+    <Card>
+      <Grid
+        container
+        item
+        direction="column"
+        alignItems="center"
+        spacing={1}
+        style={{ padding: "7px 0" }}
+      >
+        {project?.linkGroups?.map(linkGroup => {
+          return linkGroup.links?.map(link => {
+            return (
+              <Grid item key={link.id}>
+                <Link
+                  to={link.url}
+                  style={{
+                    textDecoration: "none",
+                    color: "inherit",
+                  }}
+                >
+                  <img src={link.imagePath} alt={link.name} />
+                </Link>
+              </Grid>
+            );
+          });
+        })}
+      </Grid>
+    </Card>
+  );
+};
+
+export default QuickLinks;

--- a/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quickLinks.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { Card, Grid } from "@clutch-sh/core";
 
-const QuickLinks = (project: IClutch.core.project.v1.IProject) => {
+const QuickLinks = (linkGroups: IClutch.core.project.v1.ILinkGroup[]) => {
   return (
     <Card>
       <Grid
@@ -14,17 +14,11 @@ const QuickLinks = (project: IClutch.core.project.v1.IProject) => {
         spacing={1}
         style={{ padding: "7px 0" }}
       >
-        {project?.linkGroups?.map(linkGroup => {
+        {linkGroups?.map(linkGroup => {
           return linkGroup.links?.map(link => {
             return (
               <Grid item key={link.name}>
-                <Link
-                  to={link.url}
-                  style={{
-                    textDecoration: "none",
-                    color: "inherit",
-                  }}
-                >
+                <Link to={link.url}>
                   <img width="29px" height="29px" src={linkGroup.imagePath} alt={link.name} />
                 </Link>
               </Grid>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Adds support for images to the quick links.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
<img width="675" alt="Screen Shot 2022-03-29 at 12 57 18 PM" src="https://user-images.githubusercontent.com/66325812/160700489-af8b1502-abcf-4583-933d-ea444b404870.png">

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
