### PR TITLE
Fix broken radio buttons

### DIFF
--- a/frontend/packages/core/src/Input/radio.tsx
+++ b/frontend/packages/core/src/Input/radio.tsx
@@ -4,7 +4,7 @@ import { Radio as MuiRadio } from "@mui/material";
 
 import styled from "../styled";
 
-const StyledRadio = styled(MuiRadio)<{ $checked: RadioProps["selected"] }>(
+const StyledRadio = styled(MuiRadio)<{ checked: RadioProps["selected"] }>(
   {
     ".MuiIconButton-label": {
       height: "24px",
@@ -15,7 +15,7 @@ const StyledRadio = styled(MuiRadio)<{ $checked: RadioProps["selected"] }>(
   },
   props => ({
     "&:hover > .MuiIconButton-label > div": {
-      border: props.$checked ? "1px solid #283CD2" : "1px solid #2E45DC",
+      border: props.checked ? "1px solid #283CD2" : "1px solid #fff",
     },
   })
 );
@@ -66,7 +66,7 @@ const Radio: React.FC<RadioProps> = ({
 }) => {
   return (
     <StyledRadio
-      $checked={selected}
+      checked={selected}
       checkedIcon={
         <SelectedIcon>
           <SelectedCenter />

--- a/frontend/packages/core/src/Input/radio.tsx
+++ b/frontend/packages/core/src/Input/radio.tsx
@@ -15,7 +15,7 @@ const StyledRadio = styled(MuiRadio)<{ checked: RadioProps["selected"] }>(
   },
   props => ({
     "&:hover > .MuiIconButton-label > div": {
-      border: props.checked ? "1px solid #283CD2" : "1px solid #fff",
+      border: props.checked ? "1px solid #283CD2" : "1px solid #2E45DC",
     },
   })
 );

--- a/frontend/packages/core/src/chip.tsx
+++ b/frontend/packages/core/src/chip.tsx
@@ -72,7 +72,7 @@ const CHIP_COLOR_MAP = {
 const StyledChip = styled(MuiChip)<{
   $filled: ChipProps["filled"];
   $variant: ChipProps["variant"];
-  size: ChipProps["size"];
+  $size: ChipProps["size"];
 }>(
   {
     cursor: "inherit",
@@ -86,7 +86,7 @@ const StyledChip = styled(MuiChip)<{
     },
   },
   props => ({
-    height: props.size === "small" ? "24px" : "32px",
+    height: props.$size === "small" ? "24px" : "32px",
     background: props.$filled
       ? CHIP_COLOR_MAP[props.$variant].borderColor
       : CHIP_COLOR_MAP[props.$variant].background,
@@ -96,7 +96,7 @@ const StyledChip = styled(MuiChip)<{
 );
 
 const Chip = ({ variant, filled = false, size = "medium", ...props }: ChipProps) => (
-  <StyledChip $variant={variant} $filled={filled} size={size} {...props} />
+  <StyledChip $variant={variant} $filled={filled} $size={size} {...props} />
 );
 
 export { Chip, CHIP_VARIANTS };

--- a/frontend/packages/core/src/chip.tsx
+++ b/frontend/packages/core/src/chip.tsx
@@ -72,7 +72,7 @@ const CHIP_COLOR_MAP = {
 const StyledChip = styled(MuiChip)<{
   $filled: ChipProps["filled"];
   $variant: ChipProps["variant"];
-  $size: ChipProps["size"];
+  size: ChipProps["size"];
 }>(
   {
     cursor: "inherit",
@@ -86,7 +86,7 @@ const StyledChip = styled(MuiChip)<{
     },
   },
   props => ({
-    height: props.$size === "small" ? "24px" : "32px",
+    height: props.size === "small" ? "24px" : "32px",
     background: props.$filled
       ? CHIP_COLOR_MAP[props.$variant].borderColor
       : CHIP_COLOR_MAP[props.$variant].background,
@@ -96,7 +96,7 @@ const StyledChip = styled(MuiChip)<{
 );
 
 const Chip = ({ variant, filled = false, size = "medium", ...props }: ChipProps) => (
-  <StyledChip $variant={variant} $filled={filled} $size={size} {...props} />
+  <StyledChip $variant={variant} $filled={filled} size={size} {...props} />
 );
 
 export { Chip, CHIP_VARIANTS };


### PR DESCRIPTION
- fixed broken radio buttons. its prop `checked` was changed to `$checked` for the styled component wrapping it. however, the underlying MUI component still expects a `checked` prop to function