### PR TITLE
frontend: Override for landing page

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -61,6 +61,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
   const [workflowSessionStore, setWorkflowSessionStore] = React.useState<HydratedData>();
   const [hydrateState, setHydrateState] = React.useState<HydrateState | null>(null);
   const [hydrateError, setHydrateError] = React.useState<ClutchError | null>(null);
+  const [hasCustomLanding, setHasCustomLanding] = React.useState<boolean>(false);
 
   /** Used to control a race condition from displaying the workflow and the state being updated with the hydrated data */
   const [shortLinkLoading, setShortLinkLoading] = React.useState<boolean>(false);
@@ -88,6 +89,9 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
      * by manually providing the full path in the URI.
      */
     const pw = _.cloneDeep(workflows).filter(workflow => {
+      if (workflow.path === "") {
+        setHasCustomLanding(true);
+      }
       const publicRoutes = workflow.routes.filter(route => {
         return !(route?.hideNav !== undefined ? route.hideNav : false);
       });
@@ -125,7 +129,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
               )}
               <Routes>
                 <Route path="/" element={<AppLayout isLoading={isLoading} />}>
-                  <Route key="landing" path="" element={<Landing />} />
+                  {!hasCustomLanding && <Route key="landing" path="" element={<Landing />} />}
                   {workflows.map((workflow: Workflow) => {
                     const workflowPath = workflow.path.replace(/^\/+/, "").replace(/\/+$/, "");
                     const workflowKey = workflow.path.split("/")[0];

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -89,6 +89,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
      * by manually providing the full path in the URI.
      */
     const pw = _.cloneDeep(workflows).filter(workflow => {
+      /** Used to control a custom landing page */
       if (workflow.path === "") {
         setHasCustomLanding(true);
       }

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -30,6 +30,7 @@ interface BaseWorkflowConfiguration {
   group: string;
   /**
    * The path (subordinate to the group) where the workflow will exist.
+   * (optionally) use "" to override the landing page
    */
   path: string;
   /**

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -30,7 +30,7 @@ interface BaseWorkflowConfiguration {
   group: string;
   /**
    * The path (subordinate to the group) where the workflow will exist.
-   * (optionally) use "" to override the landing page
+   * (optionally) use "" to override the landing page, will need to also update the route path
    */
   path: string;
   /**
@@ -70,6 +70,7 @@ export interface Route {
   component: React.FC<any>;
   description: string;
   displayName?: string;
+  /** (optionally) use "" to override the landing page */
   path: string;
   /** Properties required by the Component that are set only via the config. */
   requiredConfigProps?: string[];


### PR DESCRIPTION
### Description
- For custom gateways, need a way to override the landing page if so desired. This PR adds a check in a workflow loop that already exists to see if there is a workflow with no path (ie a landing), if so it will set a boolean variable to not render the current landing page and allow the workflow route to take over.

#### Screenshot (workflow path of "examples")
![Screen Shot 2022-09-14 at 2 21 50 PM](https://user-images.githubusercontent.com/8338893/190265034-446cb825-542c-4333-a502-43bafe70cb20.png)

#### Screenshot (workflow path of "")
![Screen Shot 2022-09-14 at 2 22 00 PM](https://user-images.githubusercontent.com/8338893/190265005-9d6d3ca1-e60e-4071-8317-4ae96f8b9d48.png)

### Testing Performed
manual