### PR TITLE
Frontend: add new package to dev deps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,6 +76,7 @@
     "eslint": "^8.3.0",
     "lerna": "^4.0.0",
     "license-checker": "^25.0.1",
+    "material-table": "^2.0.3",
     "prettier": "^2.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
PR adds `material-table` to the package.json in the dev dependencies. This is needed for an internal gateway we're spinning up. 

We're not sure why this is needed for the new gateway and not our other internal implementation but this change unblocks the failing build of the new gateway.

shout out to @jdslaugh for realizing this was what was needed for the new gateway.

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
