### PR TITLE
frontend: Fixing Select defaultOption bug

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -201,15 +201,15 @@ const Select = ({
   options,
   onChange,
 }: SelectProps) => {
-  const defaultIdx = defaultOption < options.length && defaultOption > 0 ? defaultOption : 0;
-  const [selectedIdx, setSelectedIdx] = React.useState(defaultIdx);
-
   // Flattens all options and sub grouped options for easier retrieval
   const flatOptions: BaseSelectOptions[] = flatten(
     options.map((option: SelectOption) =>
       option.group ? option.group.map(groupOption => groupOption) : option
     )
   );
+
+  const defaultIdx = defaultOption < flatOptions.length && defaultOption > 0 ? defaultOption : 0;
+  const [selectedIdx, setSelectedIdx] = React.useState(defaultIdx);
 
   React.useEffect(() => {
     if (flatOptions.length !== 0) {


### PR DESCRIPTION
### Description
- Fixing bug with Select defaultOption

Context:
When using the grouped feature the defaultIdx was not taking into account the flatOptions length and instead was using just the normal options length. When grouping this would be noticeably shorter and would lead to the incorrect defaultOption being selected.

### Testing Performed
manual
