### PR TITLE
frontend: ProjectSelector state bug

### DIFF
--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -154,13 +154,10 @@ const hydrateProjects = (state: State, dispatch: React.Dispatch<Action>) => {
       .then(resp => {
         const { results, partialFailures } = resp.data as IClutch.project.v1.GetProjectsResponse;
 
-        if (partialFailures && partialFailures.length) {
-          dispatch({
-            type: "HYDRATE_ERROR",
-            payload: { result: { partialFailures } },
-          });
-        }
-        dispatch({ type: "HYDRATE_END", payload: { result: results || {} } });
+        dispatch({
+          type: "HYDRATE_END",
+          payload: { result: { results: results || {}, partialFailures } },
+        });
       })
       .catch((err: ClutchError) => {
         dispatch({ type: "HYDRATE_ERROR", payload: { result: err } });


### PR DESCRIPTION
### Description
- Found issue when a partial failure is returned and the dispatches are not playing nice when called one after another.
- Instead of calling two separate reducer actions, combined the logic into just `HYDRATE_END` which fixes the issues with the state

### Testing Performed
manual

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
Future PR will include unit tests to specifically cover these scenarios
