### PR TITLE
backend: only emit github ratelimit gauge on valid response

### DIFF
--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -51,9 +51,11 @@ type StatsRoundTripper struct {
 func (st *StatsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := st.Wrapped.RoundTrip(req)
 
-	if hdr := resp.Header.Get("X-RateLimit-Remaining"); hdr != "" {
-		if v, err := strconv.Atoi(hdr); err == nil {
-			st.scope.Gauge("rate_limit_remaining").Update(float64(v))
+	if resp != nil {
+		if hdr := resp.Header.Get("X-RateLimit-Remaining"); hdr != "" {
+			if v, err := strconv.Atoi(hdr); err == nil {
+				st.scope.Gauge("rate_limit_remaining").Update(float64(v))
+			}
 		}
 	}
 	return resp, err


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes possible panic if `resp` is nil from the RoundTrip call when trying to evaluate the response headers from a GitHub GraphQL query to gauge the remaining GitHub rate limit.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
unit
