### PR TITLE
audit sink sql: close advisory conn

### DIFF
--- a/backend/service/audit/storage/sql/sql.go
+++ b/backend/service/audit/storage/sql/sql.go
@@ -214,6 +214,7 @@ func (c *client) AttemptLock(ctx context.Context, lockID uint32) (bool, error) {
 	var lock bool
 	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1);", lockID).Scan(&lock); err != nil {
 		c.logger.Error("Unable to query for a advisory lock", zap.Error(err))
+		c.advisoryLockConn = nil
 		return false, err
 	}
 	return lock, nil
@@ -228,6 +229,7 @@ func (c *client) ReleaseLock(ctx context.Context, lockID uint32) (bool, error) {
 	var unlock bool
 	if err := conn.QueryRowContext(ctx, "SELECT pg_advisory_unlock($1)", lockID).Scan(&unlock); err != nil {
 		c.logger.Error("Unable to perform an advisory unlock", zap.Error(err))
+		c.advisoryLockConn = nil
 		return false, err
 	}
 

--- a/backend/service/audit/storage/sql/sql.go
+++ b/backend/service/audit/storage/sql/sql.go
@@ -231,6 +231,11 @@ func (c *client) ReleaseLock(ctx context.Context, lockID uint32) (bool, error) {
 		return false, err
 	}
 
+	if conn != nil {
+		conn.Close()
+		c.advisoryLockConn = nil
+	}
+
 	return unlock, nil
 }
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
It seems like its best to close the connection completely and re-create for each sink loop. This actually works out better in the event the connection is severed for whatever reason this will attempt to connect on the next invocation.
