### PR TITLE
dynamodb: add support for config notes

### DIFF
--- a/frontend/workflows/dynamodb/src/index.tsx
+++ b/frontend/workflows/dynamodb/src/index.tsx
@@ -1,10 +1,11 @@
-import type { BaseWorkflowProps, WorkflowConfiguration } from "@clutch-sh/core";
+import type { BaseWorkflowProps, NoteConfig, WorkflowConfiguration } from "@clutch-sh/core";
 import type { WizardChild } from "@clutch-sh/wizard";
 
 import UpdateCapacity from "./update-capacity";
 
 interface ResolverConfigProps {
   resolverType: string;
+  notes?: NoteConfig[];
 }
 
 interface TableDetailsProps {

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -168,7 +168,7 @@ const TableDetails: React.FC<TableDetailsChild> = ({ enableOverride }) => {
           <Alert severity="warning">
             Warning: to override the DynamoDB scaling limits, check the box below. This will bypass
             the maximum limits placed on all throughput updates. Only override limits if safe to do
-            so. Picchu is the cutest!
+            so.
           </Alert>
           <CheckboxPanel
             onChange={state =>

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -22,7 +22,10 @@ import { number } from "yup";
 
 import type { ResolverChild, TableDetailsChild, WorkflowProps } from ".";
 
-const TableIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
+const TableIdentifier: React.FC<ResolverChild> = ({
+  resolverType,
+  notes = []
+}) => {
   const { onSubmit } = useWizardContext();
   const resolvedResourceData = useDataLayout("resourceData");
   const capacityUpdates = useDataLayout("capacityUpdates");
@@ -39,7 +42,16 @@ const TableIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
     onSubmit();
   };
 
-  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} />;
+  const resolverNotes = notes.filter(note => note.location === "resolver");
+
+  return (
+    <Resolver
+      type={resolverType}
+      searchLimit={1}
+      onResolve={onResolve}
+      notes={resolverNotes}
+    />
+  );
 };
 
 const TableDetails: React.FC<TableDetailsChild> = ({ enableOverride }) => {
@@ -156,7 +168,7 @@ const TableDetails: React.FC<TableDetailsChild> = ({ enableOverride }) => {
           <Alert severity="warning">
             Warning: to override the DynamoDB scaling limits, check the box below. This will bypass
             the maximum limits placed on all throughput updates. Only override limits if safe to do
-            so.
+            so. Picchu is the cutest!
           </Alert>
           <CheckboxPanel
             onChange={state =>
@@ -201,7 +213,7 @@ const Confirm: React.FC<WizardChild> = () => {
   );
 };
 
-const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, enableOverride, heading }) => {
+const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, notes = [], enableOverride, heading}) => {
   const dataLayout = {
     resourceData: {},
     capacityUpdates: {},
@@ -249,8 +261,8 @@ const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, enableOverride,
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
-      <TableIdentifier name="Lookup" resolverType={resolverType} />
+    <Wizard dataLayout={dataLayout} heading={heading}> 
+      <TableIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
       <TableDetails name="Modify" enableOverride={enableOverride} />
       <Confirm name="Results" />
     </Wizard>

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -22,10 +22,7 @@ import { number } from "yup";
 
 import type { ResolverChild, TableDetailsChild, WorkflowProps } from ".";
 
-const TableIdentifier: React.FC<ResolverChild> = ({
-  resolverType,
-  notes = []
-}) => {
+const TableIdentifier: React.FC<ResolverChild> = ({ resolverType, notes = [] }) => {
   const { onSubmit } = useWizardContext();
   const resolvedResourceData = useDataLayout("resourceData");
   const capacityUpdates = useDataLayout("capacityUpdates");
@@ -45,12 +42,7 @@ const TableIdentifier: React.FC<ResolverChild> = ({
   const resolverNotes = notes.filter(note => note.location === "resolver");
 
   return (
-    <Resolver
-      type={resolverType}
-      searchLimit={1}
-      onResolve={onResolve}
-      notes={resolverNotes}
-    />
+    <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} notes={resolverNotes} />
   );
 };
 
@@ -213,7 +205,12 @@ const Confirm: React.FC<WizardChild> = () => {
   );
 };
 
-const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, notes = [], enableOverride, heading}) => {
+const UpdateCapacity: React.FC<WorkflowProps> = ({
+  resolverType,
+  notes = [],
+  enableOverride,
+  heading,
+}) => {
   const dataLayout = {
     resourceData: {},
     capacityUpdates: {},
@@ -261,7 +258,7 @@ const UpdateCapacity: React.FC<WorkflowProps> = ({ resolverType, notes = [], ena
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}> 
+    <Wizard dataLayout={dataLayout} heading={heading}>
       <TableIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
       <TableDetails name="Modify" enableOverride={enableOverride} />
       <Confirm name="Results" />


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR adds support for displaying resolver notes from the DynamoDB Update Capacity workflow configuration file. 

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
Example note: 

<img width="1444" alt="Screen Shot 2022-10-13 at 4 19 49 PM" src="https://user-images.githubusercontent.com/3279569/195728067-7bf1206d-420e-4d35-8224-4199147d677e.png">

Generated from example `clutch.config.js`:

```
"@clutch-sh/dynamodb": {
    updateCapacity: {
      componentProps: {
        resolverType: "clutch.aws.dynamodb.v1.Table",
        notes: [
          {
            severity: "info",
            text: `
              This workflow immediately provisions an additional boost of read and write capacity for a DynamoDB table and/or global secondary index.
              Capacities set by this workflow are **TEMPORARY**, subject to the table's autoscaling rules.
              View workflow docs at:
            `,
            link: "https://insert-workflow-documentation-link-here",
            location: "resolver",
          },
        ],
        enableOverride: true,
      },
    },
  },
```





### Testing Performed
<!-- Describe how you tested this change below. -->
Tested locally with custom gateway config notes.

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
