### PR TITLE
frontend: fix padding of quick links on project catalog details

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -107,7 +107,7 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
     <ProjectDetailsContext.Provider value={{ projectInfo }}>
       <StyledContainer container direction="row" wrap="nowrap">
         {/* Column for project details and header */}
-        <Grid item direction="column" xs={12} sm={12} md={12} lg={11} xl={11}>
+        <Grid item direction="column" xs={12} sm={12} md={12} lg={12} xl={12}>
           <StyledHeadingContainer item>
             {/* Static Header */}
             <ProjectHeader
@@ -160,7 +160,7 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
         </Grid>
         {/* Column for project quick links */}
         <Hidden smDown>
-          <Grid item direction="column" lg={1} xl={1}>
+          <Grid item direction="column">
             {projectInfo && <QuickLinksCard linkGroups={projectInfo?.linkGroups ?? []} />}
           </Grid>
         </Hidden>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Removes unused space in project catalog details page quick links card
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screenshot from 2022-03-30 17-29-48](https://user-images.githubusercontent.com/1004789/160952658-915f0856-6874-43b3-bda1-73f59b168ff9.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual