### PR TITLE
frontend: Catalog - Adding replace to navigate

### DIFF
--- a/frontend/workflows/projectCatalog/src/config/index.tsx
+++ b/frontend/workflows/projectCatalog/src/config/index.tsx
@@ -51,7 +51,7 @@ const Config: React.FC<ProjectDetailsConfigWorkflowProps> = ({ children, default
         splitLoc.push(selectedPath);
       }
 
-      navigate(`${splitLoc.join("/")}${convertSearchParam(searchParams)}`);
+      navigate(`${splitLoc.join("/")}${convertSearchParam(searchParams)}`, { replace: true });
     }
   }, [configPages, selectedPage]);
 


### PR DESCRIPTION
### Description
- When utilizing project catalogs configuration settings it was pushing new history onto the stack which was problematic with how many entries it was utilizing. Setting replace will replace the current entry allowing the back button to work correctly

### Testing Performed
manual
