### PR TITLE
frontend: remove width limit on metadata table disbaled textfield

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -92,9 +92,6 @@ const Grid = styled(MuiGrid)({
   ".MuiFormControl-root .MuiFormHelperText-root.Mui-error": {
     flex: 1,
   },
-  ".textfield-disabled .MuiFormControl-root .MuiInputBase-root": {
-    width: "41px",
-  },
   ".textfield-disabled .MuiInput-input": {
     padding: "0px",
     textAlign: "center",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Removes width restriction on disabled text fields for metadata table

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
**Before**
![Screen Shot 2022-10-19 at 3 26 05 PM](https://user-images.githubusercontent.com/1004789/196816308-af236e2d-72d3-484c-a82f-66a257f671ad.png)

**Now**
![Screen Shot 2022-10-19 at 3 25 26 PM](https://user-images.githubusercontent.com/1004789/196816228-88db7bc9-8bd1-4611-88e2-8849c0f694a2.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual