### PR TITLE
FE: proj catalog: add button for configuration and overflow for qlinks

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -17,7 +17,8 @@ import ProjectInfoCard from "./info";
 import QuickLinksCard from "./quick-links";
 
 const StyledContainer = styled(Grid)({
-  padding: "32px",
+  padding: "16px",
+
 });
 
 const StyledHeadingContainer = styled(Grid)({
@@ -35,7 +36,7 @@ const DisabledItem = ({ name }: { name: string }) => (
 const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
   return (
     <>
-      <Grid container direction="row" style={{ padding: "8px " }}>
+      <Grid container direction="row" style={{ padding: "8px", justifyContent: "flex-end" }}>
         <Grid item>
           <QuickLinksCard linkGroups={linkGroups} />
         </Grid>
@@ -122,7 +123,7 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
         {/* Column for project details and header */}
         <Grid item direction="column" xs={12} sm={12} md={12} lg={12} xl={12}>
           <Grid container>
-            <StyledHeadingContainer item xs={12} sm={12} md={8} lg={9} xl={10}>
+            <StyledHeadingContainer item xs={6} sm={7} md={8} lg={9} xl={10}>
               {/* Static Header */}
               <ProjectHeader
                 name={projectId}

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -18,7 +18,6 @@ import QuickLinksCard from "./quick-links";
 
 const StyledContainer = styled(Grid)({
   padding: "16px",
-
 });
 
 const StyledHeadingContainer = styled(Grid)({

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { client, Grid, styled, Tooltip } from "@clutch-sh/core";
+import { client, Grid, IconButton, styled, Tooltip } from "@clutch-sh/core";
 import { faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Hidden from "@material-ui/core/Hidden";
 import GroupIcon from "@material-ui/icons/Group";
+import SettingsIcon from "@material-ui/icons/Settings";
 import { capitalize, isEmpty } from "lodash";
 
 import type { CatalogDetailsChild, ProjectDetailsWorkflowProps } from "..";
@@ -24,10 +24,6 @@ const StyledHeadingContainer = styled(Grid)({
   marginBottom: "24px",
 });
 
-const StyledQLContainer = styled(Grid)({
-  margin: "-8px 16px 16px 0px",
-});
-
 const DisabledItem = ({ name }: { name: string }) => (
   <Grid item>
     <Tooltip title={`${capitalize(name)} is disabled`}>
@@ -35,6 +31,23 @@ const DisabledItem = ({ name }: { name: string }) => (
     </Tooltip>
   </Grid>
 );
+
+const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
+  return (
+    <>
+      <Grid container direction="row" style={{ padding: "8px " }}>
+        <Grid item>
+          <QuickLinksCard linkGroups={linkGroups} />
+        </Grid>
+        <Grid item style={{ padding: "10px" }}>
+          <IconButton onClick={() => {}}>
+            <SettingsIcon />
+          </IconButton>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
 
 const fetchProject = (project: string): Promise<IClutch.core.project.v1.IProject> =>
   client
@@ -108,18 +121,20 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
       <StyledContainer container direction="row" wrap="nowrap">
         {/* Column for project details and header */}
         <Grid item direction="column" xs={12} sm={12} md={12} lg={12} xl={12}>
-          <StyledHeadingContainer item>
-            {/* Static Header */}
-            <ProjectHeader
-              name={projectId}
-              description={projectInfo?.data?.description as string}
-            />
-          </StyledHeadingContainer>
-          <Hidden mdUp>
-            <StyledQLContainer item direction="row" xs={12} sm={12}>
-              {projectInfo && <QuickLinksCard linkGroups={projectInfo?.linkGroups ?? []} />}
-            </StyledQLContainer>
-          </Hidden>
+          <Grid container>
+            <StyledHeadingContainer item xs={12} sm={12} md={8} lg={9} xl={10}>
+              {/* Static Header */}
+              <ProjectHeader
+                name={projectId}
+                description={projectInfo?.data?.description as string}
+              />
+            </StyledHeadingContainer>
+            {projectInfo && !isEmpty(projectInfo?.linkGroups) && (
+              <Grid item xs={12} sm={12} md={4} lg={3} xl={2}>
+              <QuickLinksAndSettingsBtn linkGroups={projectInfo.linkGroups} />
+            </Grid>
+            )}
+          </Grid>
           <Grid container direction="row" spacing={2}>
             <Grid container item xs={12} sm={12} md={5} lg={4} xl={3} spacing={2}>
               <Grid item xs={12}>
@@ -159,14 +174,6 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
             </Grid>
           </Grid>
         </Grid>
-        {/* Column for project quick links */}
-        <Hidden smDown>
-          <Grid item direction="column">
-            {projectInfo && !isEmpty(projectInfo?.linkGroups) && (
-              <QuickLinksCard linkGroups={projectInfo.linkGroups!} />
-            )}
-          </Grid>
-        </Hidden>
       </StyledContainer>
     </ProjectDetailsContext.Provider>
   );

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -131,8 +131,8 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
             </StyledHeadingContainer>
             {projectInfo && !isEmpty(projectInfo?.linkGroups) && (
               <Grid item xs={12} sm={12} md={4} lg={3} xl={2}>
-              <QuickLinksAndSettingsBtn linkGroups={projectInfo.linkGroups} />
-            </Grid>
+                <QuickLinksAndSettingsBtn linkGroups={projectInfo.linkGroups} />
+              </Grid>
             )}
           </Grid>
           <Grid container direction="row" spacing={2}>

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -38,7 +38,7 @@ const QuickLinkContainer = ({ key, name, children }: QuickLinkContainerProps) =>
   );
 
   return (
-    <Grid item key={key ?? ""}>
+    <Grid item key={key ?? ""} style={{padding: "8px"}}>
       {name ? container : children}
     </Grid>
   );
@@ -84,7 +84,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
       >
         <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
       </button>
-      <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)}>
+      <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)} placement={"bottom"}>
         {validLinks.map(link => (
           <PopperItem key={link.name}>
             {link?.url && (
@@ -156,16 +156,16 @@ const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => {
         <SlicedLinkGroup slicedLinkGroups={firstFive} />
         {overflow.length > 0 && (
           <>
-            <IconButton size="small" ref={anchorRef} onClick={() => setOpen(true)}>
+            <IconButton size="small" variant={"neutral"} ref={anchorRef} onClick={() => setOpen(true)}>
               <ExpandMoreIcon />
             </IconButton>
             <Popper
               open={open}
               anchorRef={anchorRef}
               onClickAway={() => setOpen(false)}
-              placement="bottom"
+              placement="bottom-end"
             >
-              <Grid style={{ padding: "8px" }}>
+              <Grid style={{ padding: "8px" }} direction="row" container>
                 <SlicedLinkGroup slicedLinkGroups={overflow} />
               </Grid>
             </Popper>

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -38,7 +38,7 @@ const QuickLinkContainer = ({ key, name, children }: QuickLinkContainerProps) =>
   );
 
   return (
-    <Grid item key={key ?? ""} style={{padding: "8px"}}>
+    <Grid item key={key ?? ""} style={{ padding: "8px" }}>
       {name ? container : children}
     </Grid>
   );
@@ -84,7 +84,12 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
       >
         <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
       </button>
-      <Popper open={open} anchorRef={anchorRef} onClickAway={() => setOpen(false)} placement={"bottom"}>
+      <Popper
+        open={open}
+        anchorRef={anchorRef}
+        onClickAway={() => setOpen(false)}
+        placement="bottom"
+      >
         {validLinks.map(link => (
           <PopperItem key={link.name}>
             {link?.url && (
@@ -156,7 +161,12 @@ const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => {
         <SlicedLinkGroup slicedLinkGroups={firstFive} />
         {overflow.length > 0 && (
           <>
-            <IconButton size="small" variant={"neutral"} ref={anchorRef} onClick={() => setOpen(true)}>
+            <IconButton
+              size="small"
+              variant="neutral"
+              ref={anchorRef}
+              onClick={() => setOpen(true)}
+            >
               <ExpandMoreIcon />
             </IconButton>
             <Popper

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -3,6 +3,7 @@ import type { clutch as IClutch } from "@clutch-sh/api";
 import {
   Card,
   Grid,
+  IconButton,
   Link,
   Popper,
   PopperItem,
@@ -10,6 +11,7 @@ import {
   TooltipContainer,
   Typography,
 } from "@clutch-sh/core";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 interface LinkGroupProps {
   linkGroupName: string;
@@ -102,17 +104,16 @@ export interface QuickLinksProps {
   linkGroups: IClutch.core.project.v1.ILinkGroup[];
 }
 
-const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => (
-  <Card>
-    <Grid
-      container
-      item
-      direction="column"
-      alignItems="center"
-      spacing={1}
-      style={{ padding: "8px" }}
-    >
-      {(linkGroups || []).map(linkGroup => {
+// TODO(smonero): Wasn't sure if I should make an interface for this or just reuse
+// or not make one at all since its so simple
+interface SlicedLinkGroupProps {
+  slicedLinkGroups: IClutch.core.project.v1.ILinkGroup[];
+}
+
+const SlicedLinkGroup = ({ slicedLinkGroups }: SlicedLinkGroupProps) => {
+  return (
+    <>
+      {(slicedLinkGroups || []).map(linkGroup => {
         if (linkGroup.links?.length === 1) {
           return (
             <QuickLink
@@ -130,8 +131,48 @@ const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => (
           />
         );
       })}
-    </Grid>
-  </Card>
-);
+    </>
+  );
+};
 
+const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => {
+  const anchorRef = React.useRef(null);
+  const [open, setOpen] = React.useState(false);
+  // Show only the first five quick links, and put the rest in
+  // an overflow popper
+  const firstFive = linkGroups.slice(0, 5);
+  const overflow = linkGroups.slice(5);
+
+  return (
+    <Card>
+      <Grid
+        container
+        item
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        style={{ padding: "10px" }}
+      >
+        <SlicedLinkGroup slicedLinkGroups={firstFive} />
+        {overflow.length > 0 && (
+          <>
+            <IconButton size="small" ref={anchorRef} onClick={() => setOpen(true)}>
+              <ExpandMoreIcon />
+            </IconButton>
+            <Popper
+              open={open}
+              anchorRef={anchorRef}
+              onClickAway={() => setOpen(false)}
+              placement="bottom"
+            >
+              <Grid style={{ padding: "8px" }}>
+                <SlicedLinkGroup slicedLinkGroups={overflow} />
+              </Grid>
+            </Popper>
+          </>
+        )}
+      </Grid>
+    </Card>
+  );
+};
 export default QuickLinksCard;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
In the case where there are more than 5 links, there is an overflow popout now. There is also a button that will allow for configuration.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local
### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #
![th](https://user-images.githubusercontent.com/66325812/165884025-8651a4d2-eb14-48f9-995f-1bd53225e585.gif)


### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
- [x] possibly remove some of the redundant styling
<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
