### PR TITLE
k8s: add direct clientset access

### DIFF
--- a/backend/mock/service/k8smock/k8smock.go
+++ b/backend/mock/service/k8smock/k8smock.go
@@ -355,6 +355,10 @@ func (*svc) Clientsets(ctx context.Context) ([]string, error) {
 	return []string{"fake-user@fake-cluster"}, nil
 }
 
+func (*svc) GetK8sClientset(clientset string) (k8sservice.ContextClientset, error) {
+	return nil, nil
+}
+
 func New() k8sservice.Service {
 	return &svc{}
 }

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -22,6 +22,7 @@ const (
 type ClientsetManager interface {
 	Clientsets(ctx context.Context) (map[string]ContextClientset, error)
 	GetK8sClientset(ctx context.Context, clientset, cluster, namespace string) (ContextClientset, error)
+	GetK8sClientsetSimple(clientset string) (ContextClientset, error)
 }
 
 type ContextClientset interface {
@@ -140,6 +141,14 @@ func (m *managerImpl) Clientsets(ctx context.Context) (map[string]ContextClients
 		ret[k] = v
 	}
 	return ret, nil
+}
+
+func (m *managerImpl) GetK8sClientsetSimple(clientset string) (ContextClientset, error) {
+	cs, ok := m.clientsets[clientset]
+	if !ok {
+		return nil, fmt.Errorf("clientset [%s] is not found", clientset)
+	}
+	return cs, nil
 }
 
 func (m *managerImpl) GetK8sClientset(ctx context.Context, clientset, cluster, namespace string) (ContextClientset, error) {

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -22,7 +22,7 @@ const (
 type ClientsetManager interface {
 	Clientsets(ctx context.Context) (map[string]ContextClientset, error)
 	GetK8sClientset(ctx context.Context, clientset, cluster, namespace string) (ContextClientset, error)
-	GetK8sClientsetSimple(clientset string) (ContextClientset, error)
+	GetK8sClientsetDirect(clientset string) (ContextClientset, error)
 }
 
 type ContextClientset interface {
@@ -143,11 +143,11 @@ func (m *managerImpl) Clientsets(ctx context.Context) (map[string]ContextClients
 	return ret, nil
 }
 
-// GetK8sClientsetSimple is used to expose access directly to a single clientset.
+// GetK8sClientsetDirect is used to expose access directly to a single clientset.
 // There is an public method on the K8s service interface that allows implementers direct access to a clientset if necessary,
 // this use case comes up with a private gateway wishes to add k8s specific features
 // that don’t make sense to upstream but would like to make use of the clientsets that we already provide.
-func (m *managerImpl) GetK8sClientsetSimple(clientset string) (ContextClientset, error) {
+func (m *managerImpl) GetK8sClientsetDirect(clientset string) (ContextClientset, error) {
 	cs, ok := m.clientsets[clientset]
 	if !ok {
 		return nil, fmt.Errorf("clientset [%s] is not found", clientset)

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -143,6 +143,10 @@ func (m *managerImpl) Clientsets(ctx context.Context) (map[string]ContextClients
 	return ret, nil
 }
 
+// GetK8sClientsetSimple is used to expose access directly to a single clientset.
+// There is an public method on the K8s service interface that allows implementers direct access to a clientset if necessary,
+// this use case comes up with a private gateway wishes to add k8s specific features
+// that don’t make sense to upstream but would like to make use of the clientsets that we already provide.
 func (m *managerImpl) GetK8sClientsetSimple(clientset string) (ContextClientset, error) {
 	cs, ok := m.clientsets[clientset]
 	if !ok {

--- a/backend/service/k8s/clientset_test.go
+++ b/backend/service/k8s/clientset_test.go
@@ -47,13 +47,13 @@ func TestClientsetManager(t *testing.T) {
 	assert.Nil(t, cs)
 
 	// Simple clientset is found.
-	cs, err = m.GetK8sClientsetSimple("core-0")
+	cs, err = m.GetK8sClientsetDirect("core-0")
 	assert.NoError(t, err)
 	assert.NotNil(t, cs)
 	assert.Equal(t, "core-cluster-0", cs.Cluster())
 
 	// Simple clientset is not found error.
-	cs, err = m.GetK8sClientsetSimple("undefined")
+	cs, err = m.GetK8sClientsetDirect("undefined")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "clientset [undefined] is not found")
 	assert.Nil(t, cs)

--- a/backend/service/k8s/clientset_test.go
+++ b/backend/service/k8s/clientset_test.go
@@ -55,6 +55,6 @@ func TestClientsetManager(t *testing.T) {
 	// Simple clientset is not found error.
 	cs, err = m.GetK8sClientsetSimple("undefined")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "is not found")
+	assert.Contains(t, err.Error(), "clientset [undefined] is not found")
 	assert.Nil(t, cs)
 }

--- a/backend/service/k8s/clientset_test.go
+++ b/backend/service/k8s/clientset_test.go
@@ -45,4 +45,16 @@ func TestClientsetManager(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "impossible to determine")
 	assert.Nil(t, cs)
+
+	// Simple clientset is found.
+	cs, err = m.GetK8sClientsetSimple("core-0")
+	assert.NoError(t, err)
+	assert.NotNil(t, cs)
+	assert.Equal(t, "core-cluster-0", cs.Cluster())
+
+	// Simple clientset is not found error.
+	cs, err = m.GetK8sClientsetSimple("undefined")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is not found")
+	assert.Nil(t, cs)
 }

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -52,6 +52,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 type Service interface {
 	// All names of clientsets.
 	Clientsets(ctx context.Context) ([]string, error)
+	GetK8sClientset(clientset string) (ContextClientset, error)
 
 	// Pod management functions.
 	DescribePod(ctx context.Context, clientset, cluster, namespace, name string) (*k8sapiv1.Pod, error)

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -138,6 +138,10 @@ func (s *svc) Clientsets(ctx context.Context) ([]string, error) {
 	return ret, nil
 }
 
+func (s *svc) GetK8sClientset(clientset string) (ContextClientset, error) {
+	return s.manager.GetK8sClientsetSimple(clientset)
+}
+
 // Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.
 func (s *svc) InterceptError(e error) error {
 	return ConvertError(e)

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -140,7 +140,7 @@ func (s *svc) Clientsets(ctx context.Context) ([]string, error) {
 }
 
 func (s *svc) GetK8sClientset(clientset string) (ContextClientset, error) {
-	return s.manager.GetK8sClientsetSimple(clientset)
+	return s.manager.GetK8sClientsetDirect(clientset)
 }
 
 // Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Add direct client access for K8s clientsets, which may be needed if you wanted to implement custom logic with the K8s client in a users private gateway.

### Testing Performed
Unit