### PR TITLE
frontend: date time picker - only trigger onChange when value is valid

### DIFF
--- a/frontend/packages/core/src/Input/date-time.tsx
+++ b/frontend/packages/core/src/Input/date-time.tsx
@@ -3,6 +3,7 @@ import type { DateTimePickerProps as MuiDateTimePickerProps } from "@mui/lab";
 import { DateTimePicker as MuiDateTimePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import type { Dayjs } from "dayjs";
 
 import styled from "../styled";
 
@@ -20,11 +21,16 @@ const PaddedTextField = styled(TextField)({
 export interface DateTimePickerProps
   extends Pick<MuiDateTimePickerProps, "disabled" | "value" | "onChange" | "label"> {}
 
-const DateTimePicker = ({ ...props }: DateTimePickerProps) => {
+const DateTimePicker = ({ onChange, ...props }: DateTimePickerProps) => {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <MuiDateTimePicker
         renderInput={inputProps => <PaddedTextField {...inputProps} />}
+        onChange={(value: Dayjs) => {
+          if (value.isValid()) {
+            onChange(value.toDate());
+          }
+        }}
         {...props}
       />
     </LocalizationProvider>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
only trigger onChange when new value is valid. This prevents onChange from firing when users are manually modifying the date time value / selecting values through the modals.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
