### PR TITLE
backend: return partial errors from ListPods

### DIFF
--- a/backend/module/k8s/pods.go
+++ b/backend/module/k8s/pods.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
+	"google.golang.org/genproto/googleapis/rpc/status"
 )
 
 func (a *k8sAPI) DescribePod(ctx context.Context, req *k8sapiv1.DescribePodRequest) (*k8sapiv1.DescribePodResponse, error) {
@@ -24,10 +25,17 @@ func (a *k8sAPI) DeletePod(ctx context.Context, req *k8sapiv1.DeletePodRequest) 
 
 func (a *k8sAPI) ListPods(ctx context.Context, req *k8sapiv1.ListPodsRequest) (*k8sapiv1.ListPodsResponse, error) {
 	pods, err := a.k8s.ListPods(ctx, req.Clientset, req.Cluster, req.Namespace, req.Options)
-	if err != nil {
+	// If there's a complete failure, return it directly
+	// If there are only partial failures, set it on the response
+	if len(pods) == 0 && err != nil {
 		return nil, err
 	}
-	return &k8sapiv1.ListPodsResponse{Pods: pods}, nil
+
+	result := &k8sapiv1.ListPodsResponse{Pods: pods}
+	if err != nil {
+		result.PartialFailures = []*status.Status{{Message: err.Error()}}
+	}
+	return result, nil
 }
 
 func (a *k8sAPI) UpdatePod(ctx context.Context, req *k8sapiv1.UpdatePodRequest) (*k8sapiv1.UpdatePodResponse, error) {

--- a/backend/service/k8s/pods.go
+++ b/backend/service/k8s/pods.go
@@ -55,7 +55,7 @@ func (s *svc) ListPods(ctx context.Context, clientset, cluster, namespace string
 	}
 
 	podList, err := cs.CoreV1().Pods(cs.Namespace()).List(ctx, opts)
-	if err != nil {
+	if len(podList.Items) == 0 && err != nil {
 		return nil, err
 	}
 
@@ -65,7 +65,7 @@ func (s *svc) ListPods(ctx context.Context, clientset, cluster, namespace string
 		pods = append(pods, podDescription(&pod, cs.Cluster()))
 	}
 
-	return pods, nil
+	return pods, err
 }
 
 // Update pod fields if the current field values match with that's described by expectedObjectMetaFields


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
If there were partial errors, return them in the response in addition to the pods that were found. If there was a complete failure, return `nil` as the response and the error as a separate value.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
