### PR TITLE
FE: add support for location notes in delete pod

### DIFF
--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -23,7 +23,6 @@ const PodIdentifier: React.FC<ResolverChild> = ({ resolverType, notes = [] }) =>
   const { onSubmit } = useWizardContext();
   const resolvedResourceData = useDataLayout("resourceData");
   const resolverInput = useDataLayout("resolverInput");
-  const resolverNotes = notes.filter(note => note.location === "resolver");
   const onResolve = ({ results, input }) => {
     // Decide how to process results.
     resolvedResourceData.assign(results[0]);
@@ -32,7 +31,7 @@ const PodIdentifier: React.FC<ResolverChild> = ({ resolverType, notes = [] }) =>
   };
 
   return (
-    <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={resolverNotes} />
+    <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={notes} />
   );
 };
 

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -30,9 +30,7 @@ const PodIdentifier: React.FC<ResolverChild> = ({ resolverType, notes = [] }) =>
     onSubmit();
   };
 
-  return (
-    <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={notes} />
-  );
+  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={notes} />;
 };
 
 const PodDetails: React.FC<VerifyChild> = ({ notes = [] }) => {

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -31,7 +31,9 @@ const PodIdentifier: React.FC<ResolverChild> = ({ resolverType, notes = [] }) =>
     onSubmit();
   };
 
-  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={resolverNotes} />;
+  return (
+    <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={resolverNotes} />
+  );
 };
 
 const PodDetails: React.FC<VerifyChild> = ({ notes = [] }) => {

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -8,22 +8,22 @@ import {
   FeatureOff,
   FeatureOn,
   MetadataTable,
+  NotePanel,
   Resolver,
   SimpleFeatureFlag,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
-import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
 import _ from "lodash";
 
-import type { ConfirmChild, ResolverChild, WorkflowProps } from ".";
+import type { ConfirmChild, ResolverChild, VerifyChild, WorkflowProps } from ".";
 
 const PodIdentifier: React.FC<ResolverChild> = ({ resolverType, notes = [] }) => {
   const { onSubmit } = useWizardContext();
   const resolvedResourceData = useDataLayout("resourceData");
   const resolverInput = useDataLayout("resolverInput");
-
+  const resolverNotes = notes.filter(note => note.location === "resolver");
   const onResolve = ({ results, input }) => {
     // Decide how to process results.
     resolvedResourceData.assign(results[0]);
@@ -31,17 +31,19 @@ const PodIdentifier: React.FC<ResolverChild> = ({ resolverType, notes = [] }) =>
     onSubmit();
   };
 
-  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={notes} />;
+  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={resolverNotes} />;
 };
 
-const PodDetails: React.FC<WizardChild> = () => {
+const PodDetails: React.FC<VerifyChild> = ({ notes = [] }) => {
   const { onSubmit, onBack } = useWizardContext();
   const resourceData = useDataLayout("resourceData");
   const instance = resourceData.displayValue() as IClutch.k8s.v1.Pod;
+  const locationNotes = notes.filter(note => note.location === "verify");
 
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>
       <strong>Pod Details</strong>
+      <NotePanel notes={locationNotes} />
       <MetadataTable
         data={[
           { name: "Name", value: instance.name },
@@ -67,12 +69,6 @@ const PodDetails: React.FC<WizardChild> = () => {
   );
 };
 
-/*
-TODO: Need information boxes for
-  These changes are not permanent, and will be overwritten on your next deploy. Adjust your manifest.yaml to persist changes across deploys.
-and
-  Note: the HPA should take just a few minutes to scale in either direction.
-*/
 const Confirm: React.FC<ConfirmChild> = () => {
   const deletionData = useDataLayout("deletionData");
   const podData = useDataLayout("resourceData");
@@ -112,7 +108,7 @@ const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <PodIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
-      <PodDetails name="Verify" />
+      <PodDetails name="Verify" notes={notes} />
       <Confirm name="Confirmation" />
     </Wizard>
   );

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -17,6 +17,7 @@ interface ConfirmConfigProps {
 
 export interface WorkflowProps extends BaseWorkflowProps, ResolverConfigProps, ConfirmConfigProps {}
 export interface ResolverChild extends WizardChild, ResolverConfigProps {}
+export interface VerifyChild extends WizardChild, ConfirmConfigProps {}
 export interface ConfirmChild extends WizardChild, ConfirmConfigProps {}
 
 const register = (): WorkflowConfiguration => {

--- a/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Terminate Instance workflow renders correctly 1`] = `
 "<Wizard dataLayout={{...}} heading={[undefined]}>
   <PodIdentifier name=\\"Lookup\\" resolverType=\\"clutch.k8s.v1.Pod\\" notes={{...}} />
-  <PodDetails name=\\"Verify\\" />
+  <PodDetails name=\\"Verify\\" notes={{...}} />
   <Confirm name=\\"Confirmation\\" />
 </Wizard>"
 `;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It would be nice to support notes in different locations for the delete pod flow. This PR adds support for prop-drilling the notes from the config down to the delete pod workflow. Note that the delete pod workflow does not work in local dev because of the way k8s clusters are set up.

There are generally 2 ways that users get to the delete pod workflow - 1. is through the k8s dashboard, and 2. is through the normal sidebar. The link from the k8s dashboard will jump to the second step in the wizard. The notes can potentially show up on the first step and second steps of the wizard, depending on their `location` field. Thus, no matter which way the users are using the delete pod workflow, they will see the notes.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
