### PR TITLE
frontend: simply experimentation fields and fix css

### DIFF
--- a/frontend/workflows/experimentation/src/core/form-fields.tsx
+++ b/frontend/workflows/experimentation/src/core/form-fields.tsx
@@ -1,17 +1,8 @@
 import React from "react";
 import type { FieldValues, UseFormRegister } from "react-hook-form";
-import { RadioGroup, Select, TextField } from "@clutch-sh/core";
-import styled from "@emotion/styled";
+import { Select, TextField } from "@clutch-sh/core";
 
-const FieldContainer = styled.div({
-  alignItems: "center",
-  display: "flex",
-  flexDirection: "column",
-  width: "100%",
-  "> *": {
-    margin: "inherit",
-  },
-});
+type FieldType = "title" | "text" | "number" | "select";
 
 interface FormProps {
   state: any;
@@ -34,21 +25,10 @@ interface SelectOption {
   value: string;
 }
 
-interface RadioGroupProps {
-  options: RadioGroupOption[];
-  defaultValue: string;
-  disabled?: boolean;
-}
-
-interface RadioGroupOption {
-  label: string;
-  value: string;
-}
-
 export interface FormItem {
   name?: string;
   label: string;
-  type: string;
+  type: FieldType;
   validation?: any;
   visible?: boolean;
   inputProps?: SelectProps | TextFieldProps;
@@ -58,7 +38,7 @@ const FormFields: React.FC<FormProps> = ({ state, items, register, errors }) => 
   const [data, setData] = state;
 
   return (
-    <FieldContainer>
+    <>
       {items.map(field => {
         if (field.type === "title") {
           return (
@@ -88,26 +68,6 @@ const FormFields: React.FC<FormProps> = ({ state, items, register, errors }) => 
             />
           );
         }
-        if (field.type === "radio-group") {
-          const customProps: RadioGroupProps = field.inputProps as RadioGroupProps;
-          return (
-            <RadioGroup
-              key={field.label}
-              name={field.name}
-              label={field.label}
-              disabled={customProps.disabled}
-              options={customProps.options}
-              defaultOption={customProps.options
-                .map(o => o.value)
-                .indexOf(customProps.defaultValue)}
-              onChange={value => {
-                const copiedData = { ...data };
-                copiedData[field.name] = value;
-                setData(copiedData);
-              }}
-            />
-          );
-        }
         if (field.type === "select") {
           const customProps: SelectProps = field.inputProps as SelectProps;
           return (
@@ -130,7 +90,7 @@ const FormFields: React.FC<FormProps> = ({ state, items, register, errors }) => 
 
         return <div key="blank" />;
       })}
-    </FieldContainer>
+    </>
   );
 };
 

--- a/frontend/workflows/redisexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/redisexperimentation/src/start-experiment.tsx
@@ -12,7 +12,7 @@ import {
   Form,
   useNavigate,
 } from "@clutch-sh/core";
-import { FormFields, PageLayout } from "@clutch-sh/experimentation";
+import { FormFields, FormItem, PageLayout } from "@clutch-sh/experimentation";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
@@ -101,7 +101,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({ environments, onS
         defaultValue: initialExperimentData.faultType,
       },
     },
-  ];
+  ] as FormItem[];
 
   const schema: { [name: string]: yup.StringSchema | yup.NumberSchema } = {};
   fields

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -92,7 +92,7 @@ const ExperimentDetails: React.FC<ExperimentDetailsProps> = ({
     {
       name: "upstreamClusterType",
       label: "Upstream Cluster Type",
-      type: "radio-group",
+      type: "select",
       visible: upstreamClusterTypeSelectionEnabled,
       inputProps: {
         options: [


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
simplify experimentation workflows by the removing radio button option. This was only used in one spot at the moment and it was easily swapped out with a select which both aesthetically looks nicer and also makes sense given users can only select one option.

This allowed for the removal of the wrapping form element which was there to apply centering to the page for the smaller radio buttons which then let's the form styles properly cascade down providing proper margins.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2022-09-29 at 12 42 10 PM](https://user-images.githubusercontent.com/1004789/193128882-b42d4c44-dba7-45ea-b968-1444903f0010.png)

![Screen Shot 2022-09-29 at 12 46 43 PM](https://user-images.githubusercontent.com/1004789/193128908-a19da5d8-3ba2-4f4d-9727-1473c51a6e56.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
