### PR TITLE
frontend: add type information to Project Catalog StyledLink

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/helpers.tsx
+++ b/frontend/workflows/projectCatalog/src/details/helpers.tsx
@@ -6,7 +6,7 @@ import { client, Grid, Link, styled, Typography } from "@clutch-sh/core";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-const StyledLink = styled(Link)({
+const StyledLink: React.ElementType = styled(Link)({
   whiteSpace: "nowrap",
 });
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add type information to StyledLink since it's exported from project catalog helpers

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
N/A