### PR TITLE
backend: use variable for max limit paginated query builder error

### DIFF
--- a/backend/service/topology/querybuilder.go
+++ b/backend/service/topology/querybuilder.go
@@ -40,7 +40,7 @@ func paginatedQueryBuilder(
 ) (sq.SelectBuilder, uint64, error) {
 	queryLimit := queryDefaultLimit
 	if limit > maxResultLimit {
-		return sq.SelectBuilder{}, 0, status.Error(codes.InvalidArgument, "maximum query limit is 1000")
+		return sq.SelectBuilder{}, 0, status.Error(codes.InvalidArgument, fmt.Sprintf("maximum query limit is %d", maxResultLimit))
 	} else if limit > 0 {
 		queryLimit = limit
 	}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Update error message to use variable value in topo query builder

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
N/A
