### PR TITLE
tools: fix yarn initalization in compile-protos

### DIFF
--- a/tools/compile-protos.sh
+++ b/tools/compile-protos.sh
@@ -237,6 +237,7 @@ install_protobufjs() {
   if [[ ! -f "${PROTOBUFJS_DIR}/node_modules/.bin/pbjs" ]]; then
     echo "info: Downloading protobufjs to build environment"
     mkdir -p "${PROTOBUFJS_DIR}"
+    "${BUILD_ROOT}/bin/yarn.sh" --cwd "${PROTOBUFJS_DIR}" init --yes
     "${BUILD_ROOT}/bin/yarn.sh" --cwd "${PROTOBUFJS_DIR}" add --frozen-lockfile "protobufjs@${PROTOBUFJS_RELEASE}"
   fi
 }
@@ -248,7 +249,7 @@ install_googleapis() {
     googleapis_zip_out="/tmp/googleapis-${GOOGLEAPIS_SHA}.zip"
     curl -sSL -o "${googleapis_zip_out}" \
       "https://github.com/googleapis/googleapis/archive/${GOOGLEAPIS_SHA}.zip"
-    
+
     googleapis_dir_out="/tmp/googleapis-${GOOGLEAPIS_SHA}"
     mkdir -p "${googleapis_dir_out}"
     unzip -q -o "${googleapis_zip_out}" -d "${googleapis_dir_out}"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

In the case where in a user has a fresh clone of clutch and in their directory hierarchy they have a package.json (higher than clutch), yarn chooses to use that directory as its installation point.

In doing so, the path to pbjs that we expect isn't right, because the pbjs we installed ended up in a different directory.

If we first call yarn init, we generate a package.json in the expected path, ensuring that yarn installs to the correct directory.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Manually invoked `make api` in this repo as a standalone and as a gateway. Between invocations I cleared the build/bin directory.
