### PR TITLE
frontend: fix select icon position

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -147,7 +147,7 @@ const StyledSelect = styled(BaseSelect)({
     top: "unset",
     transform: "unset",
     display: "flex",
-    justifyContent: "center",
+    justifyContent: "flex-end",
     alignItems: "center",
     boxSizing: "border-box",
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
fixes positioning of select expand/collapse icon. Currently by having it centered there is a chance the icon can overlap with the text. This does also adjust some of the existing places where the icon is more indented at the moment from the end of a field.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
**Current Behavior**
Resolver
![Screen Shot 2022-10-24 at 6 54 16 PM](https://user-images.githubusercontent.com/1004789/197664598-67633502-8477-478d-9fc7-ef8a96569997.png)

![Screen Shot 2022-10-24 at 7 02 50 PM](https://user-images.githubusercontent.com/1004789/197664722-12970ac7-3fdb-40ef-b534-aeb3636712cb.png)


**Proposed Changes**
Resolver
![Screen Shot 2022-10-24 at 6 54 26 PM](https://user-images.githubusercontent.com/1004789/197664604-ca7927d5-727e-40aa-bfcb-ac2ec0a48a11.png)

![Screen Shot 2022-10-24 at 7 02 26 PM](https://user-images.githubusercontent.com/1004789/197664729-4a828320-3218-4a5b-962d-d78783f6b4f0.png)

### Testing Performed

<!-- Describe how you tested this change below. -->
manual
