### PR TITLE
audit sink sql: use dedicated connection for advisory locks

### DIFF
--- a/backend/service/audit/audit.go
+++ b/backend/service/audit/audit.go
@@ -201,11 +201,12 @@ func (c *client) poll() {
 		if isLocked {
 			c.scope.Counter("lock_acquired").Inc(1)
 
+			c.readAndFanout(ctx)
+
 			_, err := c.storage.ReleaseLock(ctx, lockID)
 			if err != nil {
 				c.logger.Error("Error trying to release lock", zap.Error(err))
 			}
-			c.readAndFanout(ctx)
 		} else {
 			c.scope.Counter("lock_not_acquired").Inc(1)
 		}

--- a/backend/service/audit/storage/sql/sql.go
+++ b/backend/service/audit/storage/sql/sql.go
@@ -230,6 +230,12 @@ func (c *client) ReleaseLock(ctx context.Context, lockID uint32) (bool, error) {
 		c.logger.Error("Unable to perform an advisory unlock", zap.Error(err))
 		return false, err
 	}
+
+	// conn should never be nil but this guards against a panic in the event that it is
+	if conn != nil {
+		conn.Close()
+	}
+
 	return unlock, nil
 }
 

--- a/backend/service/audit/storage/sql/sql.go
+++ b/backend/service/audit/storage/sql/sql.go
@@ -196,7 +196,7 @@ func (c *client) getAdvisoryConn() (*sql.Conn, error) {
 		return c.advisoryLockConn, nil
 	}
 
-	advisoryLockConn, err := c.db.Conn(context.TODO())
+	advisoryLockConn, err := c.db.Conn(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/service/audit/storage/sql/sql_test.go
+++ b/backend/service/audit/storage/sql/sql_test.go
@@ -9,6 +9,7 @@ import (
 
 	ec2v1 "github.com/lyft/clutch/backend/api/aws/ec2/v1"
 	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
+	"github.com/lyft/clutch/backend/mock/service/dbmock"
 )
 
 func TestConvertAPIBody(t *testing.T) {
@@ -63,4 +64,16 @@ func TestAPIBodyProto(t *testing.T) {
 		}
 		assert.NoError(t, err)
 	}
+}
+
+func TestGetAdvisoryConn(t *testing.T) {
+	dbm := dbmock.NewMockDB()
+	c := &client{
+		db: dbm.DB(),
+	}
+
+	conn, err := c.getAdvisoryConn()
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+	assert.NotNil(t, c.advisoryLockConn)
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Use a dedicated connection for the audit sink advisory lock. Previously we were using the db session pool for all advisory lock requests, the issue with this is that in order for a session level advisory lock to be unlock, the unlock request must come from the same session. This [post](https://engineering.qubecinema.com/2019/08/26/unlocking-advisory-locks.html) summarizes the issue we are running into nicely.

In this pr I also moved the `readAndFanout()` before calling `ReleaseLock()`, this was the original intent but this was not setup correctly.

### Testing Performed
unit
