### PR TITLE
FE: add a test to Tabs component

### DIFF
--- a/frontend/packages/core/src/tests/tab.test.tsx
+++ b/frontend/packages/core/src/tests/tab.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import { Tab, Tabs } from "../tab";
+
+describe("Tabs component aka TabGroup", () => {
+  describe("basic rendering", () => {
+    let component;
+    beforeEach(() => {
+      component = shallow(
+        <Tabs value={1}>
+          <Tab label="meow" />
+          <Tab label="mix" />
+        </Tabs>
+      );
+    });
+
+    it("renders", () => {
+      expect(component.find(Tabs)).toBeDefined();
+    });
+
+    it("renders 2 Tabs", () => {
+      expect(component.find(Tab)).toHaveLength(2);
+    });
+
+    it("has the second tab selected (index 1)", () => {
+      expect(component.find("TabContext").prop("value")).toBe("1");
+    });
+  });
+});

--- a/frontend/packages/core/src/tests/tab.test.tsx
+++ b/frontend/packages/core/src/tests/tab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import { Tab, Tabs } from "../tab";
 
@@ -25,6 +25,19 @@ describe("Tabs component", () => {
 
     it("displays the tab from the specified value", () => {
       expect(component.find("TabContext").prop("value")).toBe("1");
+    });
+
+    it("has the mix tab selected", () => {
+      // use mount instead of shallow so that we get the other props like
+      // `selected`
+      const mounted = mount(
+        <Tabs value={1}>
+          <Tab label="meow" />
+          <Tab label="mix" />
+        </Tabs>
+      );
+      expect(mounted.find(Tab).at(1).prop("label")).toBe("mix");
+      expect(mounted.find(Tab).at(1).prop("selected")).toBe(true);
     });
   });
 });

--- a/frontend/packages/core/src/tests/tab.test.tsx
+++ b/frontend/packages/core/src/tests/tab.test.tsx
@@ -3,8 +3,8 @@ import { shallow } from "enzyme";
 
 import { Tab, Tabs } from "../tab";
 
-describe("Tabs component aka TabGroup", () => {
-  describe("basic rendering", () => {
+describe("Tabs component", () => {
+  describe("with a value set", () => {
     let component;
     beforeEach(() => {
       component = shallow(
@@ -19,11 +19,11 @@ describe("Tabs component aka TabGroup", () => {
       expect(component.find(Tabs)).toBeDefined();
     });
 
-    it("renders 2 Tabs", () => {
+    it("renders children tabs", () => {
       expect(component.find(Tab)).toHaveLength(2);
     });
 
-    it("has the second tab selected (index 1)", () => {
+    it("displays the tab from the specified value", () => {
       expect(component.find("TabContext").prop("value")).toBe("1");
     });
   });


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Another test, this one for the Tabs component. This part of an wider effort to add more FE tests to Clutch.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
