### PR TITLE
housekeeping: envoyproxy/go-control-plane to hash 7857518

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200623234511-94959e3146b2
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/envoyproxy/go-control-plane v0.10.1
+	github.com/envoyproxy/go-control-plane v0.10.3
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/go-git/go-billy/v5 v5.3.1
@@ -82,7 +82,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490 // indirect
+	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200623234511-94959e3146b2
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/envoyproxy/go-control-plane v0.10.3
+	github.com/envoyproxy/go-control-plane v0.10.3-0.20220808135628-785751892618
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/fullstorydev/grpcurl v1.8.6
 	github.com/go-git/go-billy/v5 v5.3.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -280,8 +280,9 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490 h1:KwaoQzs/WeUxxJqiJsZ4euOly1Az/IgZXXSxlD/UBNk=
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc h1:PYXxkRUBGUMa5xgMVMDl62vEklZvKpVaxQeN9ie7Hfk=
+github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go/v2 v2.1.1/go.mod h1:7NtUnP6eK+l6k483WSYNrq3Kb23bWV10IRV1TyeSpwM=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -467,8 +468,9 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
-github.com/envoyproxy/go-control-plane v0.10.1 h1:cgDRLG7bs59Zd+apAWuzLQL95obVYAymNJek76W3mgw=
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
+github.com/envoyproxy/go-control-plane v0.10.3 h1:xdCVXxEe0Y3FQith+0cj2irwZudqGYvecuLB1HtdexY=
+github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/envoyproxy/protoc-gen-validate v0.6.7 h1:qcZcULcd/abmQg6dwigimCNEyi4gg31M/xaciQlDml8=
@@ -749,6 +751,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0 h1:ESEyqQqXXFIcImj/BE8oKEX37Zsuceb2cZI+EL/zNCY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0/go.mod h1:XnLCLFp3tjoZJszVKjfpyAK6J8sYIcQXWQxmqLWF21I=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
@@ -1337,6 +1340,7 @@ go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16g
 go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.11.0/go.mod h1:QpEjXPrNQzrFDZgoTo49dgHR9RYRSrg3NAKnUGl9YpQ=
+go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.temporal.io/api v1.5.0/go.mod h1:BqKxEJJYdxb5dqf0ODfzfMxh8UEQ5L3zKS51FiIYYkA=
 go.temporal.io/api v1.7.1-0.20220223032354-6e6fe738916a h1:SgkeoCikBXMd/3fNNtymIfhpxk8o/E3zIZFBFkHzTtU=
 go.temporal.io/api v1.7.1-0.20220223032354-6e6fe738916a/go.mod h1:OnUq5eS+Nyx+irKb3Ws5YB7yjGFf5XmI3WcVRU9COEo=
@@ -1921,6 +1925,7 @@ google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/genproto v0.0.0-20220314164441-57ef72a4c106/go.mod h1:hAL49I2IFola2sVEjAn7MEwsja0xp51I0tlGAf9hz4E=
 google.golang.org/genproto v0.0.0-20220317150908-0efb43f6373e/go.mod h1:hAL49I2IFola2sVEjAn7MEwsja0xp51I0tlGAf9hz4E=
+google.golang.org/genproto v0.0.0-20220329172620-7be39ac1afc7/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220401170504-314d38edb7de h1:9Ti5SG2U4cAcluryUo/sFay3TQKoxiFMfaT0pbizU7k=
 google.golang.org/genproto v0.0.0-20220401170504-314d38edb7de/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -469,8 +469,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
-github.com/envoyproxy/go-control-plane v0.10.3 h1:xdCVXxEe0Y3FQith+0cj2irwZudqGYvecuLB1HtdexY=
-github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20220808135628-785751892618 h1:mYLMd5M3cH3ZqZeAtu6nHN9KmIDjPCdRMqhyPu5taJg=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20220808135628-785751892618/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/envoyproxy/protoc-gen-validate v0.6.7 h1:qcZcULcd/abmQg6dwigimCNEyi4gg31M/xaciQlDml8=

