### PR TITLE
frontend: Overrides for title and logo

### DIFF
--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -14,6 +14,11 @@ import { UserInformation } from "./user";
 
 export const APP_BAR_HEIGHT = "64px";
 
+export interface HeaderProps {
+  title?: string;
+  logo?: React.ReactNode;
+}
+
 const AppBar = styled(MuiAppBar)({
   minWidth: "fit-content",
   background: "linear-gradient(90deg, #38106b 4.58%, #131c5f 89.31%)",
@@ -32,17 +37,15 @@ const Title = styled(Typography)({
   color: "rgba(255, 255, 255, 0.87)",
 });
 
-const Header: React.FC = () => {
+const Header: React.FC<HeaderProps> = ({ title = "clutch", logo = <Logo /> }) => {
   const showNotifications = false;
 
   return (
     <>
       <AppBar position="fixed" elevation={0}>
         <Toolbar>
-          <Link to="/">
-            <Logo />
-          </Link>
-          <Title>clutch</Title>
+          <Link to="/">{logo}</Link>
+          <Title>{title}</Title>
           <Grid container alignItems="center" justifyContent="flex-end">
             <Box>
               <SearchField />

--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -33,6 +33,13 @@ const Title = styled(Typography)({
   color: "rgba(255, 255, 255, 0.87)",
 });
 
+const StyledLogo = styled("img")({
+  width: "48px",
+  height: "48px",
+  padding: "1px",
+  verticalAlign: "middle",
+});
+
 const Header: React.FC<AppConfiguration> = ({ title = "clutch", logo = <Logo /> }) => {
   const showNotifications = false;
 
@@ -40,7 +47,7 @@ const Header: React.FC<AppConfiguration> = ({ title = "clutch", logo = <Logo /> 
     <>
       <AppBar position="fixed" elevation={0}>
         <Toolbar>
-          <Link to="/">{logo}</Link>
+          <Link to="/">{typeof logo === "string" ? <StyledLogo src={logo} /> : logo}</Link>
           <Title>{title}</Title>
           <Grid container alignItems="center" justifyContent="flex-end">
             <Box>

--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -11,13 +11,9 @@ import Notifications from "./notifications";
 import SearchField from "./search";
 import ShortLinker from "./shortLinker";
 import { UserInformation } from "./user";
+import type { AppConfiguration } from "../AppProvider";
 
 export const APP_BAR_HEIGHT = "64px";
-
-export interface HeaderProps {
-  title?: string;
-  logo?: React.ReactNode;
-}
 
 const AppBar = styled(MuiAppBar)({
   minWidth: "fit-content",
@@ -37,7 +33,7 @@ const Title = styled(Typography)({
   color: "rgba(255, 255, 255, 0.87)",
 });
 
-const Header: React.FC<HeaderProps> = ({ title = "clutch", logo = <Logo /> }) => {
+const Header: React.FC<AppConfiguration> = ({ title = "clutch", logo = <Logo /> }) => {
   const showNotifications = false;
 
   return (

--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import styled from "@emotion/styled";
 import { AppBar as MuiAppBar, Box, Grid, Toolbar, Typography } from "@mui/material";
 
+import type { AppConfiguration } from "../AppProvider";
 import { FeatureOn, SimpleFeatureFlag } from "../flags";
 import { NPSHeader } from "../NPS";
 
@@ -11,7 +12,6 @@ import Notifications from "./notifications";
 import SearchField from "./search";
 import ShortLinker from "./shortLinker";
 import { UserInformation } from "./user";
-import type { AppConfiguration } from "../AppProvider";
 
 export const APP_BAR_HEIGHT = "64px";
 

--- a/frontend/packages/core/src/AppLayout/index.tsx
+++ b/frontend/packages/core/src/AppLayout/index.tsx
@@ -3,9 +3,8 @@ import { Outlet } from "react-router-dom";
 import styled from "@emotion/styled";
 import { Grid as MuiGrid } from "@mui/material";
 
-import Loadable from "../loading";
-
 import type { AppConfiguration } from "../AppProvider";
+import Loadable from "../loading";
 
 import Drawer from "./drawer";
 import Header, { APP_BAR_HEIGHT } from "./header";

--- a/frontend/packages/core/src/AppLayout/index.tsx
+++ b/frontend/packages/core/src/AppLayout/index.tsx
@@ -5,6 +5,8 @@ import { Grid as MuiGrid } from "@mui/material";
 
 import Loadable from "../loading";
 
+import type { AppConfiguration } from "../AppProvider";
+
 import Drawer from "./drawer";
 import Header, { APP_BAR_HEIGHT } from "./header";
 
@@ -21,12 +23,13 @@ const MainContent = styled.div({ overflowY: "auto", width: "100%" });
 
 interface AppLayoutProps {
   isLoading?: boolean;
+  configuration?: AppConfiguration;
 }
 
-const AppLayout: React.FC<AppLayoutProps> = ({ isLoading = false }) => {
+const AppLayout: React.FC<AppLayoutProps> = ({ isLoading = false, configuration }) => {
   return (
     <AppGrid container direction="column">
-      <Header />
+      <Header title={configuration.title} logo={configuration.logo} />
       <ContentGrid container wrap="nowrap">
         {isLoading ? (
           <Loadable isLoading={isLoading} variant="overlay" />

--- a/frontend/packages/core/src/AppLayout/index.tsx
+++ b/frontend/packages/core/src/AppLayout/index.tsx
@@ -25,10 +25,10 @@ interface AppLayoutProps {
   configuration?: AppConfiguration;
 }
 
-const AppLayout: React.FC<AppLayoutProps> = ({ isLoading = false, configuration }) => {
+const AppLayout: React.FC<AppLayoutProps> = ({ isLoading = false, configuration = {} }) => {
   return (
     <AppGrid container direction="column">
-      <Header title={configuration.title} logo={configuration.logo} />
+      <Header {...configuration} />
       <ContentGrid container wrap="nowrap">
         {isLoading ? (
           <Loadable isLoading={isLoading} variant="overlay" />

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -61,6 +61,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
   const [workflowSessionStore, setWorkflowSessionStore] = React.useState<HydratedData>();
   const [hydrateState, setHydrateState] = React.useState<HydrateState | null>(null);
   const [hydrateError, setHydrateError] = React.useState<ClutchError | null>(null);
+  const [hasCustomLanding, setHasCustomLanding] = React.useState<boolean>(false);
 
   /** Used to control a race condition from displaying the workflow and the state being updated with the hydrated data */
   const [shortLinkLoading, setShortLinkLoading] = React.useState<boolean>(false);
@@ -88,6 +89,9 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
      * by manually providing the full path in the URI.
      */
     const pw = _.cloneDeep(workflows).filter(workflow => {
+      if (workflow.path === "") {
+        setHasCustomLanding(true);
+      }
       const publicRoutes = workflow.routes.filter(route => {
         return !(route?.hideNav !== undefined ? route.hideNav : false);
       });
@@ -125,7 +129,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
               )}
               <Routes>
                 <Route path="/" element={<AppLayout isLoading={isLoading} />}>
-                  <Route key="landing" path="" element={<Landing />} />
+                  {!hasCustomLanding && <Route key="landing" path="" element={<Landing />} />}
                   {workflows.map((workflow: Workflow) => {
                     const workflowPath = workflow.path.replace(/^\/+/, "").replace(/\/+$/, "");
                     const workflowKey = workflow.path.split("/")[0];

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -89,6 +89,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
      * by manually providing the full path in the URI.
      */
     const pw = _.cloneDeep(workflows).filter(workflow => {
+      /** Used to control a custom landing page */
       if (workflow.path === "") {
         setHasCustomLanding(true);
       }

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -26,8 +26,10 @@ export interface UserConfiguration {
 }
 
 export interface AppConfiguration {
+  /** Will override the title of the given application */
   title?: string;
-  logo?: React.ReactNode;
+  /** Supports a react node or a string representing a public assets path */
+  logo?: React.ReactNode | string;
 }
 
 /**

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -25,6 +25,11 @@ export interface UserConfiguration {
   };
 }
 
+export interface AppConfiguration {
+  title?: string;
+  logo?: React.ReactNode;
+}
+
 /**
  * Filter workflow routes using available feature flags.
  * @param workflows a list of valid Workflow objects.
@@ -50,11 +55,13 @@ interface ClutchAppProps {
     [key: string]: () => WorkflowConfiguration;
   };
   configuration: UserConfiguration;
+  appConfiguration: AppConfiguration;
 }
 
 const ClutchApp: React.FC<ClutchAppProps> = ({
   availableWorkflows,
   configuration: userConfiguration,
+  appConfiguration,
 }) => {
   const [workflows, setWorkflows] = React.useState<Workflow[]>([]);
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
@@ -129,7 +136,10 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
                 </Toast>
               )}
               <Routes>
-                <Route path="/" element={<AppLayout isLoading={isLoading} />}>
+                <Route
+                  path="/"
+                  element={<AppLayout isLoading={isLoading} configuration={appConfiguration} />}
+                >
                   {!hasCustomLanding && <Route key="landing" path="" element={<Landing />} />}
                   {workflows.map((workflow: Workflow) => {
                     const workflowPath = workflow.path.replace(/^\/+/, "").replace(/\/+$/, "");

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -30,6 +30,7 @@ interface BaseWorkflowConfiguration {
   group: string;
   /**
    * The path (subordinate to the group) where the workflow will exist.
+   * (optionally) use "" to override the landing page
    */
   path: string;
   /**


### PR DESCRIPTION
### Description
This PR adds the ability to specify a custom title and logo for the application through the new appConfiguration object or remove them altogether.

#### Overridden Title w/no img
```
ReactDOM.render(
  <ClutchApp
    availableWorkflows={registeredWorkflows}
    configuration={
      process.env.NODE_ENV === "development" ? devConfig : prodConfig
    }
    appConfiguration={{ title: "Custom Title ", logo: null}}
  />,
  document.getElementById("root")
);
```

![Screen Shot 2022-09-15 at 9 59 14 AM](https://user-images.githubusercontent.com/8338893/190464099-800d02ff-65d4-468a-8ec4-bbbfaaa25a53.png)

#### Custom Logo & Custom Title
```
ReactDOM.render(
  <ClutchApp
    availableWorkflows={registeredWorkflows}
    configuration={
      process.env.NODE_ENV === "development" ? devConfig : prodConfig
    }
    appConfiguration={{ title: "CustomTitle", logo: <GemIcon size="medium" /> }}
  />,
  document.getElementById("root")
);
```

![Screen Shot 2022-09-19 at 11 18 17 AM](https://user-images.githubusercontent.com/8338893/191086477-37537082-b8d0-475b-89b4-24c89e6971f5.png)

#### Custom Asset Img & Custom Title
```
ReactDOM.render(
  <ClutchApp
    availableWorkflows={registeredWorkflows}
    configuration={
      process.env.NODE_ENV === "development" ? devConfig : prodConfig
    }
    appConfiguration={{ title: "Custom Title ", logo: "./assets/test.png" }}
  />,
  document.getElementById("root")
);
```

![Screen Shot 2022-09-19 at 11 13 02 AM](https://user-images.githubusercontent.com/8338893/191085968-fc010e74-6380-4519-8d2e-5c7441eb2b3f.png)

### Testing Performed
manual
