### PR TITLE
FE: project catalog: adjust spacing

### DIFF
--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -45,7 +45,7 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
         justify="flex-end"
         spacing={1}
         style={{
-          paddingRight: "32px",
+          padding: "8px 32px 0px 0px",
         }}
       >
         <Grid item>

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -19,6 +19,7 @@ import QuickLinksCard from "./quick-links";
 
 const StyledContainer = styled(Grid)({
   padding: "16px",
+  justifyContent: "center",
 });
 
 const StyledHeadingContainer = styled(Grid)({
@@ -138,7 +139,7 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
               />
             </StyledHeadingContainer>
             {projectInfo && !isEmpty(projectInfo?.linkGroups) && (
-              <Grid item xs={12} sm={12} md={5} lg={4} xl={3}>
+              <Grid container item xs={12} sm={12} md={5} lg={4} xl={3} spacing={2}>
                 <QuickLinksAndSettingsBtn linkGroups={projectInfo.linkGroups} />
               </Grid>
             )}

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -19,7 +19,6 @@ import QuickLinksCard from "./quick-links";
 
 const StyledContainer = styled(Grid)({
   padding: "16px",
-  justifyContent: "center",
 });
 
 const StyledHeadingContainer = styled(Grid)({

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -45,7 +45,7 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
         justify="flex-end"
         spacing={1}
         style={{
-          padding: "8px",
+          paddingRight: "32px",
         }}
       >
         <Grid item>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
The final design is like the second pic but with 8px padding added to the top

Another potential option is to use `justify-content` to center the grid items rather than having things left aligned like they are now. Note that the project catalog search page has things left aligned, not centered, so I guess it is good to be consistent.

Before:
<img width="1666" alt="Screen Shot 2022-05-24 at 8 37 00 PM" src="https://user-images.githubusercontent.com/66325812/170174660-9cca24d9-6b2f-4195-bb95-fced8b5924d6.png">

After [FINAL DESIGN]:

![Screen Shot 2022-05-25 at 2 15 40 PM](https://user-images.githubusercontent.com/66325812/170370136-240effc4-97f8-4986-8e78-d9ed00380869.png)

[old design] After (before shifting things over for Josh's comment):
<img width="1660" alt="Screen Shot 2022-05-24 at 8 36 27 PM" src="https://user-images.githubusercontent.com/66325812/170174653-3b6315f1-d953-4e28-ba1d-c10ad6fe60c4.png">

justify content strategy (could also center the top grid row as well, you can see the lower one is centered but it doesn't line up with the header anymore):

<img width="1658" alt="Screen Shot 2022-05-24 at 8 18 11 PM" src="https://user-images.githubusercontent.com/66325812/170174789-a41e669a-aedf-49dc-8eba-2a73c5f25e04.png">



<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
