### PR TITLE
ProjectCatalog: Adding chevron identifying a chip with a link

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/info/chipsRow.tsx
+++ b/frontend/workflows/projectCatalog/src/details/info/chipsRow.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { CHIP_VARIANTS } from "@clutch-sh/core";
 import { Chip, Grid, Link, Tooltip } from "@clutch-sh/core";
+import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 
 export interface ProjectInfoChip {
   text: string;
@@ -13,13 +14,17 @@ export interface ProjectInfoChip {
 const ChipsRow = ({ chips = [] }: { chips: ProjectInfoChip[] }) => (
   <>
     {chips.map(({ variant = "neutral", text, icon, title, url }) => {
-      const chipElem = <Chip variant={variant} label={text} size="small" icon={icon} />;
-      return (
-        <Grid item>
-          <Tooltip title={title ?? text}>
-            {url ? <Link href={url}>{chipElem}</Link> : chipElem}
-          </Tooltip>
+      const chipText = (
+        <Grid container direction="row" wrap="nowrap">
+          {text}
+          {url && <ChevronRightIcon fontSize="small" style={{ marginRight: "-12px" }} />}
         </Grid>
+      );
+      const chipElem = <Chip variant={variant} label={chipText} size="small" icon={icon} />;
+      return (
+        <Tooltip title={title ?? text}>
+          <Grid item>{url ? <Link href={url}>{chipElem}</Link> : chipElem}</Grid>
+        </Tooltip>
       );
     })}
   </>


### PR DESCRIPTION
### Description
- Adds a chevron icon to indicate a chip has a link and is clickable

#### Before
<img width="529" alt="Screen Shot 2022-04-04 at 3 58 24 PM" src="https://user-images.githubusercontent.com/8338893/161646200-0cf2e894-2bdd-4ca6-a293-b4978c712324.png">

#### After
<img width="478" alt="Screen Shot 2022-04-04 at 3 58 00 PM" src="https://user-images.githubusercontent.com/8338893/161646208-79f1eebc-6f24-453c-b0cc-80e4cca549d2.png">

#### Without Negative Margin
<img width="134" alt="Screen Shot 2022-04-04 at 4 01 43 PM" src="https://user-images.githubusercontent.com/8338893/161646302-8bfebf89-1e1f-4743-99a1-3a3aaabe3a50.png">

### Testing Performed
manual
