### PR TITLE
frontend: Toast Bug Fix

### DIFF
--- a/frontend/packages/core/src/Feedback/toast.tsx
+++ b/frontend/packages/core/src/Feedback/toast.tsx
@@ -40,15 +40,17 @@ const Toast: React.FC<ToastProps> = ({
         }
       }}
     >
-      <Alert
-        elevation={6}
-        variant="filled"
-        onClose={onClose ? onDismiss : null}
-        severity={severity}
-        title={title}
-      >
-        {children}
-      </Alert>
+      <div>
+        <Alert
+          elevation={6}
+          variant="filled"
+          onClose={onClose ? onDismiss : null}
+          severity={severity}
+          title={title}
+        >
+          {children}
+        </Alert>
+      </div>
     </Snackbar>
   );
 };


### PR DESCRIPTION
### Description
- With the upgrade to MUIv5 the Toast component was no longer working and instead throwing an error `Cannot read property scrollTop of null`
- Fix was to wrap the children in a div to correctly forward the ref, taken from https://mui.com/material-ui/migration/troubleshooting/#cannot-read-property-scrolltop-of-null

NOTE: Tried to use React.forwardRef but was unable to get it to work correctly, wrapping the alert component mitigates the issue without any other changes

### Testing Performed
manual

