### PR TITLE
tools: update pre-flight check script for local yarn binary

### DIFF
--- a/tools/preflight-checks.sh
+++ b/tools/preflight-checks.sh
@@ -19,7 +19,6 @@ fi
 
 echo "${REPO_ROOT}"
 
-API_ROOT="${REPO_ROOT}/api"
 BUILD_ROOT="${REPO_ROOT}/build"
 
 # param 1 - required version

--- a/tools/preflight-checks.sh
+++ b/tools/preflight-checks.sh
@@ -9,11 +9,15 @@ MIN_GO_VERSION="1.17"
 MIN_NODE_VERSION="16.0.0"
 MIN_YARN_VERSION="1.22.0"
 
+SCRIPT_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
 REPO_ROOT="${SCRIPT_ROOT}"
 # Use alternate root if provided as command line argument.
-if [[ -n "${1-}" ]]; then
+if [[ -n "${1-}" ]] && [[ "$1" == *"/"* ]]; then
   REPO_ROOT="${1}"
+  shift
 fi
+
+echo "${REPO_ROOT}"
 
 API_ROOT="${REPO_ROOT}/api"
 BUILD_ROOT="${REPO_ROOT}/build"
@@ -90,6 +94,7 @@ frontend() {
 }
 
 main() {
+  echo "Running pre-flight checks..."
   # always check OS level requirements
   os
 
@@ -108,6 +113,7 @@ main() {
     printf "\nPlease refer to the development requirements https://clutch.sh/docs/getting-started/local-build/#requirements"
     return 1
   fi
+  echo "Pre-flight checks satisfied!"
 }
 
 main "$@"

--- a/tools/preflight-checks.sh
+++ b/tools/preflight-checks.sh
@@ -9,6 +9,15 @@ MIN_GO_VERSION="1.17"
 MIN_NODE_VERSION="16.0.0"
 MIN_YARN_VERSION="1.22.0"
 
+REPO_ROOT="${SCRIPT_ROOT}"
+# Use alternate root if provided as command line argument.
+if [[ -n "${1-}" ]]; then
+  REPO_ROOT="${1}"
+fi
+
+API_ROOT="${REPO_ROOT}/api"
+BUILD_ROOT="${REPO_ROOT}/build"
+
 # param 1 - required version
 # param 2 - current version
 # returns true or false if the version is ok
@@ -68,11 +77,11 @@ frontend() {
     fi
   fi
 
-  if ! command -v yarn &> /dev/null; then
+  if ! command -v "${BUILD_ROOT}/bin/yarn.sh" &> /dev/null; then
     echo "yarn is not installed or cannot be found in the current PATH, this is a required dependency."
     did_checks_pass=false
   else
-    current_version=$(yarn --version)
+    current_version=$("${BUILD_ROOT}/bin/yarn.sh" --version)
     if ! is_version_ok $MIN_YARN_VERSION "$current_version"; then
       echo "yarn version must be >= $MIN_YARN_VERSION, current version $current_version"
       did_checks_pass=false


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This updates the pre-flight script to look for the local yarn binary that's installed into the local bin directory instead of globally. As part of this modification the script needs to read in a local directory override since it can be run from any gateway and needs to check that gateway for the yarn binary.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual