### PR TITLE
frontend: ShortLinks Patch for ProjectSelector

### DIFF
--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -237,6 +237,7 @@ const ProjectSelector = ({ onError }: ProjectSelectorProps) => {
 
     if (onError && state.projectErrors && state.projectErrors.length) {
       onError({ errors: state.projectErrors });
+      dispatch({ type: "CLEAR_ERRORS" });
     }
 
     const dashState: DashState = { projectData: {}, selected: [] };

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -237,7 +237,7 @@ const ProjectSelector = ({ onError }: ProjectSelectorProps) => {
 
     if (onError && state.projectErrors && state.projectErrors.length) {
       onError({ errors: state.projectErrors });
-      dispatch({ type: "CLEAR_ERRORS" });
+      dispatch({ type: "CLEAR_PROJECT_ERRORS" });
     }
 
     const dashState: DashState = { projectData: {}, selected: [] };

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -279,7 +279,7 @@ const selectorReducer = (state: State, action: Action): State => {
         error: action?.payload?.result,
       };
     }
-    case "CLEAR_ERRORS": {
+    case "CLEAR_PROJECT_ERRORS": {
       return { ...state, projectErrors: [] };
     }
     default:

--- a/frontend/workflows/projectSelector/src/selector-reducer.tsx
+++ b/frontend/workflows/projectSelector/src/selector-reducer.tsx
@@ -165,7 +165,6 @@ const selectorReducer = (state: State, action: Action): State => {
       };
     }
     // Background actions.
-
     case "HYDRATE_START": {
       return { ...state, loading: true };
     }
@@ -279,6 +278,9 @@ const selectorReducer = (state: State, action: Action): State => {
         loading: false,
         error: action?.payload?.result,
       };
+    }
+    case "CLEAR_ERRORS": {
+      return { ...state, projectErrors: [] };
     }
     default:
       throw new Error(`unknown resolver action`);

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -24,7 +24,11 @@ interface UserPayload {
   projects?: string[];
 }
 
-type BackgroundActionKind = "HYDRATE_START" | "HYDRATE_END" | "HYDRATE_ERROR" | "CLEAR_ERRORS";
+type BackgroundActionKind =
+  | "HYDRATE_START"
+  | "HYDRATE_END"
+  | "HYDRATE_ERROR"
+  | "CLEAR_PROJECT_ERRORS";
 
 interface BackgroundAction {
   type: BackgroundActionKind;

--- a/frontend/workflows/projectSelector/src/types.tsx
+++ b/frontend/workflows/projectSelector/src/types.tsx
@@ -24,7 +24,7 @@ interface UserPayload {
   projects?: string[];
 }
 
-type BackgroundActionKind = "HYDRATE_START" | "HYDRATE_END" | "HYDRATE_ERROR";
+type BackgroundActionKind = "HYDRATE_START" | "HYDRATE_END" | "HYDRATE_ERROR" | "CLEAR_ERRORS";
 
 interface BackgroundAction {
   type: BackgroundActionKind;


### PR DESCRIPTION
### Description
Ran into an error when an error is returned via onError it wasn't being cleared. So if you successfully make a change afterwards you would get the same initial error. This PR modifies the logic so after calling `onError` it will immediately dispatch a change to clear the error from the state.

### Testing Performed
manual

To test, search for a deprecated project (which will generate a toast), let it clear. Then look up anything else. You'll get the same initial error as the first one.
