### PR TITLE
FE: remove built in padding around toggle group

### DIFF
--- a/frontend/packages/core/src/Input/toggle-button-group.tsx
+++ b/frontend/packages/core/src/Input/toggle-button-group.tsx
@@ -22,7 +22,6 @@ const StyledMuiToggleButtonGroup = styled(MuiToggleButtonGroup)({
     },
     textTransform: "none",
   },
-  padding: "6px 16px",
 });
 
 // TODO(smonero): add some tests


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Removed some unnecessary padding
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
