### PR TITLE
Remove UTM params as default

### DIFF
--- a/frontend/packages/core/src/navigation.tsx
+++ b/frontend/packages/core/src/navigation.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-router-dom";
 import type { PartialPath, State } from "history";
 
-const UTM_PARAMS = ["utm_source", "utm_medium"];
+const UTM_PARAMS = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
 
 /**
  * A custom partial Path object that may be missing some properties.
@@ -88,7 +88,7 @@ const useNavigate = () => {
       newSearchParams = (to?.search || {}) as URLSearchParamsInit;
     }
     const searchParams = createSearchParams(newSearchParams);
-    if (options?.utm || options?.utm === undefined) {
+    if (options?.utm) {
       UTM_PARAMS.forEach(p => {
         const param = currentSearchParams.get(p);
         if (param && !searchParams.get(p)) {
@@ -135,7 +135,7 @@ interface SearchParamOptions extends ReactRouterNavigateOptions {
 }
 
 /**
- * A convienence wrapper for reading and writing search parameters via the
+ * A convenience wrapper for reading and writing search parameters via the
  * URLSearchParams interface. This custom hook wraps react-routers implementation
  * but changes the function to write search parameters to preserve UTM parameters
  * by default.
@@ -159,7 +159,7 @@ const useSearchParams = (): readonly [
       reactRouterOptions.state = options.state;
     }
 
-    if (options?.utm || options?.utm === undefined) {
+    if (options?.utm) {
       UTM_PARAMS.forEach(p => {
         const param = searchParams.get(p);
         if (param && !newSearchParams[p]) {

--- a/frontend/packages/core/src/tests/navigation.test.tsx
+++ b/frontend/packages/core/src/tests/navigation.test.tsx
@@ -66,7 +66,7 @@ describe("useNavigate", () => {
     });
 
     it("preserves only UTM params from existing search", () => {
-      nav("/foo");
+      nav("/foo", { utm: true });
       expect(mockNav).toHaveBeenCalledWith(
         { pathname: "/foo", search: "?utm_source=test&utm_medium=run" },
         {}
@@ -74,33 +74,49 @@ describe("useNavigate", () => {
     });
 
     it("merges UTM params with new search", () => {
-      nav({
-        pathname: "/foo",
-        search: {
-          new: "value",
+      nav(
+        {
+          pathname: "/foo",
+          search: {
+            new: "value",
+          },
         },
-      });
+        { utm: true }
+      );
       expect(mockNav).toHaveBeenCalledWith(
-        { pathname: "/foo", search: "?new=value&utm_source=test&utm_medium=run" },
+        {
+          pathname: "/foo",
+          search: "?new=value&utm_source=test&utm_medium=run",
+        },
         {}
       );
     });
 
     it("can bypass UTM tracking", () => {
-      nav("/foo", { utm: false });
+      nav("/foo");
       expect(mockNav).toHaveBeenCalledWith({ pathname: "/foo", search: "" }, {});
     });
 
     it("overwrites existing UTM params", () => {
-      nav({
-        pathname: "/foo",
-        search: {
-          utm_source: "newsource",
-          utm_medium: "newmedium",
+      nav(
+        {
+          pathname: "/foo",
+          search: {
+            utm_source: "newsource",
+            utm_medium: "newmedium",
+            utm_campaign: "newcampaign",
+            utm_term: "newterm",
+            utm_content: "newcontent",
+          },
         },
-      });
+        { utm: true }
+      );
       expect(mockNav).toHaveBeenCalledWith(
-        { pathname: "/foo", search: "?utm_source=newsource&utm_medium=newmedium" },
+        {
+          pathname: "/foo",
+          search:
+            "?utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_term=newterm&utm_content=newcontent",
+        },
         {}
       );
     });
@@ -223,7 +239,7 @@ describe("useSearchParams", () => {
     });
 
     it("preserves only UTM params from existing search", () => {
-      setSearchParams({});
+      setSearchParams({}, { utm: true });
       expect(mockSetSearchParams).toHaveBeenCalledWith(
         { utm_source: "test", utm_medium: "run" },
         {}
@@ -231,7 +247,7 @@ describe("useSearchParams", () => {
     });
 
     it("merges UTM params with new search", () => {
-      setSearchParams({ new: "value" });
+      setSearchParams({ new: "value" }, { utm: true });
       expect(mockSetSearchParams).toHaveBeenCalledWith(
         { utm_source: "test", utm_medium: "run", new: "value" },
         {}
@@ -239,7 +255,7 @@ describe("useSearchParams", () => {
     });
 
     it("can bypass UTM tracking", () => {
-      setSearchParams({ foo: "bar" }, { utm: false });
+      setSearchParams({ foo: "bar" });
       expect(mockSetSearchParams).toHaveBeenCalledWith({ foo: "bar" }, {});
     });
 
@@ -247,11 +263,17 @@ describe("useSearchParams", () => {
       setSearchParams({
         utm_source: "newsource",
         utm_medium: "newmedium",
+        utm_campaign: "newcampaign",
+        utm_term: "newterm",
+        utm_content: "newcontent",
       });
       expect(mockSetSearchParams).toHaveBeenCalledWith(
         {
           utm_source: "newsource",
           utm_medium: "newmedium",
+          utm_campaign: "newcampaign",
+          utm_term: "newterm",
+          utm_content: "newcontent",
         },
         {}
       );


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This pull request removes UTM parameters on navigation unless the options explicitly state `{ utm: true }`.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
