### PR TITLE
frontend: inherit min height/width in paper component

### DIFF
--- a/frontend/packages/core/src/paper.tsx
+++ b/frontend/packages/core/src/paper.tsx
@@ -10,6 +10,8 @@ const StyledPaper = styled(MuiPaper)({
   border: "1px solid rgba(13, 16, 48, 0.1)",
   background: "#FFFFFF",
   padding: "16px",
+  minWidth: "inherit",
+  minHeight: "inherit",
 });
 
 const Paper = ({ children }: PaperProps) => <StyledPaper>{children}</StyledPaper>;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Add css to inherit min width and height in paper component

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual