### PR TITLE
FE: fix alignment of icons and add feature flag for settings button

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -48,7 +48,7 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
         <Grid item>
           <QuickLinksCard linkGroups={linkGroups} />
         </Grid>
-        <SimpleFeatureFlag feature="projectSettings">
+        <SimpleFeatureFlag feature="projectCatalogSettings">
           <Grid item>
             <IconButton onClick={() => {}}>
               <SettingsIcon />

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { client, Grid, IconButton, styled, Tooltip } from "@clutch-sh/core";
+import { client, Grid, IconButton, SimpleFeatureFlag, styled, Tooltip } from "@clutch-sh/core";
 import { faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import GroupIcon from "@material-ui/icons/Group";
@@ -39,11 +39,13 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
         <Grid item>
           <QuickLinksCard linkGroups={linkGroups} />
         </Grid>
-        <Grid item style={{ padding: "10px" }}>
-          <IconButton onClick={() => {}}>
-            <SettingsIcon />
-          </IconButton>
-        </Grid>
+        <SimpleFeatureFlag feature="projectSettings">
+          <Grid item style={{ padding: "10px" }}>
+            <IconButton onClick={() => {}}>
+              <SettingsIcon />
+            </IconButton>
+          </Grid>
+        </SimpleFeatureFlag>
       </Grid>
     </>
   );

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { client, Grid, IconButton, SimpleFeatureFlag, styled, Tooltip } from "@clutch-sh/core";
+import {
+  client,
+  FeatureOn,
+  Grid,
+  IconButton,
+  SimpleFeatureFlag,
+  styled,
+  Tooltip,
+} from "@clutch-sh/core";
 import { faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import GroupIcon from "@material-ui/icons/Group";
@@ -49,11 +57,13 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
           <QuickLinksCard linkGroups={linkGroups} />
         </Grid>
         <SimpleFeatureFlag feature="projectCatalogSettings">
-          <Grid item>
-            <IconButton onClick={() => {}}>
-              <SettingsIcon />
-            </IconButton>
-          </Grid>
+          <FeatureOn>
+            <Grid item>
+              <IconButton onClick={() => {}}>
+                <SettingsIcon />
+              </IconButton>
+            </Grid>
+          </FeatureOn>
         </SimpleFeatureFlag>
       </Grid>
     </>

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -35,12 +35,21 @@ const DisabledItem = ({ name }: { name: string }) => (
 const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
   return (
     <>
-      <Grid container direction="row" style={{ padding: "8px", justifyContent: "flex-end" }}>
+      <Grid
+        container
+        direction="row"
+        style={{
+          padding: "8px",
+          justifyContent: "flex-end",
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
         <Grid item>
           <QuickLinksCard linkGroups={linkGroups} />
         </Grid>
         <SimpleFeatureFlag feature="projectSettings">
-          <Grid item style={{ padding: "10px" }}>
+          <Grid item>
             <IconButton onClick={() => {}}>
               <SettingsIcon />
             </IconButton>

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -47,7 +47,8 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
         container
         direction="row"
         alignItems="center"
-        spacing={2}
+        justify="flex-end"
+        spacing={1}
         style={{
           padding: "8px",
         }}
@@ -142,7 +143,7 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
         {/* Column for project details and header */}
         <Grid item direction="column" xs={12} sm={12} md={12} lg={12} xl={12}>
           <Grid container>
-            <StyledHeadingContainer item xs={6} sm={7} md={8} lg={9} xl={10}>
+            <StyledHeadingContainer item xs={6} sm={6} md={7} lg={8} xl={9}>
               {/* Static Header */}
               <ProjectHeader
                 name={projectId}
@@ -150,7 +151,7 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
               />
             </StyledHeadingContainer>
             {projectInfo && !isEmpty(projectInfo?.linkGroups) && (
-              <Grid item xs={12} sm={12} md={4} lg={3} xl={2}>
+              <Grid item xs={12} sm={12} md={5} lg={4} xl={3}>
                 <QuickLinksAndSettingsBtn linkGroups={projectInfo.linkGroups} />
               </Grid>
             )}

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -1,15 +1,7 @@
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import {
-  client,
-  FeatureOn,
-  Grid,
-  IconButton,
-  SimpleFeatureFlag,
-  styled,
-  Tooltip,
-} from "@clutch-sh/core";
+import { FeatureOn, Grid, IconButton, SimpleFeatureFlag, styled, Tooltip } from "@clutch-sh/core";
 import { faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import GroupIcon from "@material-ui/icons/Group";

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -46,11 +46,10 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
       <Grid
         container
         direction="row"
+        alignItems="center"
+        spacing={2}
         style={{
           padding: "8px",
-          justifyContent: "flex-end",
-          display: "flex",
-          alignItems: "center",
         }}
       >
         <Grid item>

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -94,15 +94,17 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
         open={open}
         anchorRef={anchorRef}
         onClickAway={() => setOpen(false)}
-        placement="bottom"
+        placement="bottom-end"
       >
         {validLinks.map(link => (
           <PopperItem key={link.name}>
             {link?.url && (
               <Link href={link.url}>
-                <Typography color="inherit" variant="body4">
-                  {link.name}
-                </Typography>
+                <span style={{ whiteSpace: "nowrap" }}>
+                  <Typography color="inherit" variant="body4">
+                    {link.name}
+                  </Typography>
+                </span>
               </Link>
             )}
           </PopperItem>

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -78,7 +78,13 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
     <QuickLinkContainer key={linkGroupName} name={linkGroupName}>
       <button
         type="button"
-        style={{ padding: 0, background: "transparent", border: "0", cursor: "pointer", display: "flex" }}
+        style={{
+          padding: 0,
+          background: "transparent",
+          border: "0",
+          cursor: "pointer",
+          display: "flex",
+        }}
         ref={anchorRef}
         onClick={() => setOpen(true)}
       >

--- a/frontend/workflows/projectCatalog/src/details/quick-links.tsx
+++ b/frontend/workflows/projectCatalog/src/details/quick-links.tsx
@@ -78,7 +78,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
     <QuickLinkContainer key={linkGroupName} name={linkGroupName}>
       <button
         type="button"
-        style={{ padding: 0, background: "transparent", border: "0", cursor: "pointer" }}
+        style={{ padding: 0, background: "transparent", border: "0", cursor: "pointer", display: "flex" }}
         ref={anchorRef}
         onClick={() => setOpen(true)}
       >


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Since settings button isn't working yet we can gate it using a feature flag. We also use flex to put the icons at the same height.
before:
<img width="248" alt="Screen Shot 2022-04-29 at 10 55 19 PM" src="https://user-images.githubusercontent.com/66325812/166093496-f4f2f4ec-4996-48d1-a61f-e4b2bf8a67f1.png">

after:

<img width="352" alt="Screen Shot 2022-04-29 at 10 53 16 PM" src="https://user-images.githubusercontent.com/66325812/166093502-d70b1d5b-4810-403b-b2f4-eea7186f79d0.png">

edit: might not need the feature flag because https://github.com/lyft/clutch/pull/2219 will probably be merged in soon

Also fixed the text to be `noWrap` to prevent wrapping of long links, and set spacing to 1 for that grid in the corner.

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
