### PR TITLE
k8s: refactor direct clientset access

### DIFF
--- a/backend/mock/service/k8smock/k8smock.go
+++ b/backend/mock/service/k8smock/k8smock.go
@@ -355,7 +355,7 @@ func (*svc) Clientsets(ctx context.Context) ([]string, error) {
 	return []string{"fake-user@fake-cluster"}, nil
 }
 
-func (*svc) GetK8sClientset(clientset string) (k8sservice.ContextClientset, error) {
+func (*svc) GetK8sClientset(ctx context.Context, clientset string) (k8sservice.ContextClientset, error) {
 	return nil, nil
 }
 

--- a/backend/service/k8s/clientset.go
+++ b/backend/service/k8s/clientset.go
@@ -22,7 +22,6 @@ const (
 type ClientsetManager interface {
 	Clientsets(ctx context.Context) (map[string]ContextClientset, error)
 	GetK8sClientset(ctx context.Context, clientset, cluster, namespace string) (ContextClientset, error)
-	GetK8sClientsetDirect(clientset string) (ContextClientset, error)
 }
 
 type ContextClientset interface {
@@ -141,18 +140,6 @@ func (m *managerImpl) Clientsets(ctx context.Context) (map[string]ContextClients
 		ret[k] = v
 	}
 	return ret, nil
-}
-
-// GetK8sClientsetDirect is used to expose access directly to a single clientset.
-// There is an public method on the K8s service interface that allows implementers direct access to a clientset if necessary,
-// this use case comes up with a private gateway wishes to add k8s specific features
-// that don’t make sense to upstream but would like to make use of the clientsets that we already provide.
-func (m *managerImpl) GetK8sClientsetDirect(clientset string) (ContextClientset, error) {
-	cs, ok := m.clientsets[clientset]
-	if !ok {
-		return nil, fmt.Errorf("clientset [%s] is not found", clientset)
-	}
-	return cs, nil
 }
 
 func (m *managerImpl) GetK8sClientset(ctx context.Context, clientset, cluster, namespace string) (ContextClientset, error) {

--- a/backend/service/k8s/clientset_test.go
+++ b/backend/service/k8s/clientset_test.go
@@ -45,16 +45,4 @@ func TestClientsetManager(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "impossible to determine")
 	assert.Nil(t, cs)
-
-	// Simple clientset is found.
-	cs, err = m.GetK8sClientsetDirect("core-0")
-	assert.NoError(t, err)
-	assert.NotNil(t, cs)
-	assert.Equal(t, "core-cluster-0", cs.Cluster())
-
-	// Simple clientset is not found error.
-	cs, err = m.GetK8sClientsetDirect("undefined")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "clientset [undefined] is not found")
-	assert.Nil(t, cs)
 }

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -140,7 +140,8 @@ func (s *svc) Clientsets(ctx context.Context) ([]string, error) {
 }
 
 func (s *svc) GetK8sClientset(clientset string) (ContextClientset, error) {
-	return s.manager.GetK8sClientsetDirect(clientset)
+	// Dont specify cluster or namespace, were simply looking for the clientset.
+	return s.manager.GetK8sClientset(context.Background(), clientset, "", "")
 }
 
 // Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.

--- a/backend/service/k8s/k8s.go
+++ b/backend/service/k8s/k8s.go
@@ -52,7 +52,7 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 type Service interface {
 	// All names of clientsets.
 	Clientsets(ctx context.Context) ([]string, error)
-	GetK8sClientset(clientset string) (ContextClientset, error)
+	GetK8sClientset(ctx context.Context, clientset string) (ContextClientset, error)
 
 	// Pod management functions.
 	DescribePod(ctx context.Context, clientset, cluster, namespace, name string) (*k8sapiv1.Pod, error)
@@ -139,9 +139,9 @@ func (s *svc) Clientsets(ctx context.Context) ([]string, error) {
 	return ret, nil
 }
 
-func (s *svc) GetK8sClientset(clientset string) (ContextClientset, error) {
+func (s *svc) GetK8sClientset(ctx context.Context, clientset string) (ContextClientset, error) {
 	// Dont specify cluster or namespace, were simply looking for the clientset.
-	return s.manager.GetK8sClientset(context.Background(), clientset, "", "")
+	return s.manager.GetK8sClientset(ctx, clientset, "", "")
 }
 
 // Implement the interface provided by errorintercept, so errors are caught at middleware and converted to gRPC status.

--- a/backend/service/k8s/k8s_test.go
+++ b/backend/service/k8s/k8s_test.go
@@ -163,5 +163,5 @@ func TestGetK8sClientset(t *testing.T) {
 	cs, err = svc.GetK8sClientset("unknown")
 	assert.Error(t, err)
 	assert.Nil(t, cs)
-	assert.Contains(t, err.Error(), "clientset [unknown] is not found")
+	assert.Contains(t, err.Error(), "clientset 'unknown' not found")
 }

--- a/backend/service/k8s/k8s_test.go
+++ b/backend/service/k8s/k8s_test.go
@@ -154,13 +154,13 @@ func TestGetK8sClientset(t *testing.T) {
 	assert.True(t, ok)
 
 	// Get valid clientset
-	cs, err := svc.GetK8sClientset("test-user@test-cluster")
+	cs, err := svc.GetK8sClientset(context.Background(), "test-user@test-cluster")
 	assert.NoError(t, err)
 	assert.NotNil(t, cs)
 	assert.Equal(t, "test-cluster", cs.Cluster())
 
 	// Try to get an unknown clientset
-	cs, err = svc.GetK8sClientset("unknown")
+	cs, err = svc.GetK8sClientset(context.Background(), "unknown")
 	assert.Error(t, err)
 	assert.Nil(t, cs)
 	assert.Contains(t, err.Error(), "clientset 'unknown' not found")


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
In https://github.com/lyft/clutch/pull/2232 i made changes to allow for direct cientset access. However upon looking back the implementation could of been simpler without needing to change the `ClientsetManager` interface at all. This refactor uses the existing `GetK8sClientset` func with defaults. I also updated the the k8s interface to include a context for this new function as its now required.

### Testing Performed
Unit.
