### PR TITLE
[DS-9347] Adding schema info in mock describe table call

### DIFF
--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -125,27 +125,42 @@ func (s *svc) S3GetBucketPolicy(ctx context.Context, account, region, bucket, ac
 }
 
 func (s *svc) DescribeTable(ctx context.Context, account, region, tableName string) (*dynamodbv1.Table, error) {
-	currentThroughput := &dynamodbv1.Throughput{
-		ReadCapacityUnits:  100,
-		WriteCapacityUnits: 200,
-	}
-	gsis := []*dynamodbv1.GlobalSecondaryIndex{
-		{
-			Name: "test-gsi",
-			ProvisionedThroughput: &dynamodbv1.Throughput{
-				ReadCapacityUnits:  10,
-				WriteCapacityUnits: 20,
-			},
-			Status: dynamodbv1.GlobalSecondaryIndex_Status(5),
-		},
-	}
-
 	ret := &dynamodbv1.Table{
-		Name:                   tableName,
-		Region:                 region,
-		ProvisionedThroughput:  currentThroughput,
-		Status:                 dynamodbv1.Table_Status(5),
-		GlobalSecondaryIndexes: gsis,
+		Name:   tableName,
+		Region: region,
+		ProvisionedThroughput: &dynamodbv1.Throughput{
+			ReadCapacityUnits:  100,
+			WriteCapacityUnits: 200,
+		},
+		Status: dynamodbv1.Table_Status(5),
+		GlobalSecondaryIndexes: []*dynamodbv1.GlobalSecondaryIndex{
+			{
+				Name: "test-gsi",
+				ProvisionedThroughput: &dynamodbv1.Throughput{
+					ReadCapacityUnits:  10,
+					WriteCapacityUnits: 20,
+				},
+				Status: dynamodbv1.GlobalSecondaryIndex_Status(5),
+			},
+		},
+		KeySchemas: []*dynamodbv1.KeySchema{
+			{AttributeName: "ID",
+				Type: dynamodbv1.KeySchema_HASH,
+			},
+			{AttributeName: "Status",
+				Type: dynamodbv1.KeySchema_RANGE,
+			},
+		},
+		AttributeDefinitions: []*dynamodbv1.AttributeDefinition{
+			{
+				AttributeName: "OrderID",
+				AttributeType: "S",
+			},
+			{
+				AttributeName: "OrderStatus",
+				AttributeType: "S",
+			},
+		},
 	}
 	return ret, nil
 }

--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -153,12 +153,20 @@ func (s *svc) DescribeTable(ctx context.Context, account, region, tableName stri
 		},
 		AttributeDefinitions: []*dynamodbv1.AttributeDefinition{
 			{
-				AttributeName: "OrderID",
+				AttributeName: "ID",
 				AttributeType: "S",
 			},
 			{
-				AttributeName: "OrderStatus",
+				AttributeName: "Status",
 				AttributeType: "S",
+			},
+			{
+				AttributeName: "Weight",
+				AttributeType: "N",
+			},
+			{
+				AttributeName: "Active",
+				AttributeType: "B",
 			},
 		},
 	}


### PR DESCRIPTION
Adding schema info in mock describe table call. By default this would have been nil values, and it's more helpful with some test data. Also updated some of the variable setting into inline instantiation for easier readability and since the variables weren't being modified in a significant way.