### PR TITLE
frontend: remove ability to remove users default project in catalog index

### DIFF
--- a/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import type { clutch as IClutch } from "@clutch-sh/api";
 import { Card, Grid, IconButton, Typography } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import CloseIcon from "@material-ui/icons/Close";
 
 import LanguageIcon from "../helpers/language-icon";
+
+import type { CatalogProject } from "./types";
 
 const StyledCard = styled(Card)({
   width: "384px",
@@ -26,7 +27,7 @@ const StyledCard = styled(Card)({
 });
 
 interface ProjectCardProps {
-  project: IClutch.core.project.v1.IProject;
+  project: CatalogProject;
   onRemove: () => void;
 }
 
@@ -40,9 +41,11 @@ const ProjectCard = ({ project, onRemove }: ProjectCardProps) => {
     <StyledCard>
       <Grid container justify="flex-end">
         <Grid item className="remove">
-          <IconButton size="small" variant="neutral" onClick={remove}>
-            <CloseIcon />
-          </IconButton>
+          {project.removable && (
+            <IconButton size="small" variant="neutral" onClick={remove}>
+              <CloseIcon />
+            </IconButton>
+          )}
         </Grid>
       </Grid>
       <Grid container wrap="nowrap">

--- a/frontend/workflows/projectCatalog/src/catalog/types.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/types.tsx
@@ -1,6 +1,10 @@
 import type { clutch as IClutch } from "@clutch-sh/api";
 import type { ClutchError } from "@clutch-sh/core";
 
+export interface CatalogProject extends IClutch.core.project.v1.IProject {
+  removable?: boolean;
+}
+
 type UserActionKind = "ADD_PROJECT" | "CLEAR_ERROR" | "REMOVE_PROJECT" | "SEARCH";
 
 interface UserPayload {
@@ -31,7 +35,7 @@ interface BackgroundAction {
 
 export type Action = UserAction | BackgroundAction;
 export interface CatalogState {
-  projects: IClutch.core.project.v1.IProject[];
+  projects: CatalogProject[];
   search?: string;
   isLoading: boolean;
   isSearching: boolean;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Change the behavior of project catalog index to prevent users from removing the default set of services they own.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual