### PR TITLE
FE: text-field : allow for clicking to trigger a submit function

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -174,12 +174,19 @@ const IconButton = styled(MuiIconButton)({
 interface AutocompleteResultProps {
   id?: string;
   label: string;
+  stateUpdater?: (string) => void;
+  onReturn?: () => void;
 }
 
-const AutocompleteResult: React.FC<AutocompleteResultProps> = ({ id, label }) => (
+const AutocompleteResult: React.FC<AutocompleteResultProps> = ({ id, label, stateUpdater, onReturn }) => (
   <ResultGrid container alignItems="center">
     <Grid item xs>
-      <ResultLabel>{label || id}</ResultLabel>
+      <ResultLabel onClick={() => {
+        stateUpdater(id);
+        onReturn();
+      }}>
+        {label || id}
+        </ResultLabel>
     </Grid>
   </ResultGrid>
 );
@@ -206,7 +213,8 @@ export interface TextFieldProps
       | "value"
     >,
     Pick<MuiInputProps, "readOnly" | "endAdornment"> {
-  onReturn?: () => void;
+//  onReturn?: (v: string) => void;
+      onReturn?: () => void;
   autocompleteCallback?: (v: string) => Promise<{ results: { id?: string; label: string }[] }>;
   formRegistration?: UseFormRegister<FieldValues>;
 }
@@ -231,6 +239,7 @@ const TextFieldRef = (
   }: TextFieldProps,
   ref
 ) => {
+  const [currentTextValue, setCurrentTextValue] = React.useState<string>("");
   const formValidation =
     formRegistration !== undefined ? formRegistration(name, { required }) : undefined;
   const changeCallback = onChange !== undefined ? onChange : e => {};
@@ -238,6 +247,7 @@ const TextFieldRef = (
     e: React.KeyboardEvent<HTMLDivElement | HTMLTextAreaElement | HTMLInputElement>
   ) => {
     if (formValidation !== undefined) {
+      console.log("inside formValidation")
       formValidation.onChange(e);
     }
     changeCallback(e as React.ChangeEvent<any>);
@@ -328,7 +338,8 @@ const TextFieldRef = (
         onInputChange={(__, v) => autoCompleteDebounce(v)}
         renderOption={(otherProps, option: AutocompleteResultProps) => (
           <li className="MuiAutocomplete-option" {...otherProps}>
-            <AutocompleteResult key={option.id} id={option.id} label={option.label} />
+            {/*<AutocompleteResult key={option.id} id={option.id} label={option.label} func={onReturn} />*/}
+            <AutocompleteResult key={option.id} id={option.id} label={option.label} stateUpdater={setCurrentTextValue} onReturn={onReturn}/>
           </li>
         )}
         onSelectCapture={e => {
@@ -338,7 +349,7 @@ const TextFieldRef = (
           changeCallback(e as React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);
         }}
         defaultValue={{ id: defaultVal, label: defaultVal }}
-        value={value}
+        value={currentTextValue}
         renderInput={inputProps => (
           <StyledTextField
             {...inputProps}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This is an example of how to use `onClick()` to trigger a function when clicking on an autocomplete item. Right now in Clutch, because the autocomplete is uncontrolled, and the internal k8sdash is wrapped in a form, the internal `value` is not updated when clicking on an autocomplete choice. Thus, clicking on an option makes a submit request (as in, calls `onReturn()`), but the request usually fails because the `value` has not been updated until after.

There is probably a more elegant way of doing this, especially because this way doesn't update the query params (users would have to do that separately). It does do the basic functionality though of allowing for a submission of updated `value` when clicking on an autocomplete item.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
