### PR TITLE
frontend: ProjectCatalog Config params patch

### DIFF
--- a/frontend/workflows/projectCatalog/src/config/index.tsx
+++ b/frontend/workflows/projectCatalog/src/config/index.tsx
@@ -54,11 +54,11 @@ const Config: React.FC<ProjectDetailsConfigWorkflowProps> = ({ children, default
           if (title) {
             validPages.push(
               React.cloneElement(child, {
-                onError: (error: ClutchError) => {
+                onError: (e: ClutchError) => {
                   if (onError) {
-                    onError(error);
+                    onError(e);
                   }
-                  setError(error);
+                  setError(e);
                 },
               })
             );

--- a/frontend/workflows/projectCatalog/src/config/index.tsx
+++ b/frontend/workflows/projectCatalog/src/config/index.tsx
@@ -13,7 +13,7 @@ const StyledContainer = styled(Grid)({
   padding: "32px",
 });
 
-const Config: React.FC<ProjectDetailsConfigWorkflowProps> = ({ children, defaultRoute }) => {
+const Config: React.FC<ProjectDetailsConfigWorkflowProps> = ({ children, defaultRoute = "/" }) => {
   const { projectId, configType = defaultRoute } = useParams();
   const location = useLocation();
   const navigate = useNavigate();

--- a/frontend/workflows/projectCatalog/src/config/index.tsx
+++ b/frontend/workflows/projectCatalog/src/config/index.tsx
@@ -49,10 +49,19 @@ const Config: React.FC<ProjectDetailsConfigWorkflowProps> = ({ children, default
 
       React.Children.forEach(children, (child, index) => {
         if (React.isValidElement(child)) {
-          const { title, path } = child?.props;
+          const { title, path, onError } = child?.props;
 
           if (title) {
-            validPages.push(child);
+            validPages.push(
+              React.cloneElement(child, {
+                onError: (error: ClutchError) => {
+                  if (onError) {
+                    onError(error);
+                  }
+                  setError(error);
+                },
+              })
+            );
 
             if (configType === path) {
               setSelectedPage(index);
@@ -94,12 +103,7 @@ const Config: React.FC<ProjectDetailsConfigWorkflowProps> = ({ children, default
           </Grid>
         )}
         <Grid item xs={12}>
-          {configPages &&
-            configPages.length > 0 &&
-            React.cloneElement(configPages[selectedPage], {
-              ...configPages[selectedPage].props,
-              onError: setError,
-            })}
+          {configPages && configPages.length > 0 && configPages[selectedPage]}
         </Grid>
       </StyledContainer>
     </ProjectDetailsContext.Provider>

--- a/frontend/workflows/projectCatalog/src/index.tsx
+++ b/frontend/workflows/projectCatalog/src/index.tsx
@@ -28,7 +28,7 @@ export interface ProjectDetailsWorkflowProps extends WorkflowProps {
 
 export interface ProjectDetailsConfigWorkflowProps extends WorkflowProps {
   children?: ProjectConfigPage | ProjectConfigPage[];
-  defaultRoute: string;
+  defaultRoute?: string;
 }
 
 const register = (): WorkflowConfiguration => {

--- a/frontend/workflows/projectCatalog/src/index.tsx
+++ b/frontend/workflows/projectCatalog/src/index.tsx
@@ -12,7 +12,7 @@ type DetailCard = CatalogDetailsCard | typeof DynamicCard | typeof MetaCard;
 export interface ProjectConfigProps {
   title: string;
   path: string;
-  onError: (error: ClutchError) => void;
+  onError?: (error: ClutchError) => void;
 }
 
 type CatalogDetailsChild = React.ReactElement<DetailCard>;


### PR DESCRIPTION
### Description
- Making `onError` optional since it is currently set during `cloneElement`
- Making `defaultRoute` optional
- Adjusted onError handler and will check if the user has already defined one and call that one before setting the error

### Testing Performed
manual