### PR TITLE
Frontend: Add disabled prop to PopperItemProps

### DIFF
--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -70,7 +70,7 @@ const ListItemText = styled(MuiListItemText)({
   },
 });
 
-export interface PopperItemProps extends Pick<ListItemProps, "selected"> {
+export interface PopperItemProps extends Pick<ListItemProps, "selected" | "disabled"> {
   children: React.ReactNode;
   component?: React.ElementType;
   componentProps?: any;


### PR DESCRIPTION
### Description
We have a use case for wanting to disable a popper menu item if a condition isn't meant so PR adds `disabled` to the set of props that are picked from `ListItemProps`.