### PR TITLE
FE: allow for callback to set value in Tabs component

### DIFF
--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -81,12 +81,16 @@ const TabPanel = styled(MuiTabPanel)({
 
 export interface TabsProps extends Pick<MuiTabsProps, "value" | "variant"> {
   children: React.ReactElement<TabProps> | React.ReactElement<TabProps>[];
+  setIndex?: (index: string) => void;
 }
 
-export const Tabs = ({ children, value, variant }: TabsProps) => {
+export const Tabs = ({ children, value, variant, setIndex }: TabsProps) => {
   const [selectedIndex, setSelectedIndex] = React.useState((value || 0).toString());
   const onChangeMiddleware = (_, v: string) => {
     setSelectedIndex(v);
+    if (setIndex) {
+      setIndex(v);
+    }
   };
 
   return (

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -81,15 +81,15 @@ const TabPanel = styled(MuiTabPanel)({
 
 export interface TabsProps extends Pick<MuiTabsProps, "value" | "variant"> {
   children: React.ReactElement<TabProps> | React.ReactElement<TabProps>[];
-  setIndex?: (index: string) => void;
+  setValueCallback?: (index: string) => void;
 }
 
-export const Tabs = ({ children, value, variant, setIndex }: TabsProps) => {
+export const Tabs = ({ children, value, variant, setValueCallback }: TabsProps) => {
   const [selectedIndex, setSelectedIndex] = React.useState((value || 0).toString());
   const onChangeMiddleware = (_, v: string) => {
     setSelectedIndex(v);
-    if (setIndex) {
-      setIndex(v);
+    if (setValueCallback) {
+      setValueCallback(v);
     }
   };
 

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -81,15 +81,15 @@ const TabPanel = styled(MuiTabPanel)({
 
 export interface TabsProps extends Pick<MuiTabsProps, "value" | "variant"> {
   children: React.ReactElement<TabProps> | React.ReactElement<TabProps>[];
-  setValueCallback?: (index: string) => void;
+  onChange?: (value: string) => void;
 }
 
-export const Tabs = ({ children, value, variant, setValueCallback }: TabsProps) => {
+export const Tabs = ({ children, value, variant, onChange }: TabsProps) => {
   const [selectedIndex, setSelectedIndex] = React.useState((value || 0).toString());
   const onChangeMiddleware = (_, v: string) => {
     setSelectedIndex(v);
-    if (setValueCallback) {
-      setValueCallback(v);
+    if (onChange) {
+      onChange(v);
     }
   };
 

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -81,6 +81,8 @@ const TabPanel = styled(MuiTabPanel)({
 
 export interface TabsProps extends Pick<MuiTabsProps, "value" | "variant"> {
   children: React.ReactElement<TabProps> | React.ReactElement<TabProps>[];
+  // To allow for callback functionality, use `onChange`
+  // Note the value is referring to the index, like "0", "1", "2", etc.
   onChange?: (value: string) => void;
 }
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It is convenient to allow for a callback function to communicate back the tab index to a parent.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
