### PR TITLE
frontend: First-of-type form fix

### DIFF
--- a/frontend/packages/core/src/Input/form.tsx
+++ b/frontend/packages/core/src/Input/form.tsx
@@ -15,7 +15,7 @@ const FormRow = styled.div({
   "> *": {
     margin: "0 8px",
   },
-  "> *:first-child": {
+  "> *:first-of-type": {
     margin: "0 8px 0 0",
   },
   "> *:last-child": {


### PR DESCRIPTION
### Description
- Adjusted Form css to use `first-of-type` instead of `first-child` to mitigate error being thrown

![Screen Shot 2022-09-28 at 5 32 33 PM](https://user-images.githubusercontent.com/8338893/192912166-fd9a4ee7-5b54-4c26-9ae1-919902865037.png)

```
react_devtools_backend.js:4026 The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type". 
    at http://localhost:3000/static/js/bundle.js:1284:66
    at form
```

### Testing Performed
manual