### PR TITLE
FE: Project Selector: Add Quick Links

### DIFF
--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -222,7 +222,10 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                 </StyledClearIcon>
               </StyledHoverOptions>
               {!state?.loading && state?.projectData?.[key]?.linkGroups && (
-                <ProjectLinks linkGroups={state?.projectData?.[key]?.linkGroups} name={[key]} />
+                <ProjectLinks
+                  linkGroups={state?.projectData?.[key]?.linkGroups ?? []}
+                  name={[key]}
+                />
               )}
             </StyledMenuItem>
           ))}

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -36,8 +36,9 @@ const StyledCount = styled.span({
   display: "inline-block",
 });
 
+// This div used to have `padding: "0 25px 0 8px"` but that made it look weird when we implemented quicklinks
+// because the "only" and "x" buttons are hidden when the popper is expanded and mouse is no longer hovering.
 const StyledMenuItem = styled.div({
-  padding: "0 25px 0 8px",
   height: "48px",
   display: "flex",
   alignItems: "center",
@@ -123,6 +124,10 @@ const StyledHoverOptions = styled.div({
   alignItems: "center",
 });
 
+const StyledFlexEnd = styled.div({
+  justifyContent: "right",
+  flexDirection: "row-reverse",
+});
 interface ProjectGroupProps {
   title: string;
   group: Group;
@@ -134,6 +139,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
   const state = useReducerState();
 
   const [collapsed, setCollapsed] = React.useState(false);
+  const [keyWithQLinksOpen, setKeyWithQLinksOpen] = React.useState("");
 
   const groupKeys = Object.keys(state?.[group] ?? {});
   const numProjects = groupKeys.length;
@@ -219,10 +225,16 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                     </IconButton>
                   )}
                 </StyledClearIcon>
-                {state?.projectData?.key?.linkGroups && (
-                  <ProjectLinks linkGroups={state?.projectData?.key?.linkGroups} />
-                )}
               </StyledHoverOptions>
+              <StyledFlexEnd hidden={key !== keyWithQLinksOpen}>
+                {state?.projectData?.key?.linkGroups && (
+                  <ProjectLinks
+                    linkGroups={state?.projectData?.key?.linkGroups}
+                    name={key}
+                    setVisibleFn={setKeyWithQLinksOpen}
+                  />
+                )}
+              </StyledFlexEnd>
             </StyledMenuItem>
           ))}
         </div>

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -7,7 +7,7 @@ import ClearIcon from "@material-ui/icons/Clear";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
-import { ProjectLinks } from "./project-links";
+import ProjectLinks from "./project-links";
 import type { Group } from "./types";
 
 const StyledGroup = styled.div({

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -7,6 +7,7 @@ import ClearIcon from "@material-ui/icons/Clear";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
+import { ProjectLinks } from "./project-links";
 import type { Group } from "./types";
 
 const StyledGroup = styled.div({
@@ -87,7 +88,7 @@ const StyledMenuItemName = styled.span({
 });
 
 const StyledClearIcon = styled.span({
-  width: "24px",
+  width: "36px",
   ".MuiIconButton-root": {
     padding: "6px",
     color: "rgba(13, 16, 48, 0.38)",
@@ -218,6 +219,9 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                     </IconButton>
                   )}
                 </StyledClearIcon>
+                {state?.projectData?.key?.linkGroups && (
+                  <ProjectLinks linkGroups={state?.projectData?.key?.linkGroups} />
+                )}
               </StyledHoverOptions>
             </StyledMenuItem>
           ))}

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -221,7 +221,7 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                   )}
                 </StyledClearIcon>
               </StyledHoverOptions>
