### PR TITLE
backend: align with Lyft golangci-lint baseline

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   - exportloopref
   - gci
   - gocritic
+  - gofmt
   - goimports
   - gosec
   - gosimple

--- a/backend/middleware/accesslog/accesslog_test.go
+++ b/backend/middleware/accesslog/accesslog_test.go
@@ -25,7 +25,7 @@ func TestNew(t *testing.T) {
 		{config: nil},
 		{config: &accesslogv1.Config{
 			StatusCodeFilters: []*accesslogv1.Config_StatusCodeFilter{
-				&accesslogv1.Config_StatusCodeFilter{
+				{
 					FilterType: &accesslogv1.Config_StatusCodeFilter_Equals{
 						Equals: 1,
 					},

--- a/backend/mock/service/k8smock/k8smock.go
+++ b/backend/mock/service/k8smock/k8smock.go
@@ -62,7 +62,7 @@ func (s *svc) DescribePod(_ context.Context, clientset, cluster, namespace, name
 
 func (s *svc) ListPods(_ context.Context, clientset, cluster, namespace string, listOptions *k8sv1.ListOptions) ([]*k8sv1.Pod, error) {
 	pods := []*k8sv1.Pod{
-		&k8sv1.Pod{
+		{
 			Cluster:     cluster,
 			Namespace:   namespace,
 			Name:        "name1",
@@ -72,7 +72,7 @@ func (s *svc) ListPods(_ context.Context, clientset, cluster, namespace string, 
 			Labels:      listOptions.Labels,
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.Pod{
+		{
 			Cluster:     cluster,
 			Namespace:   namespace,
 			Name:        "name2",
@@ -98,14 +98,14 @@ func (*svc) DescribeDeployment(ctx context.Context, clientset, cluster, namespac
 
 func (s *svc) ListDeployments(_ context.Context, clientset, cluster, namespace string, listOptions *k8sv1.ListOptions) ([]*k8sv1.Deployment, error) {
 	deployments := []*k8sv1.Deployment{
-		&k8sv1.Deployment{
+		{
 			Cluster:     cluster,
 			Namespace:   namespace,
 			Name:        "deployment1",
 			Labels:      map[string]string{"Key": "value"},
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.Deployment{
+		{
 			Cluster:     cluster,
 			Namespace:   namespace,
 			Name:        "deployment2",
@@ -136,14 +136,14 @@ func (*svc) DescribeStatefulSet(ctx context.Context, clientset, cluster, namespa
 
 func (s *svc) ListStatefulSets(_ context.Context, clientset, cluster, namespace string, listOptions *k8sv1.ListOptions) ([]*k8sv1.StatefulSet, error) {
 	statefulsets := []*k8sv1.StatefulSet{
-		&k8sv1.StatefulSet{
+		{
 			Cluster:     cluster,
 			Namespace:   namespace,
 			Name:        "statefulset1",
 			Labels:      map[string]string{"Key": "value"},
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.StatefulSet{
+		{
 			Cluster:     cluster,
 			Namespace:   namespace,
 			Name:        "statefulset2",
@@ -183,12 +183,12 @@ func (s *svc) DescribeService(_ context.Context, clientset, cluster, namespace, 
 
 func (s *svc) ListServices(_ context.Context, clientset, cluster, namespace string, listOptions *k8sv1.ListOptions) ([]*k8sv1.Service, error) {
 	services := []*k8sv1.Service{
-		&k8sv1.Service{
+		{
 			Cluster:   "fake-cluster-name",
 			Namespace: namespace,
 			Name:      "service1",
 		},
-		&k8sv1.Service{
+		{
 			Cluster:   "fake-cluster-name",
 			Namespace: namespace,
 			Name:      "service2",
@@ -214,7 +214,7 @@ func (s *svc) DescribeCronJob(_ context.Context, clientset, cluster, namespace, 
 
 func (s *svc) ListCronJobs(_ context.Context, clientset, cluster, namespace string, listOptions *k8sv1.ListOptions) ([]*k8sv1.CronJob, error) {
 	crons := []*k8sv1.CronJob{
-		&k8sv1.CronJob{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "cronjob1",
@@ -222,7 +222,7 @@ func (s *svc) ListCronJobs(_ context.Context, clientset, cluster, namespace stri
 			Labels:      map[string]string{"Key": "value"},
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.CronJob{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "cronjob2",
@@ -254,28 +254,28 @@ func (*svc) DeleteConfigMap(ctx context.Context, clientset, cluster, namespace, 
 
 func (s *svc) ListConfigMaps(_ context.Context, clientset, cluster, namespace string, listOptions *k8sv1.ListOptions) ([]*k8sv1.ConfigMap, error) {
 	configMaps := []*k8sv1.ConfigMap{
-		&k8sv1.ConfigMap{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "name1",
 			Labels:      listOptions.Labels,
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.ConfigMap{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "name2",
 			Labels:      listOptions.Labels,
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.ConfigMap{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "foo-bar",
 			Labels:      listOptions.Labels,
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.ConfigMap{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "stuff-things",
@@ -288,14 +288,14 @@ func (s *svc) ListConfigMaps(_ context.Context, clientset, cluster, namespace st
 
 func (s *svc) ListJobs(_ context.Context, clientset, cluster, namespace string, listOptions *k8sv1.ListOptions) ([]*k8sv1.Job, error) {
 	jobs := []*k8sv1.Job{
-		&k8sv1.Job{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "name1",
 			Labels:      listOptions.Labels,
 			Annotations: map[string]string{"Key": "value"},
 		},
-		&k8sv1.Job{
+		{
 			Cluster:     "fake-cluster-name",
 			Namespace:   namespace,
 			Name:        "name2",
@@ -327,7 +327,7 @@ func (s *svc) DescribeNamespace(_ context.Context, clientset, cluster, name stri
 
 func (s *svc) ListEvents(_ context.Context, clientset, cluster, namespace, name string, kind k8sv1.ObjectKind) ([]*k8sv1.Event, error) {
 	return []*k8sv1.Event{
-		&k8sv1.Event{
+		{
 			Name:               "event1",
 			Reason:             "reason-1",
 			Description:        "description-1",

--- a/backend/mock/service/topologymock/topologymock.go
+++ b/backend/mock/service/topologymock/topologymock.go
@@ -34,7 +34,7 @@ func (s *svc) Search(context.Context, *topologyv1.SearchRequest) ([]*topologyv1.
 			Id: "pod-123",
 			Pb: &any.Any{},
 			Metadata: map[string]*structpb.Value{
-				"label": &structpb.Value{},
+				"label": {},
 			},
 		},
 	}, "1", nil
@@ -46,7 +46,7 @@ func (s *svc) Autocomplete(ctx context.Context, typeURL, search string, limit ui
 			Id: "autocomplete-result",
 			Pb: &any.Any{},
 			Metadata: map[string]*structpb.Value{
-				"label": &structpb.Value{},
+				"label": {},
 			},
 		},
 	}, nil

--- a/backend/module/chaos/experimentation/xds/poller_test.go
+++ b/backend/module/chaos/experimentation/xds/poller_test.go
@@ -165,8 +165,8 @@ func TestECDSResourcesRefresh(t *testing.T) {
 	ecdsConfig := ECDSConfig{
 		ecdsResourceMap: &SafeEcdsResourceMap{},
 		enabledClusters: map[string]struct{}{
-			"foo": struct{}{},
-			"bar": struct{}{},
+			"foo": {},
+			"bar": {},
 		},
 	}
 

--- a/backend/module/chaos/serverexperimentation/xds/rtds_faults_generator.go
+++ b/backend/module/chaos/serverexperimentation/xds/rtds_faults_generator.go
@@ -59,8 +59,8 @@ func (g RTDSFaultsGenerator) GenerateResource(experiment *experimentstore.Experi
 	}
 
 	return xds.NewRTDSResource(cluster, []*xds.RuntimeKeyValue{
-		&xds.RuntimeKeyValue{Key: percentageKey, Value: percentageValue},
-		&xds.RuntimeKeyValue{Key: faultKey, Value: faultValue},
+		{Key: percentageKey, Value: percentageValue},
+		{Key: faultKey, Value: faultValue},
 	})
 }
 

--- a/backend/module/feedback/feedback_test.go
+++ b/backend/module/feedback/feedback_test.go
@@ -70,13 +70,13 @@ func TestGetConfigSurveys(t *testing.T) {
 		},
 		{
 			surveyMap: surveyLookup{surveys: map[string]*feedbackv1cfg.SurveyOrigin{
-				"FOO": &feedbackv1cfg.SurveyOrigin{},
+				"FOO": {},
 			}},
 			expectedOk: false,
 		},
 		{
 			surveyMap: surveyLookup{surveys: map[string]*feedbackv1cfg.SurveyOrigin{
-				"WIZARD": &feedbackv1cfg.SurveyOrigin{Survey: &feedbackv1cfg.Survey{Prompt: "bar"}},
+				"WIZARD": {Survey: &feedbackv1cfg.Survey{Prompt: "bar"}},
 			}},
 			expectedOk: true,
 		},

--- a/backend/service/auditsink/slack/slack_helper_test.go
+++ b/backend/service/auditsink/slack/slack_helper_test.go
@@ -24,7 +24,7 @@ func TestNewOverrideLookup(t *testing.T) {
 			override: []*configv1.CustomMessage{{FullMethod: "foo", Message: "bar"}},
 			output: OverrideLookup{
 				messages: map[string]*configv1.CustomMessage{
-					"foo": &configv1.CustomMessage{FullMethod: "foo", Message: "bar"},
+					"foo": {FullMethod: "foo", Message: "bar"},
 				},
 			},
 		},
@@ -69,7 +69,7 @@ func TestGetOverrideMessage(t *testing.T) {
 		{
 			input: OverrideLookup{
 				messages: map[string]*configv1.CustomMessage{
-					"/clutch.k8s.v1.K8sAPI/DescribePod": &configv1.CustomMessage{FullMethod: "/clutch.k8s.v1.K8sAPI/DescribePod", Message: "foo"},
+					"/clutch.k8s.v1.K8sAPI/DescribePod": {FullMethod: "/clutch.k8s.v1.K8sAPI/DescribePod", Message: "foo"},
 				},
 			},
 			service:    "clutch.k8s.v1.K8sAPI",
@@ -80,8 +80,8 @@ func TestGetOverrideMessage(t *testing.T) {
 		{
 			input: OverrideLookup{
 				messages: map[string]*configv1.CustomMessage{
-					"/clutch.k8s.v1.K8sAPI/DescribePod": &configv1.CustomMessage{FullMethod: "/clutch.k8s.v1.K8sAPI/DescribePod", Message: "foo"},
-					"foo":                               &configv1.CustomMessage{FullMethod: "foo", Message: "foo"},
+					"/clutch.k8s.v1.K8sAPI/DescribePod": {FullMethod: "/clutch.k8s.v1.K8sAPI/DescribePod", Message: "foo"},
+					"foo":                               {FullMethod: "foo", Message: "foo"},
 				},
 			},
 			service:      "clutch.k8s.v1.K8sAPI",

--- a/backend/service/auditsink/slack/slack_test.go
+++ b/backend/service/auditsink/slack/slack_test.go
@@ -81,7 +81,7 @@ func TestAuditEventToMessage(t *testing.T) {
 		{
 			svc: &svc{logger: log, overrides: OverrideLookup{
 				messages: map[string]*configv1.CustomMessage{
-					"foo": &configv1.CustomMessage{FullMethod: "foo", Message: "{{.Request.name}}"},
+					"foo": {FullMethod: "foo", Message: "{{.Request.name}}"},
 				},
 			}},
 			user:     userName,
@@ -92,7 +92,7 @@ func TestAuditEventToMessage(t *testing.T) {
 		{
 			svc: &svc{logger: log, overrides: OverrideLookup{
 				messages: map[string]*configv1.CustomMessage{
-					"/clutch.aws.v1.Instance/GetInstance": &configv1.CustomMessage{
+					"/clutch.aws.v1.Instance/GetInstance": {
 						FullMethod: "/clutch.aws.v1.Instance/GetInstance",
 						Message:    "Instance `{{.Request.instanceId}}` region is `{{.Response.instance.region}}`",
 					}},
@@ -106,7 +106,7 @@ func TestAuditEventToMessage(t *testing.T) {
 		{
 			svc: &svc{logger: log, overrides: OverrideLookup{
 				messages: map[string]*configv1.CustomMessage{
-					"/clutch.aws.v1.Instance/GetInstance": &configv1.CustomMessage{
+					"/clutch.aws.v1.Instance/GetInstance": {
 						FullMethod: "/clutch.aws.v1.Instance/GetInstance",
 						Message:    "{{Foo}}",
 					}},
@@ -153,8 +153,8 @@ func TestFormatCustomText(t *testing.T) {
 	k8sUpdateReq := &k8sapiv1.UpdatePodRequest{
 		ExpectedObjectMetaFields: &k8sapiv1.ExpectedObjectMetaFields{
 			Annotations: map[string]*k8sapiv1.NullableString{
-				"baz": &k8sapiv1.NullableString{Kind: &k8sapiv1.NullableString_Null{}},
-				"foo": &k8sapiv1.NullableString{Kind: &k8sapiv1.NullableString_Value{Value: "new-value"}},
+				"baz": {Kind: &k8sapiv1.NullableString_Null{}},
+				"foo": {Kind: &k8sapiv1.NullableString_Value{Value: "new-value"}},
 			},
 		},
 		ObjectMetaFields:       &k8sapiv1.ObjectMetaFields{Labels: map[string]string{"foo": "new-value"}},

--- a/backend/service/k8s/configmap_test.go
+++ b/backend/service/k8s/configmap_test.go
@@ -61,7 +61,7 @@ func TestListConfigMaps(t *testing.T) {
 
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "testing-cluster",
@@ -110,7 +110,7 @@ func TestDescribeConfigMap(t *testing.T) {
 
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "testing-cluster",
@@ -135,7 +135,7 @@ func TestDeleteConfigMap(t *testing.T) {
 
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "testing-cluster",

--- a/backend/service/k8s/cronjob_test.go
+++ b/backend/service/k8s/cronjob_test.go
@@ -27,7 +27,7 @@ func testCronService() *svc {
 	cs := fake.NewSimpleClientset(cron)
 	return &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",

--- a/backend/service/k8s/deployment_test.go
+++ b/backend/service/k8s/deployment_test.go
@@ -37,7 +37,7 @@ func TestDescribeDeployment(t *testing.T) {
 	cs := testDeploymentClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -58,7 +58,7 @@ func TestListDeployments(t *testing.T) {
 	cs := testDeploymentClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -81,7 +81,7 @@ func TestUpdateDeployment(t *testing.T) {
 	cs := testDeploymentClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -101,7 +101,7 @@ func TestDeleteDeployment(t *testing.T) {
 	cs := testDeploymentClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",

--- a/backend/service/k8s/event_test.go
+++ b/backend/service/k8s/event_test.go
@@ -59,7 +59,7 @@ func TestListEvents(t *testing.T) {
 	cs := testEventClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",

--- a/backend/service/k8s/hpa_test.go
+++ b/backend/service/k8s/hpa_test.go
@@ -105,7 +105,7 @@ func TestResizeHPA(t *testing.T) {
 	cs := testHPAClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -175,7 +175,7 @@ func TestDeleteHPA(t *testing.T) {
 	cs := testHPAClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",

--- a/backend/service/k8s/job_test.go
+++ b/backend/service/k8s/job_test.go
@@ -61,7 +61,7 @@ func TestListJobs(t *testing.T) {
 
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "testing-cluster",
@@ -110,7 +110,7 @@ func TestDeleteJob(t *testing.T) {
 
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "testing-cluster",
@@ -131,7 +131,7 @@ func TestCreateJob(t *testing.T) {
 
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "testing-cluster",

--- a/backend/service/k8s/namespace_test.go
+++ b/backend/service/k8s/namespace_test.go
@@ -27,7 +27,7 @@ func TestDescribeNamespace(t *testing.T) {
 	cs := testNamespaceClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "core-testing",

--- a/backend/service/k8s/pods_test.go
+++ b/backend/service/k8s/pods_test.go
@@ -164,7 +164,7 @@ func TestDeletePod(t *testing.T) {
 	cs := testPodClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -195,7 +195,7 @@ func TestListPods(t *testing.T) {
 	cs := testPodClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"testing-clientset": {
 				Interface: cs,
 				namespace: "testing-namespace",
 				cluster:   "testing-cluster",
@@ -246,7 +246,7 @@ func TestPodDescription(t *testing.T) {
 					},
 					Reason: "Evicted",
 					Conditions: []corev1.PodCondition{
-						corev1.PodCondition{
+						{
 							Type:   corev1.ContainersReady,
 							Status: corev1.ConditionTrue,
 						},
@@ -276,7 +276,7 @@ func TestPodDescription(t *testing.T) {
 					},
 					Reason: "Evicted",
 					Conditions: []corev1.PodCondition{
-						corev1.PodCondition{
+						{
 							Type:   corev1.ContainersReady,
 							Status: corev1.ConditionTrue,
 						},
@@ -336,7 +336,7 @@ func TestUpdatePod(t *testing.T) {
 	s := &svc{
 		manager: &managerImpl{
 			clientsets: map[string]*ctxClientsetImpl{
-				"testing-clientset": &ctxClientsetImpl{
+				"testing-clientset": {
 					Interface: &fakeClient,
 					namespace: "testing-namespace",
 					cluster:   "testing-cluster",
@@ -362,7 +362,7 @@ func TestUpdatePod(t *testing.T) {
 		"testing-cluster",
 		"testing-namespace",
 		"testing-pod-name",
-		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"foo": &k8sv1.NullableString{Kind: &k8sv1.NullableString_Value{Value: "non-matching-value"}}}},
+		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"foo": {Kind: &k8sv1.NullableString_Value{Value: "non-matching-value"}}}},
 		&k8sv1.ObjectMetaFields{Annotations: map[string]string{"new-annotation": "foo"}},
 		&k8sv1.RemoveObjectMetaFields{},
 	)
@@ -374,7 +374,7 @@ func TestUpdatePod(t *testing.T) {
 		"testing-cluster",
 		"testing-namespace",
 		"testing-pod-name",
-		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"baz": &k8sv1.NullableString{Kind: &k8sv1.NullableString_Value{Value: "quuz"}}}},
+		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"baz": {Kind: &k8sv1.NullableString_Value{Value: "quuz"}}}},
 		&k8sv1.ObjectMetaFields{Annotations: map[string]string{"baz": "new-value"}},
 		&k8sv1.RemoveObjectMetaFields{},
 	)
@@ -386,7 +386,7 @@ func TestUpdatePod(t *testing.T) {
 		"testing-cluster",
 		"testing-namespace",
 		"testing-pod-name",
-		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"baz": &k8sv1.NullableString{Kind: &k8sv1.NullableString_Value{Value: "new-value"}}}},
+		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"baz": {Kind: &k8sv1.NullableString_Value{Value: "new-value"}}}},
 		&k8sv1.ObjectMetaFields{},
 		&k8sv1.RemoveObjectMetaFields{Annotations: []string{"baz"}},
 	)
@@ -409,7 +409,7 @@ func TestUpdatePod(t *testing.T) {
 		"testing-cluster",
 		"testing-namespace",
 		"testing-pod-name",
-		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"baz": &k8sv1.NullableString{Kind: &k8sv1.NullableString_Null{}}}},
+		&k8sv1.ExpectedObjectMetaFields{Annotations: map[string]*k8sv1.NullableString{"baz": {Kind: &k8sv1.NullableString_Null{}}}},
 		&k8sv1.ObjectMetaFields{Annotations: map[string]string{"baz": "new-value"}},
 		&k8sv1.RemoveObjectMetaFields{},
 	)
@@ -537,7 +537,7 @@ func TestPodStatus(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
-						corev1.ContainerStatus{
+						{
 							Name:         "container1",
 							Ready:        false,
 							RestartCount: 0,
@@ -560,7 +560,7 @@ func TestPodStatus(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
-						corev1.ContainerStatus{
+						{
 							Name:         "container1",
 							Ready:        false,
 							RestartCount: 50,
@@ -584,7 +584,7 @@ func TestPodStatus(t *testing.T) {
 				Status: corev1.PodStatus{
 					Phase: "Running",
 					ContainerStatuses: []corev1.ContainerStatus{
-						corev1.ContainerStatus{
+						{
 							Name:         "container1",
 							Ready:        true,
 							RestartCount: 0,
@@ -616,7 +616,7 @@ func TestPodStatus(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					InitContainerStatuses: []corev1.ContainerStatus{
-						corev1.ContainerStatus{
+						{
 							Name:         "container1",
 							Ready:        true,
 							RestartCount: 0,
@@ -639,7 +639,7 @@ func TestPodStatus(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
-						corev1.ContainerStatus{
+						{
 							Name:         "container1",
 							Ready:        true,
 							RestartCount: 0,

--- a/backend/service/k8s/service_test.go
+++ b/backend/service/k8s/service_test.go
@@ -33,7 +33,7 @@ func TestDescribeService(t *testing.T) {
 	cs := testServiceClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -49,7 +49,7 @@ func TestDeleteService(t *testing.T) {
 	cs := testServiceClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -73,7 +73,7 @@ func TestListServices(t *testing.T) {
 	cs := testServiceClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",

--- a/backend/service/k8s/statefulset_test.go
+++ b/backend/service/k8s/statefulset_test.go
@@ -36,7 +36,7 @@ func TestListStatefulSets(t *testing.T) {
 	cs := testStatefulSetClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -60,7 +60,7 @@ func TestUpdateStatefulSet(t *testing.T) {
 	cs := testStatefulSetClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",
@@ -213,7 +213,7 @@ func TestDeleteStatefulSet(t *testing.T) {
 	cs := testStatefulSetClientset()
 	s := &svc{
 		manager: &managerImpl{
-			clientsets: map[string]*ctxClientsetImpl{"foo": &ctxClientsetImpl{
+			clientsets: map[string]*ctxClientsetImpl{"foo": {
 				Interface: cs,
 				namespace: "default",
 				cluster:   "core-testing",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
`goimports` is not a strict superset of `gofmt`
as gofmt additionally performs simplification,
so Lyft's (internal) golangci-lint baseline has both linters enabled.

You can see the additional changes from adding `gofmt`
made automatically via `make backend-lint-fix` here.

<!-- Reference previous related pull requests below. -->
None

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
`make backend-lint; echo $?`

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
