### PR TITLE
FE: autocompletes: lowercase search strings for case insensitivity

### DIFF
--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -41,9 +41,10 @@ const autoComplete = async (type: string, search: string): Promise<any> => {
     return { results: [] };
   }
 
+  // We lowercase the search to make the lookup case insensitive
   const response = await client.post("/v1/resolver/autocomplete", {
     want: `type.googleapis.com/${type}`,
-    search,
+    search: search.toLowerCase(),
   });
 
   return { results: response?.data?.results || [] };

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -46,9 +46,10 @@ const autoComplete = async (search: string): Promise<any> => {
     return { results: [] };
   }
 
+  // We lowercase the search to make the lookup case insensitive
   const response = await client.post("/v1/resolver/autocomplete", {
     want: `type.googleapis.com/clutch.core.project.v1.Project`,
-    search,
+    search: search.toLowerCase(),
   });
 
   return { results: response?.data?.results || [] };

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -190,9 +190,10 @@ const autoComplete = async (search: string): Promise<any> => {
     return { results: [] };
   }
 
+  // We lowercase the search to make the lookup case insensitive
   const response = await client.post("/v1/resolver/autocomplete", {
     want: `type.googleapis.com/clutch.core.project.v1.Project`,
-    search,
+    search: search.toLowerCase(),
   });
 
   return { results: response?.data?.results || [] };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Before sending the autocomplete request, we lowercase the strings. This allows people to do searches that are case-insensitive. Everything in the db is lowercase.

There was a previous PR that somewhat fixed this but that was only for the k8s dash. There was also investigation into doing this on the backend instead (sending a bool in the request to specify if it was case-insensitive) but it was decided this was a quicker easier way.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
local

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
