### PR TITLE
frontend: disable end adornment when no value in text field

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -219,6 +219,14 @@ const TextField = ({
     );
   }
 
+  // We maintain a defaultVal to prevent the value from changing from underneath
+  // the component. This is required because autocomplete is uncontrolled.
+  const [defaultVal] = React.useState<string>((defaultValue as string) || "");
+  const [autoCompleteOptions, setAutoCompleteOptions] = React.useState<AutocompleteResultProps[]>(
+    []
+  );
+
+  const isEmpty = (defaultValue === undefined || defaultValue === "") && value === "";
   const textFieldProps = {
     onKeyDown,
     onFocus: onChange,
@@ -227,16 +235,10 @@ const TextField = ({
     helperText: helpText,
     InputProps: {
       readOnly,
-      endAdornment: endAdornment && <IconButton type="submit">{endAdornment}</IconButton>,
+      endAdornment: endAdornment && <IconButton type="submit" disabled={isEmpty}>{endAdornment}</IconButton>,
     },
   };
 
-  // We maintain a defaultVal to prevent the value from changing from underneath
-  // the component. This is required because autocomplete is uncontrolled.
-  const [defaultVal] = React.useState<string>((defaultValue as string) || "");
-  const [autoCompleteOptions, setAutoCompleteOptions] = React.useState<AutocompleteResultProps[]>(
-    []
-  );
   const autoCompleteDebounce = React.useRef(
     _.debounce(val => {
       if (autocompleteCallback !== undefined) {

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -235,7 +235,11 @@ const TextField = ({
     helperText: helpText,
     InputProps: {
       readOnly,
-      endAdornment: endAdornment && <IconButton type="submit" disabled={isEmpty}>{endAdornment}</IconButton>,
+      endAdornment: endAdornment && (
+        <IconButton type="submit" disabled={isEmpty}>
+          {endAdornment}
+        </IconButton>
+      ),
     },
   };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
disable the end adornment for text fields when no value is present in the field

<!-- Reference previous related pull requests below. -->

![Screenshot from 2022-04-05 14-16-18](https://user-images.githubusercontent.com/1004789/161850626-38c00528-3dc5-4682-9d0c-0145d7dddff6.png)

![Screenshot from 2022-04-05 14-16-32](https://user-images.githubusercontent.com/1004789/161850652-704a708c-a3a1-48b3-8b58-16d35a8fe14b.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual