### PR TITLE
catalog: add language title and plural

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/info/languageRow.tsx
+++ b/frontend/workflows/projectCatalog/src/details/info/languageRow.tsx
@@ -6,7 +6,7 @@ import LanguageIcon from "../../helpers/language-icon";
 const LanguageRow = ({ languages }: { languages: string[] }) => (
   <>
     <Grid item>
-      <Typography variant="body2">Language</Typography>
+      <Typography variant="body2">Language{languages.length > 1 && "s"}</Typography>
     </Grid>
     {languages.map(language => (
       <Grid item>

--- a/frontend/workflows/projectCatalog/src/helpers/language-icon.tsx
+++ b/frontend/workflows/projectCatalog/src/helpers/language-icon.tsx
@@ -9,30 +9,38 @@ interface LanguageIconProps extends Pick<FontAwesomeIconProps, "size"> {
 
 const LanguageIcon = ({ language, size = "lg", ...props }: LanguageIconProps) => {
   let icon;
+  let title;
   switch (language) {
     case "python":
       icon = faPython;
+      title = "Python";
       break;
     case "go":
       icon = faGolang;
+      title = "Golang";
       break;
     case "bash":
       icon = faTerminal;
+      title = "Shell";
       break;
     case "javascript":
       icon = faJs;
+      title = "JavaScript";
       break;
     case "java":
       icon = faJava;
+      title = "Java";
       break;
     case "rust":
       icon = faRust;
+      title = "Rust";
       break;
     default:
       icon = faGear;
+      title = "None detected";
   }
 
-  return <FontAwesomeIcon icon={icon} size={size} {...props} />;
+  return <FontAwesomeIcon title={title} icon={icon} size={size} {...props} />;
 };
 
 export default LanguageIcon;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Add alt text to the language icons since they're not the easiest thing to decipher. Also make "Language" plural when two or more languages are listed on the details card.