### PR TITLE
aws: add direct client access

### DIFF
--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -25,6 +25,10 @@ import (
 
 type svc struct{}
 
+func (s *svc) GetDirectClient(account string, region string) (clutchawsclient.DirectClient, error) {
+	panic("implement me")
+}
+
 func (s *svc) DescribeKinesisStream(ctx context.Context, account, region, streamName string) (*kinesisv1.Stream, error) {
 	ret := &kinesisv1.Stream{
 		StreamName:        streamName,

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -189,6 +189,18 @@ type Client interface {
 	GetAccountsInRegion(region string) []string
 	GetPrimaryAccountAlias() string
 	Regions() []string
+
+	GetDirectClient(account string, region string) (DirectClient, error)
+}
+
+type DirectClient interface {
+	Autoscaling() *autoscaling.Client
+	DynamoDB() *dynamodb.Client
+	EC2() *ec2.Client
+	IAM() *iam.Client
+	Kinesis() *kinesis.Client
+	S3() *s3.Client
+	STS() *sts.Client
 }
 
 type client struct {
@@ -205,13 +217,41 @@ type regionalClient struct {
 
 	dynamodbCfg *awsv1.DynamodbConfig
 
-	s3          s3Client
-	kinesis     kinesisClient
-	ec2         ec2Client
 	autoscaling autoscalingClient
 	dynamodb    dynamodbClient
-	sts         stsClient
+	ec2         ec2Client
 	iam         iamClient
+	kinesis     kinesisClient
+	s3          s3Client
+	sts         stsClient
+}
+
+func (r *regionalClient) Autoscaling() *autoscaling.Client {
+	return r.autoscaling.(*autoscaling.Client)
+}
+
+func (r *regionalClient) DynamoDB() *dynamodb.Client {
+	return r.dynamodb.(*dynamodb.Client)
+}
+
+func (r *regionalClient) EC2() *ec2.Client {
+	return r.ec2.(*ec2.Client)
+}
+
+func (r *regionalClient) IAM() *iam.Client {
+	return r.iam.(*iam.Client)
+}
+
+func (r *regionalClient) Kinesis() *kinesis.Client {
+	return r.kinesis.(*kinesis.Client)
+}
+
+func (r *regionalClient) S3() *s3.Client {
+	return r.s3.(*s3.Client)
+}
+
+func (r *regionalClient) STS() *sts.Client {
+	return r.sts.(*sts.Client)
 }
 
 type accountClients struct {
@@ -219,6 +259,10 @@ type accountClients struct {
 	regions []string
 
 	clients map[string]*regionalClient
+}
+
+func (c *client) GetDirectClient(account string, region string) (DirectClient, error) {
+	return c.getAccountRegionClient(account, region)
 }
 
 // Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -193,6 +193,11 @@ type Client interface {
 	GetDirectClient(account string, region string) (DirectClient, error)
 }
 
+// DirectClient gives access to the underlying AWS clients from the Golang SDK.
+// This allows arbitrary feature development on top of AWS from other services and modules without having to
+// contribute to the upstream interface. Using these clients will make mocking extremely difficult since it returns the
+// AWS SDK's struct types and not an interface that can be substituted for. It is recommended following initial
+// development of a feature that you add the calls to a service interface so they can be tested more easily.
 type DirectClient interface {
 	Autoscaling() *autoscaling.Client
 	DynamoDB() *dynamodb.Client

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"testing"
 	"time"
 
@@ -625,4 +626,12 @@ func (ma mockAutoscaling) UpdateAutoScalingGroup(ctx context.Context, params *au
 	}
 
 	return &autoscaling.UpdateAutoScalingGroupOutput{}, nil
+}
+
+func TestRegionalClient(t *testing.T) {
+	c := &s3.Client{}
+
+	r := &regionalClient{s3: c}
+
+	assert.Equal(t, c, r.S3())
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Adds direct client access for AWS account/region clients, which may be needed if someone wants to do implement some custom logic with AWS clients that does not makes sense to put in the upstream client.

### Testing Performed
Unit

### TODOs
- [x] Unit tests