### PR TITLE
audit: keep connection held for now

### DIFF
--- a/backend/service/audit/storage/sql/sql.go
+++ b/backend/service/audit/storage/sql/sql.go
@@ -231,11 +231,6 @@ func (c *client) ReleaseLock(ctx context.Context, lockID uint32) (bool, error) {
 		return false, err
 	}
 
-	// conn should never be nil but this guards against a panic in the event that it is
-	if conn != nil {
-		conn.Close()
-	}
-
 	return unlock, nil
 }
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
In the last update to this code, the closed connection is kept around and is no longer viable. For now just keep the connection.