### PR TITLE
housekeeping: upgrade minimist@^1.2.6

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,9 +59,6 @@
       "last 1 safari version"
     ]
   },
-  "resolutions": {
-    "minimist": "^1.2.6"
-  },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@mui/material": "^5.8.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,9 @@
       "last 1 safari version"
     ]
   },
+  "resolutions": {
+    "minimist": "^1.2.6"
+  },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@mui/material": "^5.8.5",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16058,12 +16058,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@^1.2.6:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Upgrade minimist to ^1.2.6 to pick up [CVE patch](https://github.com/advisories/GHSA-xvch-5gv4-984h)

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual / ci
