### PR TITLE
frontend: text field - only show error icon when help text set

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -249,7 +249,7 @@ const TextFieldRef = (
   let helpText = helperText;
 
   // Prepend a '!' icon to helperText displayed below the form if the form is in an error state.
-  if (error) {
+  if (error && helpText) {
     helpText = (
       <>
         <ErrorIcon />


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
fix text field to only show a helper text icon prefix if `helpText` has been set. At the moment this shows an icon with no text.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
![Screen Shot 2022-10-04 at 11 19 19 PM](https://user-images.githubusercontent.com/1004789/193994102-1f1f3865-45d7-41f1-9a10-887dec922ea1.png)

![Screen Shot 2022-10-04 at 11 20 48 PM](https://user-images.githubusercontent.com/1004789/193994188-c341c968-5f95-4f67-8d7e-f51cc4880bbc.png)


### Testing Performed
<!-- Describe how you tested this change below. -->
manual
