### PR TITLE
Revert "frontend: react-timeago update (#2348)"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,7 @@
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
     "react-scripts": "^5.0.1",
-    "react-timeago": "^7.0.0",
+    "react-timeago": "^6.0.0",
     "sort-package-json": "^1.48.1",
     "typescript": "^4.2.3",
     "webpack": "4.46.0",

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -33,7 +33,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.25.3",
-    "react-timeago": "^7.0.0",
+    "react-timeago": "^6.0.0",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/frontend/workflows/projectCatalog/package.json
+++ b/frontend/workflows/projectCatalog/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.25.3",
     "react-router-dom": "^6.0.0-beta",
-    "react-timeago": "^7.0.0"
+    "react-timeago": "^6.0.0"
   },
   "devDependencies": {
     "@clutch-sh/tools": "^2.0.0-beta"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9966,10 +9966,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@9.7.0:
-  version "9.7.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.7.0.tgz#bf55b2afd481f7a113ef5604aa8b693564b5e744"
-  integrity sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==
+cypress@9.5.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.5.0.tgz#704a79f0d3d4e775f433334eb8f5ae065e3bea31"
+  integrity sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -10003,7 +10003,7 @@ cypress@9.7.0:
     listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
-    minimist "^1.2.6"
+    minimist "^1.2.5"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
     proxy-from-env "1.0.0"
@@ -19014,10 +19014,10 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-timeago@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/react-timeago/-/react-timeago-7.1.0.tgz#248bc6aa40a561249e756b2df402c94f1a296a85"
-  integrity sha512-rouF7MiEm55fH791Y8cg+VobIJgx8gtNJ+gjr86R4ZqO1WKPkXiXjdT/lRzrvEkUzsxT1exHqV2V+Zdi114H3A==
+react-timeago@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/react-timeago/-/react-timeago-6.1.1.tgz#d9365c042428eceb90c4a689248d55b37a1bd6be"
+  integrity sha512-44zsWw2J/4AiZ/eVviygDthcDvCSuVyR/PLVF/g7OIUGq8rnEOwa3A+pHPmHt9WJ5fhHumwTY+Go+RkzEaIHvQ==
 
 react-transition-group@2.9.0:
   version "2.9.0"


### PR DESCRIPTION
This reverts commit 3603e0e0748e6cfb3a18b778e2baa6731909e9f5.

<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
