### PR TITLE
frontend: center tab layout

### DIFF
--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -66,8 +66,8 @@ export const Tab = ({ children, onClick, label, startAdornment, ...props }: TabP
   let finalLabel = label;
   if (startAdornment !== undefined) {
     finalLabel = (
-      <div style={{ display: "flex" }}>
-        <span style={{ marginRight: "7px" }}>{startAdornment}</span>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <span style={{ display: "inherit", marginRight: "7px" }}>{startAdornment}</span>
         {label}
       </div>
     );


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
centers tab layout for both text and icons

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
**before**
![Screen Shot 2022-10-20 at 4 23 08 PM](https://user-images.githubusercontent.com/1004789/197077381-f40c5635-63c6-4398-a278-b371133f9faf.png)

**now**
![Screen Shot 2022-10-20 at 4 22 05 PM](https://user-images.githubusercontent.com/1004789/197077392-190d1b30-ff3d-44ff-ae53-908be3f9d196.png)

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
