### PR TITLE
audit: save filter configuration on service

### DIFF
--- a/backend/service/audit/audit.go
+++ b/backend/service/audit/audit.go
@@ -57,6 +57,8 @@ func New(cfg *any.Any, logger *zap.Logger, scope tally.Scope) (service.Service, 
 			// Render zero values (useful for successful status).
 			EmitUnpopulated: true,
 		},
+
+		filter: config.Filter,
 	}
 
 	for _, sinkName := range config.Sinks {

--- a/backend/service/audit/audit_test.go
+++ b/backend/service/audit/audit_test.go
@@ -15,6 +15,7 @@ import (
 func TestNew(t *testing.T) {
 	cfg, _ := anypb.New(&auditconfigv1.Config{
 		StorageProvider: &auditconfigv1.Config_InMemory{InMemory: true},
+		Filter:          &auditconfigv1.Filter{Denylist: true},
 	})
 	log := zaptest.NewLogger(t)
 	scope := tally.NewTestScope("", nil)
@@ -24,6 +25,9 @@ func TestNew(t *testing.T) {
 	// Assert conformance to public interface.
 	_, ok := svc.(Auditor)
 	assert.True(t, ok)
+
+	as := svc.(*client)
+	assert.True(t, as.filter.Denylist)
 }
 
 func TestFilter(t *testing.T) {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
We were not filtering before because the filter configuration was not saved on the struct.
