### PR TITLE
github: set commit time and auto stage modified and deleted files

### DIFF
--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -299,8 +299,8 @@ type CreateBranchRequest struct {
 	SingleBranch bool
 }
 
-func commitOptionsFromClaims(ctx context.Context) *git.CommitOptions {
-	ret := &git.CommitOptions{Author: &object.Signature{}}
+func commitOptionsFromClaims(ctx context.Context, commitTime time.Time) *git.CommitOptions {
+	ret := &git.CommitOptions{Author: &object.Signature{When: commitTime}, All: true}
 
 	subject := "Anonymous User" // Used if auth is disabled or it's the actual anonymous user.
 	if claims, err := authn.ClaimsFromContext(ctx); err == nil && claims.Subject != authn.AnonymousSubject {
@@ -357,7 +357,7 @@ func (s *svc) CreateBranch(ctx context.Context, req *CreateBranchRequest) error 
 		}
 	}
 
-	opts := commitOptionsFromClaims(ctx)
+	opts := commitOptionsFromClaims(ctx, time.Now())
 	if _, err := wt.Commit(req.CommitMessage, opts); err != nil {
 		return err
 	}

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -837,10 +837,13 @@ func TestNewService(t *testing.T) {
 func TestCommitAuthorFromContext(t *testing.T) {
 	ctx := context.Background()
 	ctx = authn.ContextWithAnonymousClaims(ctx)
+	commitTime := time.Now()
 
-	result := commitOptionsFromClaims(ctx)
+	result := commitOptionsFromClaims(ctx, commitTime)
 	assert.Equal(t, "Anonymous User via Clutch", result.Author.Name)
 	assert.Equal(t, "", result.Author.Email)
+	assert.Equal(t, commitTime, result.Author.When)
+	assert.Equal(t, true, result.All)
 
 	ctx = authn.ContextWithClaims(ctx, &authn.Claims{
 		StandardClaims: &jwt.StandardClaims{
@@ -848,9 +851,12 @@ func TestCommitAuthorFromContext(t *testing.T) {
 		},
 	})
 
-	result = commitOptionsFromClaims(ctx)
+	commitTime = time.Now()
+	result = commitOptionsFromClaims(ctx, commitTime)
 	assert.Equal(t, "daniel@example.com via Clutch", result.Author.Name)
 	assert.Equal(t, "daniel@example.com", result.Author.Email)
+	assert.Equal(t, commitTime, result.Author.When)
+	assert.Equal(t, true, result.All)
 
 	ctx = authn.ContextWithClaims(ctx, &authn.Claims{
 		StandardClaims: &jwt.StandardClaims{
@@ -858,7 +864,10 @@ func TestCommitAuthorFromContext(t *testing.T) {
 		},
 	})
 
-	result = commitOptionsFromClaims(ctx)
+	commitTime = time.Now()
+	result = commitOptionsFromClaims(ctx, commitTime)
 	assert.Equal(t, "daniel123 via Clutch", result.Author.Name)
 	assert.Equal(t, "", result.Author.Email)
+	assert.Equal(t, commitTime, result.Author.When)
+	assert.Equal(t, true, result.All)
 }


### PR DESCRIPTION
### Description
The change is to enable the flag to automatically stage modified and deleted files. It also set commit time that is missed in commit option.

Previous related PRs:

- [github: add author information to branch creation](https://github.com/lyft/clutch/pull/2148)

- [github: fix commit author email field](https://github.com/lyft/clutch/pull/2155)

### Testing Performed
local

### GitHub Issue
Fixes #

### TODOs
