### PR TITLE
frontend: add noWrap prop to typography component

### DIFF
--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { TypographyProps as MuiTypographyProps } from "@material-ui/core";
 
 import styled from "./styled";
 
@@ -147,14 +148,14 @@ const StyledTypography = styled("div")<{
   ...(STYLE_MAP[props.$variant]?.props || {}),
 }));
 
-export interface TypographyProps {
+export interface TypographyProps extends Pick<MuiTypographyProps, "noWrap"> {
   variant: TextVariant;
   children: React.ReactNode;
   color?: string;
 }
 
-const Typography = ({ variant, children, color = "#0D1030" }: TypographyProps) => (
-  <StyledTypography $variant={variant} $color={color}>
+const Typography = ({ variant, children, color = "#0D1030", ...props }: TypographyProps) => (
+  <StyledTypography $variant={variant} $color={color} {...props}>
     {children}
   </StyledTypography>
 );

--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -147,11 +147,13 @@ const StyledTypography = styled("div")<{
   fontWeight: STYLE_MAP[props.$variant].weight,
   lineHeight: `${STYLE_MAP[props.$variant].lineHeight}px`,
   ...(STYLE_MAP[props.$variant]?.props || {}),
-  ...(props.noWrap ? {
-    whiteSpace: "nowrap",
-    textOverflow: "ellipsis",
-    overflow: "hidden",
-  } : {}),
+  ...(props.noWrap
+    ? {
+        whiteSpace: "nowrap",
+        textOverflow: "ellipsis",
+        overflow: "hidden",
+      }
+    : {}),
 }));
 
 export interface TypographyProps extends Pick<MuiTypographyProps, "noWrap"> {

--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -140,12 +140,18 @@ type TextVariant =
 const StyledTypography = styled("div")<{
   $variant: TypographyProps["variant"];
   $color: TypographyProps["color"];
+  noWrap: TypographyProps["noWrap"];
 }>(props => ({
   color: props.$color,
   fontSize: `${STYLE_MAP[props.$variant].size}px`,
   fontWeight: STYLE_MAP[props.$variant].weight,
   lineHeight: `${STYLE_MAP[props.$variant].lineHeight}px`,
   ...(STYLE_MAP[props.$variant]?.props || {}),
+  ...(props.noWrap ? {
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    overflow: "hidden",
+  } : {}),
 }));
 
 export interface TypographyProps extends Pick<MuiTypographyProps, "noWrap"> {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
add `noWrap` props from material ui typography component to Clutch typography component.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual