### PR TITLE
frontend: Hide Drawer if no workflows

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -169,6 +169,11 @@ const Drawer: React.FC = () => {
     setActiveWorkflow(workflowByRoute(workflows, location.pathname));
   }, [location]);
 
+  // Will hide the drawer if there are no visible workflows
+  if (!workflows.length) {
+    return null;
+  }
+
   return (
     <DrawerPanel data-qa="drawer" variant="permanent">
       {sortedGroupings(workflows).map(grouping => {


### PR DESCRIPTION
### Description
- Will hide the drawer navigation if there are no workflows visible. This can be achieved by setting `hideNav: true` for workflows

### Testing Performed
manual
