### PR TITLE
frontend: move error to text field in project catalog search

### DIFF
--- a/frontend/workflows/projectCatalog/src/catalog/catalog-reducer.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/catalog-reducer.tsx
@@ -13,13 +13,10 @@ const catalogReducer = (state: CatalogState, action: Action): CatalogState => {
       return { ...state, search: action?.payload?.search };
     }
     case "SEARCH_START": {
-      return { ...state, isSearching: true };
+      return { ...state, error: undefined, isSearching: true };
     }
     case "SEARCH_END": {
       return { ...state, search: "", isSearching: false };
-    }
-    case "CLEAR_ERROR": {
-      return { ...state, error: undefined };
     }
     case "HYDRATE_START": {
       return { ...state, isLoading: true };

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { client, Grid, Paper, TextField, Toast, Typography, useNavigate } from "@clutch-sh/core";
+import { client, Grid, Paper, TextField, Typography, useNavigate } from "@clutch-sh/core";
 import { Box, CircularProgress } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
 

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -100,6 +100,8 @@ const Catalog: React.FC<WorkflowProps> = ({ heading }) => {
                 <SearchIcon onClick={triggerProjectAdd} />
               )
             }
+            error={state.error !== undefined}
+            helperText={state?.error}
           />
         </div>
       </Paper>
@@ -113,11 +115,6 @@ const Catalog: React.FC<WorkflowProps> = ({ heading }) => {
           </Grid>
         ))}
       </Grid>
-      {state.error && (
-        <Toast severity="error" onClose={() => dispatch({ type: "CLEAR_ERROR" })}>
-          {state.error}
-        </Toast>
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Move error to text field helper text when project catalog search fails

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screenshot from 2022-04-05 15-14-34](https://user-images.githubusercontent.com/1004789/161859947-e5afae38-5dee-493c-b818-846b955ae427.png)


### Testing Performed
<!-- Describe how you tested this change below. -->
manual