--- a/backend/module/chaos/experimentation/xds/poller.go
+++ b/backend/module/chaos/experimentation/xds/poller.go
@@ -273,7 +273,7 @@ func (p *Poller) setSnapshot(ctx context.Context, resourceMap map[gcpTypes.Respo
 			return err
 		}
 
-		if newComputedVersion != currentSnapshot.GetVersion(typeURL) {
+		if currentSnapshot == nil || newComputedVersion != currentSnapshot.GetVersion(typeURL) {
 			isNewSnapshotSame = false
 		}
 

--- a/backend/module/chaos/experimentation/xds/poller.go
+++ b/backend/module/chaos/experimentation/xds/poller.go
@@ -259,20 +259,25 @@ func (p *Poller) createResourceWithTTLForECDSResource(resource *ECDSResource, tt
 func (p *Poller) setSnapshot(ctx context.Context, resourceMap map[gcpTypes.ResponseType][]gcpTypes.ResourceWithTTL, cluster string) error {
 	currentSnapshot, _ := p.cache.GetSnapshot(cluster)
 
-	snapshot := gcpCacheV3.Snapshot{}
+	snapshot := &gcpCacheV3.Snapshot{}
 	isNewSnapshotSame := true
-	for resourceType, resources := range resourceMap {
+	for responseType, resources := range resourceMap {
 		newComputedVersion, err := computeChecksum(resources)
 		if err != nil {
-			p.logger.Errorw("Unable to compute checksum", "cluster", cluster, "resourceType", resourceType, "resources", resources)
+			p.logger.Errorw("Unable to compute checksum", "cluster", cluster, "responseType", responseType, "resources", resources)
 			return nil
 		}
 
-		if newComputedVersion != currentSnapshot.Resources[resourceType].Version {
+		typeURL, err := gcpCacheV3.GetResponseTypeURL(responseType)
+		if err != nil {
+			return err
+		}
+
+		if newComputedVersion != currentSnapshot.GetVersion(typeURL) {
 			isNewSnapshotSame = false
 		}
 
-		snapshot.Resources[resourceType] = gcpCacheV3.NewResourcesWithTTL(newComputedVersion, resources)
+		snapshot.Resources[responseType] = gcpCacheV3.NewResourcesWithTTL(newComputedVersion, resources)
 	}
 
 	if isNewSnapshotSame {

--- a/backend/module/chaos/experimentation/xds/poller_test.go
+++ b/backend/module/chaos/experimentation/xds/poller_test.go
@@ -288,12 +288,13 @@ func TestECDSResourcesRefresh(t *testing.T) {
 	awaitGaugeEquals(t, scope, "active_faults+", 2)
 
 	snapshotClusterFoo, err := cache.GetSnapshot("foo")
+
 	assert.NoError(t, err)
-	assert.NotNil(t, snapshotClusterFoo.Resources[gcpTypes.ExtensionConfig].Items["filter1"].Resource.(*gcpCoreV3.TypedExtensionConfig))
+	assert.NotNil(t, snapshotClusterFoo.GetResources(gcpResourceV3.ExtensionConfigType)["filter1"].(*gcpCoreV3.TypedExtensionConfig))
 
 	snapshotClusterBar, err := cache.GetSnapshot("bar")
 	assert.NoError(t, err)
-	serializedFilterResource := snapshotClusterBar.Resources[gcpTypes.ExtensionConfig].Items["filter2"].Resource.(*gcpCoreV3.TypedExtensionConfig)
+	serializedFilterResource := snapshotClusterBar.GetResources(gcpResourceV3.ExtensionConfigType)["filter2"].(*gcpCoreV3.TypedExtensionConfig)
 	unserializedResourceFilter := &wrapperspb.StringValue{}
 	err = serializedFilterResource.TypedConfig.UnmarshalTo(unserializedResourceFilter)
 	assert.NoError(t, err)

--- a/backend/module/chaos/experimentation/xds/xds.go
+++ b/backend/module/chaos/experimentation/xds/xds.go
@@ -191,7 +191,7 @@ func (c *callbacksBase) OnStreamDeltaResponse(i int64, request *gcpDiscoveryV3.D
 	panic("delta callbacks not implemented, use 'GRPC' api_type")
 }
 
-func (c *callbacksBase) OnDeltaStreamClosed(streamID int64) {
+func (c *callbacksBase) OnDeltaStreamClosed(streamID int64, node *gcpCoreV3.Node) {
 	panic("delta callbacks not implemented, use 'GRPC' api_type")
 }
 
@@ -205,8 +205,8 @@ func (c *rtdsCallbacks) OnStreamOpen(ctx context.Context, streamID int64, typeUR
 	return c.onStreamOpen(ctx)
 }
 
-func (c *rtdsCallbacks) OnStreamClosed(streamID int64) {
-	c.logger.Debugw("RTDS onStreamClosed", "streamID", streamID)
+func (c *rtdsCallbacks) OnStreamClosed(streamID int64, node *gcpCoreV3.Node) {
+	c.logger.Debugw("RTDS onStreamClosed", "streamID", streamID, "cluster", node.Cluster)
 	c.onStreamClosed(streamID)
 }
 
@@ -247,8 +247,8 @@ func (c *ecdsCallbacks) OnStreamOpen(ctx context.Context, streamID int64, typeUR
 	return c.onStreamOpen(ctx)
 }
 
-func (c *ecdsCallbacks) OnStreamClosed(streamID int64) {
-	c.logger.Debugw("ECDS onStreamClosed", "streamID", streamID)
+func (c *ecdsCallbacks) OnStreamClosed(streamID int64, node *gcpCoreV3.Node) {
+	c.logger.Debugw("ECDS onStreamClosed", "streamID", streamID, "cluster", node.Cluster)
 	c.onStreamClosed(streamID)
 }
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
[There were some breaking changes to the API, this should fix them. It also blocks a host of other grpc upgrades.

### Testing Performed
Unit