### PR TITLE
frontend: allow wizard step errors to be undefined

### DIFF
--- a/frontend/packages/wizard/src/step.tsx
+++ b/frontend/packages/wizard/src/step.tsx
@@ -11,7 +11,7 @@ const Grid = styled(ClutchGrid)({
 
 export interface WizardStepProps {
   isLoading: boolean;
-  error: ClutchError;
+  error?: ClutchError;
 }
 
 const WizardStep: React.FC<WizardStepProps> = ({ isLoading, error, children }) => {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
allows wizard step errors to be undefined. we already handle this case [here](https://github.com/lyft/clutch/compare/wizardStepErr?expand=1#diff-405c79e6b5521a66df72764a7fbf8f954c792fa17793e69242fafc1c4ca7bbcdL19)

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual