### PR TITLE
K8s Resize HPA: add label for text fields on mix/max size row

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -19,6 +19,7 @@ import { object } from "yup";
 import { useWizardContext } from "../Contexts";
 import TextField from "../Input/text-field";
 import styled from "../styled";
+import { Typography } from "../typography";
 
 interface RowData {
   input?: {
@@ -28,6 +29,7 @@ interface RowData {
   };
   name: string;
   value: unknown;
+  disabledFieldlabel?: string;
 }
 
 interface IdentifiableRowData extends RowData {
@@ -137,6 +139,9 @@ interface MutableRowProps extends ImmutableRowProps {
   validation: UseFormReturn<FieldValues, object>;
 }
 
+// TODO: fix Grid styling to account for labels over the text field or revisit implementation
+// (ex. instead of a disabled text field and editable text field, remove disabled field and have a reset icon next to text field
+// to reset field to the default value
 const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, validation }) => {
   const error = validation?.formState?.errors?.[data.name];
 
@@ -149,6 +154,9 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
     <TableRow key={data.id}>
       <KeyCell data={data} />
       <TableCell>
+        {data.disabledFieldlabel && (
+          <Typography variant="body4">{data.disabledFieldlabel}</Typography>
+        )}
         <Grid>
           <div className="textfield-disabled">
             <TextField disabled id={data.id} name={data.name} defaultValue={data.value} />

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -77,7 +77,7 @@ const TableCell = styled(MuiTableCell)({
   fontSize: "14px",
   fontWeight: "normal",
   height: "48px",
-  padding: "0 16px",
+  padding: "8px 16px",
 });
 
 const Grid = styled(MuiGrid)({
@@ -139,8 +139,7 @@ interface MutableRowProps extends ImmutableRowProps {
   validation: UseFormReturn<FieldValues, object>;
 }
 
-// TODO: fix Grid styling to account for labels over the text field or revisit implementation
-// (ex. instead of a disabled text field and editable text field, remove disabled field and have a reset icon next to text field
+// TODO (maybe): instead of a disabled text field and editable text field, remove disabled field and have a reset icon next to text field
 // to reset field to the default value
 const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, validation }) => {
   const error = validation?.formState?.errors?.[data.name];
@@ -154,12 +153,9 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
     <TableRow key={data.id}>
       <KeyCell data={data} />
       <TableCell>
-        {data.disabledFieldlabel && (
-          <Typography variant="body4">{data.disabledFieldlabel}</Typography>
-        )}
         <Grid>
           <div className="textfield-disabled">
-            <TextField disabled id={data.id} name={data.name} defaultValue={data.value} />
+            <TextField disabled id={data.id} name={data.name} defaultValue={data.value} label={data.disabledFieldlabel ?? data.disabledFieldlabel}/>
           </div>
           <ChevronRightIcon />
           <TextField

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -26,6 +26,10 @@ interface RowData {
     type?: string;
     validation?: BaseSchema<unknown>;
   };
+  textFieldLabels?: {
+    disabledField: string;
+    updatedField: string;
+  };
   name: string;
   value: unknown;
   disabledFieldlabel?: string;
@@ -159,13 +163,14 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
               id={data.id}
               name={data.name}
               defaultValue={data.value}
-              label={data.disabledFieldlabel ?? data.disabledFieldlabel}
+              label={data.textFieldLabels?.disabledField ?? data.textFieldLabels?.disabledField}
             />
           </div>
           <ChevronRightIcon />
           <TextField
             id={data.id}
             name={data.name}
+            label={data.textFieldLabels?.updatedField ?? data.textFieldLabels?.updatedField}
             defaultValue={data.value}
             type={data?.input?.type}
             onChange={updateCallback}

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -19,7 +19,6 @@ import { object } from "yup";
 import { useWizardContext } from "../Contexts";
 import TextField from "../Input/text-field";
 import styled from "../styled";
-import { Typography } from "../typography";
 
 interface RowData {
   input?: {
@@ -155,7 +154,13 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
       <TableCell>
         <Grid>
           <div className="textfield-disabled">
-            <TextField disabled id={data.id} name={data.name} defaultValue={data.value} label={data.disabledFieldlabel ?? data.disabledFieldlabel}/>
+            <TextField
+              disabled
+              id={data.id}
+              name={data.name}
+              defaultValue={data.value}
+              label={data.disabledFieldlabel ?? data.disabledFieldlabel}
+            />
           </div>
           <ChevronRightIcon />
           <TextField

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -74,7 +74,10 @@ const HPADetails: React.FC<WizardChild> = () => {
           {
             name: "Min Size",
             value: hpa.sizing.minReplicas,
-            disabledFieldlabel: "Current size",
+            textFieldLabels: {
+              disabledField: "Current size",
+              updatedField: "New size",
+            },
             input: {
               type: "number",
               key: "sizing.minReplicas",
@@ -87,7 +90,10 @@ const HPADetails: React.FC<WizardChild> = () => {
           {
             name: "Max Size",
             value: hpa.sizing.maxReplicas,
-            disabledFieldlabel: "Current size",
+            textFieldLabels: {
+              disabledField: "Current size",
+              updatedField: "New size",
+            },
             input: {
               type: "number",
               key: "sizing.maxReplicas",

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -74,6 +74,7 @@ const HPADetails: React.FC<WizardChild> = () => {
           {
             name: "Min Size",
             value: hpa.sizing.minReplicas,
+            disabledFieldlabel: "Current size",
             input: {
               type: "number",
               key: "sizing.minReplicas",
@@ -86,6 +87,7 @@ const HPADetails: React.FC<WizardChild> = () => {
           {
             name: "Max Size",
             value: hpa.sizing.maxReplicas,
+            disabledFieldlabel: "Current size",
             input: {
               type: "number",
               key: "sizing.maxReplicas",

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -75,8 +75,8 @@ const HPADetails: React.FC<WizardChild> = () => {
             name: "Min Size",
             value: hpa.sizing.minReplicas,
             textFieldLabels: {
-              disabledField: "Current size",
-              updatedField: "New size",
+              disabledField: "Current min",
+              updatedField: "New min",
             },
             input: {
               type: "number",
@@ -91,8 +91,8 @@ const HPADetails: React.FC<WizardChild> = () => {
             name: "Max Size",
             value: hpa.sizing.maxReplicas,
             textFieldLabels: {
-              disabledField: "Current size",
-              updatedField: "New size",
+              disabledField: "Current max",
+              updatedField: "New max",
             },
             input: {
               type: "number",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
For the K8s Resize HPA flow, a label is added above the text fields on the Mix/Max Size to clarify what they are. To allow this customization, PR adds a new prop to the metadata-table component for providing these labels.

### Testing Performed
Local
<img width="500" alt="Screen Shot 2022-10-25 at 1 55 08 PM" src="https://user-images.githubusercontent.com/39421794/197847093-d71df1b7-3c3d-48a8-9910-0c4339c37856.png">

**Example of a workflow where the new prop isn't set**
<img width="500" alt="Screen Shot 2022-10-25 at 1 00 36 PM" src="https://user-images.githubusercontent.com/39421794/197837361-b4775056-d022-460f-ab4f-78377c452b57.png">

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