-              {state?.projectData?.[key]?.linkGroups && (
+              {!state?.loading && state?.projectData?.[key]?.linkGroups && (
                 <ProjectLinks linkGroups={state?.projectData?.[key]?.linkGroups} name={[key]} />
               )}
             </StyledMenuItem>

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -124,10 +124,6 @@ const StyledHoverOptions = styled.div({
   alignItems: "center",
 });
 
-const StyledFlexEnd = styled.div({
-  justifyContent: "right",
-  flexDirection: "row-reverse",
-});
 interface ProjectGroupProps {
   title: string;
   group: Group;
@@ -139,7 +135,6 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
   const state = useReducerState();
 
   const [collapsed, setCollapsed] = React.useState(false);
-  const [keyWithQLinksOpen, setKeyWithQLinksOpen] = React.useState("");
 
   const groupKeys = Object.keys(state?.[group] ?? {});
   const numProjects = groupKeys.length;
@@ -226,15 +221,9 @@ const ProjectGroup: React.FC<ProjectGroupProps> = ({ title, group, displayToggle
                   )}
                 </StyledClearIcon>
               </StyledHoverOptions>
-              <StyledFlexEnd hidden={key !== keyWithQLinksOpen}>
-                {state?.projectData?.key?.linkGroups && (
-                  <ProjectLinks
-                    linkGroups={state?.projectData?.key?.linkGroups}
-                    name={key}
-                    setVisibleFn={setKeyWithQLinksOpen}
-                  />
-                )}
-              </StyledFlexEnd>
+              {state?.projectData?.[key]?.linkGroups && (
+                <ProjectLinks linkGroups={state?.projectData?.[key]?.linkGroups} name={[key]} />
+              )}
             </StyledMenuItem>
           ))}
         </div>

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -186,6 +186,10 @@ const ProjectLinks = ({ linkGroups, name }: ProjectLinksProps) => {
   const [open, setOpen] = React.useState(false);
   const [keyWithQLinksOpen, setKeyWithQLinksOpen] = React.useState("");
 
+  if (linkGroups.length === 0) {
+    return null;
+  }
+
   return (
     <StyledFlexEnd hidden={name?.[0] !== keyWithQLinksOpen}>
       <StyledMoreVertIcon>

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -10,7 +10,7 @@ interface LinkGroupProps {
   linkGroupImage: string;
 }
 
-const ICON_SIZE = "22px";
+const ICON_SIZE = "16px";
 
 const StyledMenuItem = styled.div({
   display: "flex",
@@ -52,11 +52,21 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
   // In the case where there is only a singe link in the group, we make the title clickable.
   // In the case where there are multiple links, the title is not clickable and has different styling.
   return links.length === 1 ? (
-    <StyledMenuItem style={{ padding: "8px" }} key={links[0].url} />
+    <StyledMenuItem style={{ padding: "8px" }} key={links[0].url}>
+      <Link href={links[0]?.url ?? ""}>
+        <img
+          width={ICON_SIZE}
+          height={ICON_SIZE}
+          src={linkGroupImage}
+          alt={links[0].name ?? `Quick Link to ${links[0].url}`}
+        />
+        <StyledLinkTitle style={{ paddingLeft: "6px" }}>{linkGroupName}</StyledLinkTitle>
+      </Link>
+    </StyledMenuItem>
   ) : (
     <div>
       <div style={{ display: "flex", alignItems: "center" }}>
-        <div style={{ padding: "6px" }}>
+        <div style={{ paddingLeft: "6px", paddingRight: "6px", paddingTop: "6px" }}>
           <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
         </div>
         <StyledLinkTitle>{linkGroupName}</StyledLinkTitle>

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -82,7 +82,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
           return (
             link?.url && (
               <React.Fragment key={link.url}>
-                <StyledMenuItem style={{ padding: "6px", paddingLeft: "46px" }}>
+                <StyledMenuItem style={{ padding: "4px", paddingLeft: "46px" }}>
                   <Link href={link.url}>
                     <Typography color="inherit" variant="body4">
                       {link.name}

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -187,13 +187,13 @@ const ProjectLinks = ({ linkGroups, name }: ProjectLinksProps) => {
   const [keyWithQLinksOpen, setKeyWithQLinksOpen] = React.useState("");
 
   return (
-    <StyledFlexEnd hidden={name[0] !== keyWithQLinksOpen}>
+    <StyledFlexEnd hidden={name?.[0] !== keyWithQLinksOpen}>
       <StyledMoreVertIcon>
         <IconButton
           ref={anchorRef}
           onClick={() => {
             setOpen(true);
-            setKeyWithQLinksOpen(name[0]);
+            setKeyWithQLinksOpen(name?.[0]);
           }}
         >
           <MoreVertIcon />

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import { Grid, Link, Popper, Tooltip, TooltipContainer, Typography } from "@clutch-sh/core";
+import styled from "@emotion/styled";
+import IconButton from "@material-ui/core/IconButton";
+import MoreVertIcon from "@material-ui/icons/MoreVert";
+
+interface LinkGroupProps {
+  linkGroupName: string;
+  linkGroupImage: string;
+}
+
+interface QuickLinkProps extends LinkGroupProps {
+  link: IClutch.core.project.v1.ILink;
+}
+
+interface QuickLinkContainerProps {
+  key: string | null | undefined;
+  name: string;
+  children: React.ReactNode;
+}
+
+const ICON_SIZE = "22px";
+
+const QuickLinkContainer = ({ key, name, children }: QuickLinkContainerProps) => {
+  const container = (
+    <Tooltip title={name}>
+      <TooltipContainer>{children}</TooltipContainer>
+    </Tooltip>
+  );
+
+  return (
+    <Grid item key={key ?? ""}>
+      {name ? container : children}
+    </Grid>
+  );
+};
+
+const StyledMoreVertIcon = styled.span({
+  width: "12px",
+  ".MuiIconButton-root": {
+    padding: "6px",
+    color: "rgba(13, 16, 48, 0.38)",
+  },
+  ".MuiIconButton-root:hover": {
+    backgroundColor: "rgb(245, 246, 253)",
+  },
+  ".MuiIconButton-root:active": {
+    backgroundColor: "rgba(0,0,0, 0.1)",
+  },
+});
+
+const QuickLink = ({ link, linkGroupName, linkGroupImage }: QuickLinkProps) =>
+  link?.url ? (
+    <QuickLinkContainer key={link.name} name={linkGroupName}>
+      <Link href={link.url}>
+        <img
+          width={ICON_SIZE}
+          height={ICON_SIZE}
+          src={linkGroupImage}
+          alt={link.name ?? `Quick Link to ${link.url}`}
+        />
+        <span style={{ padding: "8px" }}>{linkGroupName}</span>
+      </Link>
+    </QuickLinkContainer>
+  ) : null;
+
+interface QuickLinkGroupProps extends LinkGroupProps {
+  links: IClutch.core.project.v1.ILink[];
+}
+// Have a popper in the case of multiple links per group
+const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroupProps) => {
+  const [validLinks, setValidLinks] = React.useState<IClutch.core.project.v1.ILink[]>([]);
+
+  React.useEffect(() => {
+    if (links) {
+      setValidLinks(links.filter(link => link?.url && link.url.length > 0));
+    }
+  }, [links]);
+
+  return (
+    <QuickLinkContainer key={linkGroupName} name={linkGroupName}>
+      <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
+      <span style={{ padding: "8px" }}>{linkGroupName}</span>
+      <div>
+        {validLinks.map(link => {
+          return (
+            link?.url && (
+              <Link href={link.url}>
+                <Typography color="inherit" variant="body4">
+                  {link.name}
+                </Typography>
+              </Link>
+            )
+          );
+        })}
+      </div>
+    </QuickLinkContainer>
+  );
+};
+
+const ExpandedLinks = ({ linkGroups }) => (
+  <Grid
+    container
+    item
+    direction="column"
+    alignItems="center"
+    spacing={1}
+    style={{ padding: "8px" }}
+  >
+    {(linkGroups || []).map(linkGroup => {
+      if (linkGroup.links?.length === 1) {
+        return (
+          <QuickLink
+            link={linkGroup.links[0]}
+            linkGroupName={linkGroup.name ?? ""}
+            linkGroupImage={linkGroup.imagePath ?? ""}
+          />
+        );
+      }
+      return (
+        <QuickLinkGroup
+          linkGroupName={linkGroup.name ?? ""}
+          linkGroupImage={linkGroup.imagePath ?? ""}
+          links={linkGroup?.links ?? []}
+        />
+      );
+    })}
+  </Grid>
+);
+
+const ProjectLinks = ({ linkGroups }) => {
+  const anchorRef = React.useRef(null);
+  const [open, setOpen] = React.useState(false);
+
+  if (!linkGroups) {
+    return null;
+  }
+
+  return (
+    <StyledMoreVertIcon>
+      <IconButton ref={anchorRef} onClick={() => setOpen(true)}>
+        <MoreVertIcon />
+        <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
+          <ExpandedLinks linkGroups={linkGroups} />
+        </Popper>
+      </IconButton>
+    </StyledMoreVertIcon>
+  );
+};
+
+export default ProjectLinks;

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Grid, Link, Popper, Tooltip, TooltipContainer, Typography } from "@clutch-sh/core";
+import { Link, Popper, Tooltip, TooltipContainer, Typography } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import IconButton from "@material-ui/core/IconButton";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
@@ -20,7 +20,15 @@ interface QuickLinkContainerProps {
   children: React.ReactNode;
 }
 
-const ICON_SIZE = "22px";
+const ICON_SIZE = "16px";
+
+const StyledMenuItem = styled.div({
+  display: "flex",
+  alignItems: "center",
+  "&:hover": {
+    backgroundColor: "rgba(13, 16, 48, 0.05)",
+  },
+});
 
 const QuickLinkContainer = ({ key, name, children }: QuickLinkContainerProps) => {
   const container = (
@@ -29,11 +37,7 @@ const QuickLinkContainer = ({ key, name, children }: QuickLinkContainerProps) =>
     </Tooltip>
   );
 
-  return (
-    <Grid item key={key ?? ""}>
-      {name ? container : children}
-    </Grid>
-  );
+  return <div key={key}>{name ? container : children}</div>;
 };
 
 const StyledMoreVertIcon = styled.span({
@@ -50,25 +54,32 @@ const StyledMoreVertIcon = styled.span({
   },
 });
 
+const StyledLinkTitle = styled.span({
+  padding: "8px",
+  fontWeight: "bold",
+});
+
 const QuickLink = ({ link, linkGroupName, linkGroupImage }: QuickLinkProps) =>
   link?.url ? (
-    <QuickLinkContainer key={link.name} name={linkGroupName}>
+    <StyledMenuItem style={{ padding: "8px" }}>
       <Link href={link.url}>
-        <img
-          width={ICON_SIZE}
-          height={ICON_SIZE}
-          src={linkGroupImage}
-          alt={link.name ?? `Quick Link to ${link.url}`}
-        />
-        <span style={{ padding: "8px" }}>{linkGroupName}</span>
+        <QuickLinkContainer key={link.name} name={linkGroupName}>
+          <img
+            width={ICON_SIZE}
+            height={ICON_SIZE}
+            src={linkGroupImage}
+            alt={link.name ?? `Quick Link to ${link.url}`}
+          />
+          <StyledLinkTitle>{linkGroupName}</StyledLinkTitle>
+        </QuickLinkContainer>
       </Link>
-    </QuickLinkContainer>
+    </StyledMenuItem>
   ) : null;
 
 interface QuickLinkGroupProps extends LinkGroupProps {
   links: IClutch.core.project.v1.ILink[];
 }
-// Have a popper in the case of multiple links per group
+
 const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroupProps) => {
   const [validLinks, setValidLinks] = React.useState<IClutch.core.project.v1.ILink[]>([]);
 
@@ -80,17 +91,21 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
 
   return (
     <QuickLinkContainer key={linkGroupName} name={linkGroupName}>
-      <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
-      <span style={{ padding: "8px" }}>{linkGroupName}</span>
+      <StyledLinkTitle>
+        <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
+      </StyledLinkTitle>
+      <StyledLinkTitle style={{ padding: "0px" }}>{linkGroupName}</StyledLinkTitle>
       <div>
         {validLinks.map(link => {
           return (
             link?.url && (
-              <Link href={link.url}>
-                <Typography color="inherit" variant="body4">
-                  {link.name}
-                </Typography>
-              </Link>
+              <StyledMenuItem style={{ padding: "8px", paddingLeft: "40px" }}>
+                <Link href={link.url}>
+                  <Typography color="inherit" variant="body4">
+                    {link.name}
+                  </Typography>
+                </Link>
+              </StyledMenuItem>
             )
           );
         })}
@@ -100,14 +115,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
 };
 
 const ExpandedLinks = ({ linkGroups }) => (
-  <Grid
-    container
-    item
-    direction="column"
-    alignItems="center"
-    spacing={1}
-    style={{ padding: "8px" }}
-  >
+  <div>
     {(linkGroups || []).map(linkGroup => {
       if (linkGroup.links?.length === 1) {
         return (
@@ -126,7 +134,7 @@ const ExpandedLinks = ({ linkGroups }) => (
         />
       );
     })}
-  </Grid>
+  </div>
 );
 
 const ProjectLinks = ({ linkGroups }) => {

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -76,7 +76,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
           return (
             link?.url && (
               <React.Fragment key={link.url}>
-                <StyledMenuItem style={{ padding: "4px", paddingLeft: "46px" }}>
+                <StyledMenuItem style={{ paddingBottom: "4px", paddingRight: "4px", paddingLeft: "46px" }}>
                   <Link href={link.url}>
                     <Typography color="inherit" variant="body4">
                       {link.name}

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -12,12 +12,24 @@ interface LinkGroupProps {
 
 const ICON_SIZE = "16px";
 
-const StyledMenuItem = styled.div({
+const itemHoverStyle = {
   display: "flex",
   alignItems: "center",
   "&:hover": {
     backgroundColor: "rgba(13, 16, 48, 0.05)",
   },
+};
+
+const StyledMenuItem = styled.div({
+  ...itemHoverStyle,
+  padding: "8px",
+});
+
+const StyledSubLink = styled.div({
+  ...itemHoverStyle,
+  paddingBottom: "4px",
+  paddingRight: "4px",
+  paddingLeft: "46px",
 });
 
 const StyledMoreVertIcon = styled.span({
@@ -37,6 +49,21 @@ const StyledLinkTitle = styled.span({
   fontWeight: "bold",
 });
 
+const StyledLinkBox = styled.div({
+  borderRadius: "4px",
+});
+
+const StyledMultilinkImage = styled.div({
+  paddingLeft: "6px",
+  paddingRight: "6px",
+  paddingTop: "6px",
+});
+
+const StyledMultilinkTitle = styled.div({
+  display: "flex",
+  alignItems: "center",
+});
+
 interface QuickLinkGroupProps extends LinkGroupProps {
   links: IClutch.core.project.v1.ILink[];
 }
@@ -49,42 +76,45 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
       setValidLinks(links.filter(link => link?.url && link.url.length > 0));
     }
   }, [links]);
+
+  if (validLinks.length === 0) {
+    return null;
+  }
+
   // In the case where there is only a singe link in the group, we make the title clickable.
   // In the case where there are multiple links, the title is not clickable and has different styling.
-  return links.length === 1 ? (
-    <StyledMenuItem style={{ padding: "8px" }} key={links[0].url}>
-      <Link href={links[0]?.url ?? ""}>
+  return validLinks.length === 1 ? (
+    <StyledMenuItem key={validLinks[0].url}>
+      <Link href={validLinks[0]?.url ?? ""}>
         <img
           width={ICON_SIZE}
           height={ICON_SIZE}
           src={linkGroupImage}
-          alt={links[0].name ?? `Quick Link to ${links[0].url}`}
+          alt={validLinks[0].name ?? `Quick Link to ${validLinks[0].url}`}
         />
         <StyledLinkTitle style={{ paddingLeft: "6px" }}>{linkGroupName}</StyledLinkTitle>
       </Link>
     </StyledMenuItem>
   ) : (
-    <div>
-      <div style={{ display: "flex", alignItems: "center" }}>
-        <div style={{ paddingLeft: "6px", paddingRight: "6px", paddingTop: "6px" }}>
+    <div key={validLinks[0].url}>
+      <StyledMultilinkTitle>
+        <StyledMultilinkImage>
           <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
-        </div>
+        </StyledMultilinkImage>
         <StyledLinkTitle>{linkGroupName}</StyledLinkTitle>
-      </div>
+      </StyledMultilinkTitle>
       <div>
         {validLinks.map(link => {
           return (
             link?.url && (
               <React.Fragment key={link.url}>
-                <StyledMenuItem
-                  style={{ paddingBottom: "4px", paddingRight: "4px", paddingLeft: "46px" }}
-                >
+                <StyledSubLink>
                   <Link href={link.url}>
                     <Typography color="inherit" variant="body4">
                       {link.name}
                     </Typography>
                   </Link>
-                </StyledMenuItem>
+                </StyledSubLink>
               </React.Fragment>
             )
           );
@@ -94,8 +124,12 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
   );
 };
 
-const ExpandedLinks = ({ linkGroups }) => (
-  <div style={{ borderRadius: "4px" }}>
+interface ExpandedLinksProps {
+  linkGroups: IClutch.core.project.v1.ILinkGroup[];
+}
+
+const ExpandedLinks = ({ linkGroups }: ExpandedLinksProps) => (
+  <StyledLinkBox>
     {(linkGroups || []).map(linkGroup => {
       return (
         <QuickLinkGroup
@@ -105,7 +139,7 @@ const ExpandedLinks = ({ linkGroups }) => (
         />
       );
     })}
-  </div>
+  </StyledLinkBox>
 );
 
 const StyledFlexEnd = styled.div({
@@ -113,7 +147,21 @@ const StyledFlexEnd = styled.div({
   flexDirection: "row-reverse",
 });
 
-const QuickLinksPopper = ({ linkGroups, anchorRef, open, setOpen, setKeyWithQLinksOpen }) => {
+interface QuickLinksPopperProps {
+  linkGroups: IClutch.core.project.v1.ILinkGroup[];
+  anchorRef: React.RefObject<HTMLElement>;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  setKeyWithQLinksOpen: (key: string) => void;
+}
+
+const QuickLinksPopper = ({
+  linkGroups,
+  anchorRef,
+  open,
+  setOpen,
+  setKeyWithQLinksOpen,
+}: QuickLinksPopperProps) => {
   return (
     <Popper
       open={open}
@@ -128,19 +176,24 @@ const QuickLinksPopper = ({ linkGroups, anchorRef, open, setOpen, setKeyWithQLin
   );
 };
 
-const ProjectLinks = ({ linkGroups, name }) => {
+interface ProjectLinksProps {
+  linkGroups: IClutch.core.project.v1.ILinkGroup[];
+  name: string[];
+}
+
+const ProjectLinks = ({ linkGroups, name }: ProjectLinksProps) => {
   const anchorRef = React.useRef(null);
   const [open, setOpen] = React.useState(false);
   const [keyWithQLinksOpen, setKeyWithQLinksOpen] = React.useState("");
 
   return (
-    <StyledFlexEnd hidden={name !== keyWithQLinksOpen}>
+    <StyledFlexEnd hidden={name[0] !== keyWithQLinksOpen}>
       <StyledMoreVertIcon>
         <IconButton
           ref={anchorRef}
           onClick={() => {
             setOpen(true);
-            setKeyWithQLinksOpen(name);
+            setKeyWithQLinksOpen(name[0]);
           }}
         >
           <MoreVertIcon />

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -76,7 +76,9 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
           return (
             link?.url && (
               <React.Fragment key={link.url}>
-                <StyledMenuItem style={{ paddingBottom: "4px", paddingRight: "4px", paddingLeft: "46px" }}>
+                <StyledMenuItem
+                  style={{ paddingBottom: "4px", paddingRight: "4px", paddingLeft: "46px" }}
+                >
                   <Link href={link.url}>
                     <Typography color="inherit" variant="body4">
                       {link.name}

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -25,7 +25,6 @@ const StyledMenuItem = styled.div({
 });
 
 const StyledMoreVertIcon = styled.span({
-  width: "12px",
   ".MuiIconButton-root": {
     padding: "6px",
     color: "rgba(13, 16, 48, 0.38)",
@@ -70,7 +69,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
     }
   }, [links]);
   return (
-    <div key={linkGroupName}>
+    <div>
       <div style={{ display: "flex", alignItems: "center" }}>
         <div style={{ padding: "6px" }}>
           <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
@@ -121,21 +120,46 @@ const ExpandedLinks = ({ linkGroups }) => (
   </div>
 );
 
-const ProjectLinks = ({ linkGroups }) => {
+interface ProjectLinksProps {
+  linkGroups: IClutch.core.project.v1.ILinkGroup[];
+  name: string;
+  setVisibleFn: (visible: string) => void;
+}
+
+const QuickLinksPopper = ({ linkGroups, anchorRef, open, setOpen, setVisibleFn }) => (
+  <Popper
+    open={open}
+    anchorRef={anchorRef}
+    onClickAway={() => {
+      setOpen(false);
+      setVisibleFn("");
+    }}
+  >
+    <ExpandedLinks linkGroups={linkGroups} />
+  </Popper>
+);
+
+const ProjectLinks = ({ linkGroups, name, setVisibleFn }: ProjectLinksProps) => {
   const anchorRef = React.useRef(null);
   const [open, setOpen] = React.useState(false);
 
-  if (!linkGroups) {
-    return null;
-  }
-
   return (
     <StyledMoreVertIcon>
-      <IconButton ref={anchorRef} onClick={() => setOpen(true)}>
+      <IconButton
+        ref={anchorRef}
+        onClick={() => {
+          setOpen(true);
+          setVisibleFn(name);
+        }}
+      >
         <MoreVertIcon />
-        <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
-          <ExpandedLinks linkGroups={linkGroups} />
-        </Popper>
+        <QuickLinksPopper
+          linkGroups={linkGroups}
+          anchorRef={anchorRef}
+          open={open}
+          setOpen={setOpen}
+          setVisibleFn={setVisibleFn}
+        />
       </IconButton>
     </StyledMoreVertIcon>
   );

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Link, Popper, Tooltip, TooltipContainer, Typography } from "@clutch-sh/core";
+import { Link, Popper, Typography } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import IconButton from "@material-ui/core/IconButton";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
@@ -14,13 +14,7 @@ interface QuickLinkProps extends LinkGroupProps {
   link: IClutch.core.project.v1.ILink;
 }
 
-interface QuickLinkContainerProps {
-  key: string | null | undefined;
-  name: string;
-  children: React.ReactNode;
-}
-
-const ICON_SIZE = "16px";
+const ICON_SIZE = "22px";
 
 const StyledMenuItem = styled.div({
   display: "flex",
@@ -29,16 +23,6 @@ const StyledMenuItem = styled.div({
     backgroundColor: "rgba(13, 16, 48, 0.05)",
   },
 });
-
-const QuickLinkContainer = ({ key, name, children }: QuickLinkContainerProps) => {
-  const container = (
-    <Tooltip title={name}>
-      <TooltipContainer>{children}</TooltipContainer>
-    </Tooltip>
-  );
-
-  return <div key={key}>{name ? container : children}</div>;
-};
 
 const StyledMoreVertIcon = styled.span({
   width: "12px",
@@ -55,23 +39,20 @@ const StyledMoreVertIcon = styled.span({
 });
 
 const StyledLinkTitle = styled.span({
-  padding: "8px",
   fontWeight: "bold",
 });
 
 const QuickLink = ({ link, linkGroupName, linkGroupImage }: QuickLinkProps) =>
   link?.url ? (
-    <StyledMenuItem style={{ padding: "8px" }}>
+    <StyledMenuItem style={{ padding: "8px" }} key={link.url}>
       <Link href={link.url}>
-        <QuickLinkContainer key={link.name} name={linkGroupName}>
-          <img
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-            src={linkGroupImage}
-            alt={link.name ?? `Quick Link to ${link.url}`}
-          />
-          <StyledLinkTitle>{linkGroupName}</StyledLinkTitle>
-        </QuickLinkContainer>
+        <img
+          width={ICON_SIZE}
+          height={ICON_SIZE}
+          src={linkGroupImage}
+          alt={link.name ?? `Quick Link to ${link.url}`}
+        />
+        <StyledLinkTitle style={{ paddingLeft: "6px" }}>{linkGroupName}</StyledLinkTitle>
       </Link>
     </StyledMenuItem>
   ) : null;
@@ -88,34 +69,37 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
       setValidLinks(links.filter(link => link?.url && link.url.length > 0));
     }
   }, [links]);
-
   return (
-    <QuickLinkContainer key={linkGroupName} name={linkGroupName}>
-      <StyledLinkTitle>
-        <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
-      </StyledLinkTitle>
-      <StyledLinkTitle style={{ padding: "0px" }}>{linkGroupName}</StyledLinkTitle>
+    <div key={linkGroupName}>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <div style={{ padding: "6px" }}>
+          <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
+        </div>
+        <StyledLinkTitle>{linkGroupName}</StyledLinkTitle>
+      </div>
       <div>
         {validLinks.map(link => {
           return (
             link?.url && (
-              <StyledMenuItem style={{ padding: "8px", paddingLeft: "40px" }}>
-                <Link href={link.url}>
-                  <Typography color="inherit" variant="body4">
-                    {link.name}
-                  </Typography>
-                </Link>
-              </StyledMenuItem>
+              <React.Fragment key={link.url}>
+                <StyledMenuItem style={{ padding: "6px", paddingLeft: "46px" }}>
+                  <Link href={link.url}>
+                    <Typography color="inherit" variant="body4">
+                      {link.name}
+                    </Typography>
+                  </Link>
+                </StyledMenuItem>
+              </React.Fragment>
             )
           );
         })}
       </div>
-    </QuickLinkContainer>
+    </div>
   );
 };
 
 const ExpandedLinks = ({ linkGroups }) => (
-  <div>
+  <div style={{ borderRadius: "4px" }}>
     {(linkGroups || []).map(linkGroup => {
       if (linkGroup.links?.length === 1) {
         return (


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add the option for quicklinks to the project selector, such as links to logs, grafana, etc.
Note that there is a very slight issue with some of our source images - the k8s one has a slightly excessive border around it which leads to it looking slightly misaligned. However, I don't think anyone will really notice. There are also differences between the figma and reality because in figma there is differing padding due to the sizing of the icons.

I also thought about making the whole box clickable instead of the image and text but I wasn't sure if that would be confusing.

![Screen Shot 2022-04-27 at 12 53 57 AM](https://user-images.githubusercontent.com/66325812/165470015-559af936-d2e3-47b7-bd81-abf6dcd55213.png)

![showingspacing](https://user-images.githubusercontent.com/66325812/165470038-ca9a1819-c574-4104-8950-8f68c273d7ef.gif)

Note I messed with the padding a fair amount and tried to end up with something that looks good. If you look closely at the inspection it looks like some values are 1 or 2 pixels off but I think they look fine. The top screenshot has no top padding on the sublinks (only bottom, left and right), whereas the bottom gif has 4px padding all around.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
 
<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
