### PR TITLE
frontend: add package scope support to workflow registrar

### DIFF
--- a/frontend/packages/tools/workflow-registrar.js
+++ b/frontend/packages/tools/workflow-registrar.js
@@ -10,13 +10,10 @@ const rootFrontendDir = `${srcDir}/..`;
 const WORKFLOW_MODULE_PATH = `${srcDir}/workflows.jsx`;
 
 const addImport = workflow => {
-  let moduleNameParts = [workflow];
-  if (workflow.includes("/")) {
-    const packageName = workflow.split("/")[1];
-    moduleNameParts = [packageName];
-    if (packageName.includes("-")) {
-      moduleNameParts = packageName.split("-");
-    }
+  const wkflwName = workflow.replace("@", "");
+  let moduleNameParts = [wkflwName];
+  if (wkflwName.includes("/")) {
+    moduleNameParts = wkflwName.split(/[/-]+/);
   }
   const moduleName = moduleNameParts
     .map((part, idx) => {
@@ -30,7 +27,7 @@ const addImport = workflow => {
     WORKFLOW_MODULE_PATH,
     `import { default as ${moduleName}} from "${workflow}";\n`
   );
-  console.log(`Registered ${moduleName} workflow...`); // eslint-disable-line no-console
+  console.log(`Registered ${workflow} workflow...`); // eslint-disable-line no-console
   return moduleName;
 };
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add support for package scopes to the workflow registrar. This allows for packages with conflicting names (@a/bar and @b/bar) to both be registered via the Clutch config utilizing the package scope for uniqueness.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual