### PR TITLE
tools: add resolution for @types/react to scaffolding

### DIFF
--- a/tools/scaffolding/templates/frontend/package.json
+++ b/tools/scaffolding/templates/frontend/package.json
@@ -22,6 +22,9 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
+  "resolutions": {
+    "@types/react": "^17.0.2"
+  },
   "devDependencies": {
     "@clutch-sh/tools": "^1.0.0-beta"
   },

--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -31,6 +31,9 @@
     "react-dom": "^17.0.2",
     "react-scripts": "^4.0.1"
   },
+  "resolutions": {
+    "@types/react": "^17.0.2"
+  },
   "workspaces": [
     "workflows/*"
   ],


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
add resolution block for react types as some of our deps don't pin this transitive dep

```
=> Found "@types/react@18.0.3"
info Has been hoisted to "@types/react"
info Reasons this module exists
   - Hoisted from "@clutch-sh#tools#@types#enzyme#@types#react"
   - Hoisted from "@clutch-sh#wizard#@material-ui#core#@types#react-transition-group#@types#react"
   - Hoisted from "@clutch-sh#wizard#@clutch-sh#core#material-table#@material-ui#pickers#@types#styled-jsx#@types#react"
   - Hoisted from "@clutch-sh#wizard#@clutch-sh#core#material-table#react-beautiful-dnd#react-redux#@types#react-redux#@types#react"
   - Hoisted from "@clutch-sh#wizard#@clutch-sh#core#material-table#react-beautiful-dnd#react-redux#@types#react-redux#@types#hoist-non-react-statics#@types#react"
```

<!-- Reference previous related pull requests below. -->
See https://github.com/facebook/react/issues/24304 for more information

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
