### PR TITLE
backend: fix nil pointer in envoy admin parser

### DIFF
--- a/backend/service/envoyadmin/parse.go
+++ b/backend/service/envoyadmin/parse.go
@@ -30,10 +30,15 @@ func nodeMetadataFromResponse(resp []byte) (*envoytriagev1.NodeMetadata, error) 
 		return nil, err
 	}
 
+	cliOptions := pb.CommandLineOptions
+	if cliOptions == nil {
+		return &envoytriagev1.NodeMetadata{}, nil
+	}
+
 	return &envoytriagev1.NodeMetadata{
-		ServiceNode:    pb.CommandLineOptions.ServiceNode,
-		ServiceCluster: pb.CommandLineOptions.ServiceCluster,
-		ServiceZone:    pb.CommandLineOptions.ServiceZone,
+		ServiceNode:    cliOptions.ServiceNode,
+		ServiceCluster: cliOptions.ServiceCluster,
+		ServiceZone:    cliOptions.ServiceZone,
 		Version:        pb.Version,
 	}, nil
 }

--- a/backend/service/envoyadmin/parse_test.go
+++ b/backend/service/envoyadmin/parse_test.go
@@ -1,0 +1,36 @@
+package envoyadmin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	envoytriagev1 "github.com/lyft/clutch/backend/api/envoytriage/v1"
+)
+
+func TestNodeMetadataFromResponse(t *testing.T) {
+	testCases := []struct {
+		resp     []byte
+		metadata *envoytriagev1.NodeMetadata
+		hasErr   bool
+	}{
+		// resp has no command line options
+		{
+			resp:     []byte("{}"),
+			metadata: &envoytriagev1.NodeMetadata{},
+			hasErr:   false,
+		},
+	}
+
+	for _, test := range testCases {
+		metadata, err := nodeMetadataFromResponse(test.resp)
+		if test.hasErr {
+			assert.Error(t, err)
+			assert.Nil(t, metadata)
+		} else {
+			assert.NoError(t, err)
+			assert.NotNil(t, metadata)
+			assert.Equal(t, test.metadata, metadata)
+		}
+	}
+}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fix a possible nil pointer error when envoy admin returns no CLI options.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
included - unit