### PR TITLE
frontend: allow users to reset project catalog index state

### DIFF
--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -1,13 +1,23 @@
 import React from "react";
-import { client, Grid, Paper, TextField, Toast, Typography, useNavigate } from "@clutch-sh/core";
+import {
+  client,
+  Grid,
+  IconButton,
+  Paper,
+  TextField,
+  Toast,
+  Typography,
+  useNavigate,
+} from "@clutch-sh/core";
 import { Box, CircularProgress } from "@material-ui/core";
+import RestoreIcon from "@material-ui/icons/Restore";
 import SearchIcon from "@material-ui/icons/Search";
 
 import type { WorkflowProps } from "..";
 
 import catalogReducer from "./catalog-reducer";
 import ProjectCard from "./project-card";
-import { addProject, getProjects, removeProject } from "./storage";
+import { addProject, clearProjects, getProjects, removeProject } from "./storage";
 import type { CatalogState } from "./types";
 
 const initialState: CatalogState = {
@@ -103,13 +113,36 @@ const Catalog: React.FC<WorkflowProps> = ({ heading }) => {
           />
         </div>
       </Paper>
-      <div style={{ marginBottom: "16px", marginTop: "32px" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: "16px",
+          marginTop: "32px",
+        }}
+      >
         <Typography variant="h3">My Projects</Typography>
+        <IconButton
+          variant="neutral"
+          onClick={() => {
+            clearProjects();
+            dispatch({ type: "HYDRATE_START" });
+            getProjects(
+              projects => dispatch({ type: "HYDRATE_END", payload: { result: projects } }),
+              setError
+            );
+          }}
+        >
+          <RestoreIcon />
+        </IconButton>
       </div>
       <Grid container direction="row" spacing={5}>
         {state.projects.map(p => (
           <Grid item onClick={() => navigateToProject(p)}>
-            <ProjectCard project={p} onRemove={() => triggerProjectRemove(p)} />
+            <ProjectCard
+              project={p}
+              onRemove={state.projects.length !== 1 ? () => triggerProjectRemove(p) : undefined}
+            />
           </Grid>
         ))}
       </Grid>

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -34,7 +34,7 @@ const Placeholder = () => (
   <Paper>
     <div style={{ margin: "32px", textAlign: "center" }}>
       <Typography variant="h5">There is nothing to display here</Typography>
-      <Typography variant="body3">Please enter a namespace and clientset to proceed.</Typography>
+      <Typography variant="body3">Please enter a project to proceed.</Typography>
     </div>
   </Paper>
 );

--- a/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
@@ -23,23 +23,28 @@ const StyledCard = styled(Card)({
   ".remove": {
     visibility: "hidden",
   },
+  ".hidden": {
+    visibility: "hidden",
+  },
 });
 
 interface ProjectCardProps {
   project: IClutch.core.project.v1.IProject;
-  onRemove: () => void;
+  onRemove?: () => void;
 }
 
 const ProjectCard = ({ project, onRemove }: ProjectCardProps) => {
   const remove = event => {
     event.stopPropagation();
-    onRemove();
+    if (onRemove) {
+      onRemove();
+    }
   };
 
   return (
     <StyledCard>
       <Grid container justify="flex-end">
-        <Grid item className="remove">
+        <Grid item className={!onRemove ? "hidden" : "remove"}>
           <IconButton size="small" variant="neutral" onClick={remove}>
             <CloseIcon />
           </IconButton>

--- a/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
@@ -23,28 +23,23 @@ const StyledCard = styled(Card)({
   ".remove": {
     visibility: "hidden",
   },
-  ".hidden": {
-    visibility: "hidden",
-  },
 });
 
 interface ProjectCardProps {
   project: IClutch.core.project.v1.IProject;
-  onRemove?: () => void;
+  onRemove: () => void;
 }
 
 const ProjectCard = ({ project, onRemove }: ProjectCardProps) => {
   const remove = event => {
     event.stopPropagation();
-    if (onRemove) {
-      onRemove();
-    }
+    onRemove();
   };
 
   return (
     <StyledCard>
       <Grid container justify="flex-end">
-        <Grid item className={!onRemove ? "hidden" : "remove"}>
+        <Grid item className="remove">
           <IconButton size="small" variant="neutral" onClick={remove}>
             <CloseIcon />
           </IconButton>

--- a/frontend/workflows/projectCatalog/src/catalog/storage.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/storage.tsx
@@ -20,17 +20,23 @@ const loadProjects = (): { [key: string]: string } => {
   }
 };
 
+const hasState = (): boolean => {
+  const storedProjects = window.localStorage.getItem(LOCAL_STORAGE_STATE_KEY);
+  return !(storedProjects === null || storedProjects === undefined);
+};
+
 const writeProjects = (projects: { [key: string]: string }) => {
   window.localStorage.setItem(LOCAL_STORAGE_STATE_KEY, JSON.stringify(projects));
 };
 
-const projectRequest = () => {
+const projectRequest = (includeOwned: boolean) => {
   const projects = loadProjects();
-  const requestData = { excludeDependencies: true } as IClutch.project.v1.GetProjectsRequest;
-  if (!Object.keys(projects).length) {
+  const requestData = {
+    excludeDependencies: true,
+    projects: Object.keys(projects),
+  } as IClutch.project.v1.GetProjectsRequest;
+  if (includeOwned) {
     requestData.users = [userId()];
-  } else {
-    requestData.projects = Object.keys(projects);
   }
   return requestData;
 };
@@ -38,10 +44,11 @@ const projectRequest = () => {
 const fetchProjects = (
   onSuccess: (pjts: IClutch.core.project.v1.IProject[]) => void,
   onError: (e: ClutchError) => void,
-  retry: number
+  retry: number,
+  includeOwned: boolean = true
 ) => {
   client
-    .post("/v1/project/getProjects", projectRequest())
+    .post("/v1/project/getProjects", projectRequest(includeOwned))
     .then(resp => {
       const { results } = resp.data as IClutch.project.v1.GetProjectsResponse;
       const selectedProjects = Object.values(results)
@@ -89,12 +96,13 @@ const fetchProjects = (
 
 const getProjects = (
   onSuccess: (pjts: IClutch.core.project.v1.IProject[]) => void,
-  onError: (e: ClutchError) => void
+  onError: (e: ClutchError) => void,
+  includeOwned: boolean = false
 ) => {
   // retry count is set to the number of projects in storage since potentially
   // all projects are invalid.
   const retryCount = Object.keys(loadProjects()).length;
-  fetchProjects(onSuccess, onError, retryCount);
+  fetchProjects(onSuccess, onError, retryCount, includeOwned);
 };
 
 /** Add a project to local storage. */
@@ -125,11 +133,11 @@ const removeProject = (
     delete storedProjects[project];
     writeProjects(storedProjects);
   }
-  getProjects(onSuccess, onError);
+  getProjects(onSuccess, onError, false);
 };
 
 const clearProjects = () => {
   writeProjects({});
 };
 
-export { addProject, clearProjects, getProjects, removeProject };
+export { addProject, clearProjects, getProjects, hasState, removeProject };

--- a/frontend/workflows/projectCatalog/src/catalog/storage.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/storage.tsx
@@ -128,4 +128,8 @@ const removeProject = (
   getProjects(onSuccess, onError);
 };
 
-export { addProject, getProjects, removeProject };
+const clearProjects = () => {
+  writeProjects({});
+};
+
+export { addProject, clearProjects, getProjects, removeProject };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add ability to reset default state of project catalog index. This continues to allow users to remove all projects (even the ones they own). If all projects have been removed users will see a placeholder (see below). On initial load (e.g. no existing state) we will fetch all the projects a users owns.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screenshot from 2022-04-05 20-14-34](https://user-images.githubusercontent.com/1004789/161889295-ee566a97-2f87-44bf-af7a-ed4588d3911d.png)

![Screenshot from 2022-04-05 20-14-51](https://user-images.githubusercontent.com/1004789/161889310-532cec0c-126c-4c32-bee8-07c761f3005f.png)

![Screenshot from 2022-04-08 09-08-29](https://user-images.githubusercontent.com/1004789/162486956-686eb3da-6404-4b3d-b5f7-792555d29f8c.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
