### PR TITLE
frontend: Fix for short link generation

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -106,7 +106,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
       retrieveWorkflowSession: () => workflowSessionStore,
       storeWorkflowSession: setWorkflowSessionStore,
     }),
-    []
+    [workflowSessionStore]
   );
 
   const appContextValue = React.useMemo(() => ({ workflows: discoverableWorkflows }), [


### PR DESCRIPTION
### Description
- From the eslint upgrade a usage a `useMemo` was not updated to recreate on state changes, this caused issues when attempting to generate a short link as it would utilize an empty state.

### Testing Performed
manual
