### PR TITLE
github: fix commit author email field

### DIFF
--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -314,7 +314,7 @@ func commitOptionsFromClaims(ctx context.Context) *git.CommitOptions {
 	if strings.Contains(subject, "@") {
 		email = subject
 	}
-	ret.Author.Email = fmt.Sprintf("<%s>", email)
+	ret.Author.Email = email
 
 	return ret
 }
@@ -358,6 +358,7 @@ func (s *svc) CreateBranch(ctx context.Context, req *CreateBranchRequest) error 
 	}
 
 	opts := commitOptionsFromClaims(ctx)
+	s.logger.Info(fmt.Sprintf("Commit author: %s", opts.Author.String()))
 	if _, err := wt.Commit(req.CommitMessage, opts); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
To fix github malformed unpack issue tracked in https://jira.lyft.net/browse/INFRAHELP-12243, extra formatting added in commit author email field from new added commit option. The fix works in local test with subject set as dev email (instead of the empty authn.ClaimsFromContext).