### PR TITLE
aws: expose access to aws.Config from DirectClient

### DIFF
--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -201,8 +201,8 @@ type Client interface {
 // AWS SDK's struct types and not an interface that can be substituted for. It is recommended following initial
 // development of a feature that you add the calls to a service interface so they can be tested more easily.
 type DirectClient interface {
-	Config() *aws.Config
 	Autoscaling() *autoscaling.Client
+	Config() *aws.Config
 	DynamoDB() *dynamodb.Client
 	EC2() *ec2.Client
 	IAM() *iam.Client

--- a/backend/service/aws/aws.go
+++ b/backend/service/aws/aws.go
@@ -143,7 +143,8 @@ func (c *client) createRegionalClients(accountAlias, region string, regions []st
 	}
 
 	c.accounts[accountAlias].clients[region] = &regionalClient{
-		region: region,
+		region:    region,
+		regionCfg: &regionCfg,
 		dynamodbCfg: &awsv1.DynamodbConfig{
 			ScalingLimits: &awsv1.ScalingLimits{
 				MaxReadCapacityUnits:  ds.MaxReadCapacityUnits,
@@ -200,6 +201,7 @@ type Client interface {
 // AWS SDK's struct types and not an interface that can be substituted for. It is recommended following initial
 // development of a feature that you add the calls to a service interface so they can be tested more easily.
 type DirectClient interface {
+	Config() *aws.Config
 	Autoscaling() *autoscaling.Client
 	DynamoDB() *dynamodb.Client
 	EC2() *ec2.Client
@@ -219,8 +221,8 @@ type client struct {
 }
 
 type regionalClient struct {
-	region string
-
+	region      string
+	regionCfg   *aws.Config
 	dynamodbCfg *awsv1.DynamodbConfig
 
 	autoscaling autoscalingClient
@@ -230,6 +232,10 @@ type regionalClient struct {
 	kinesis     kinesisClient
 	s3          s3Client
 	sts         stsClient
+}
+
+func (r *regionalClient) Config() *aws.Config {
+	return r.regionCfg
 }
 
 func (r *regionalClient) Autoscaling() *autoscaling.Client {

--- a/backend/service/aws/aws_test.go
+++ b/backend/service/aws/aws_test.go
@@ -635,3 +635,11 @@ func TestRegionalClient(t *testing.T) {
 
 	assert.Equal(t, c, r.S3())
 }
+
+func TestRegionalClientConfig(t *testing.T) {
+	c := &aws.Config{Region: "us-west-1"}
+
+	r := &regionalClient{regionCfg: c}
+
+	assert.Equal(t, c, r.Config())
+}


### PR DESCRIPTION

### Description
<!-- Describe your change below. -->
AWS has too many services and it is impossible for clutch to support all
of them. If someone wants to write a private extension for a given
service, today there is no way to get the config/credentials to
construct a client. This patch exposes a new method to get regional
config so that clients to an unsupported service can be created.


### Testing Performed
<!-- Describe how you tested this change below. -->
All unit tests performed. No impact to any additional interfaces

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

### TODOs
