### PR TITLE
frontend: NPS - Add ability to specify custom sub routes

### DIFF
--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -7,7 +7,7 @@ import {
   Paper as MuiPaper,
   Popper as MuiPopper,
 } from "@mui/material";
-import { sortBy } from "lodash";
+import { get, sortBy } from "lodash";
 
 import type { Workflow } from "../AppProvider/workflow";
 import { IconButton } from "../button";
@@ -68,8 +68,8 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
         value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
       });
 
-      if (route?.componentProps?.["customNPS"]) {
-        typeMap[group].push(...route.componentProps["customNPS"]);
+      if (get("route.componentProps.customNPS", [])) {
+        typeMap[group].push(...get("route.componentProps.customNPS", []));
       }
     });
   });

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -68,8 +68,9 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
         value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
       });
 
-      if (get("route.componentProps.customNPS", [])) {
-        typeMap[group].push(...get("route.componentProps.customNPS", []));
+      const customNPS = get("route.componentProps.customNPS", []);
+      if (customNPS) {
+        typeMap[group].push(...customNPS);
       }
     });
   });

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -68,9 +68,9 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
         value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
       });
 
-      const customNPS = get("route.componentProps.customNPS", []);
-      if (customNPS) {
-        typeMap[group].push(...customNPS);
+      const additionalNPS = get("route.componentProps.additionalNPS", []);
+      if (additionalNPS) {
+        typeMap[group].push(...additionalNPS);
       }
     });
   });

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -62,12 +62,16 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
       typeMap[group] = [];
     }
 
-    typeMap[group].push(
-      ...routes.map(route => ({
+    routes.forEach(route => {
+      typeMap[group].push({
         label: route.displayName || displayName,
         value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
-      }))
-    );
+      });
+
+      if (route?.componentProps?.["customNPS"]) {
+        typeMap[group].push(...route.componentProps["customNPS"]);
+      }
+    });
   });
 
   feedbackTypes.push(


### PR DESCRIPTION
### Description
Modifies the NPS header component, which already reads in the workflows, to check for component props on each visible route and add any custom nps additions found under its route. 

NOTE: This is only visible to routes where hideNav: false as it is hidden from the workflow context otherwise

Example:
```
  "@clutch-sh/project-catalog": {
    catalog: {
      trending: true,
      componentProps: {
        additionalNPS: [
          { label: "New Config", value: "/config/new config" },
        ],
      },
    },
  },
```

### Testing Performed
manual
