### PR TITLE
FE: Kinesis: make shard count unique

### DIFF
--- a/frontend/workflows/kinesis/package.json
+++ b/frontend/workflows/kinesis/package.json
@@ -28,6 +28,7 @@
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@emotion/styled": "^11.0.0",
     "@mui/material": "^5.8.5",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.25.3",

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -55,17 +55,20 @@ const StreamDetails: React.FC<WizardChild> = () => {
     resourceData.updateData("targetShardCount", value);
   };
 
-  const values = [
-    Math.ceil(stream.currentShardCount * 0.5),
-    Math.ceil(stream.currentShardCount * 0.75),
-    Math.ceil(stream.currentShardCount * 1),
-    Math.ceil(stream.currentShardCount * 1.25),
-    Math.ceil(stream.currentShardCount * 1.5),
-    Math.ceil(stream.currentShardCount * 1.75),
-    Math.ceil(stream.currentShardCount * 2),
-  ];
-  const options = values.map(value => {
-    return { label: value.toString() };
+  // These will be used to multiply the currentShardCount, which will populate the choices
+  const multipliers = [
+    0.5,
+    0.75,
+    1,
+    1.25,
+    1.5,
+    1.75,
+    2
+  ]
+
+  const values = multipliers.map(m => Math.ceil(stream.currentShardCount) * m)
+  const options = values.map((value, index) => {
+    return { label: value.toString() + "(current * " + multipliers[index] + ")" };
   });
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -56,19 +56,11 @@ const StreamDetails: React.FC<WizardChild> = () => {
   };
 
   // These will be used to multiply the currentShardCount, which will populate the choices
-  const multipliers = [
-    0.5,
-    0.75,
-    1,
-    1.25,
-    1.5,
-    1.75,
-    2
-  ]
+  const multipliers = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 
-  const values = multipliers.map(m => Math.ceil(stream.currentShardCount) * m)
+  const values = multipliers.map(m => Math.ceil(stream.currentShardCount) * m);
   const options = values.map((value, index) => {
-    return { label: value.toString() + "(current * " + multipliers[index] + ")" };
+    return { label: `${value.toString()}(ceil of current * ${multipliers[index]})` };
   });
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -18,6 +18,7 @@ import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
 import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
+import _ from "lodash";
 
 import type { ResolverChild, WorkflowProps } from "./index";
 
@@ -55,12 +56,17 @@ const StreamDetails: React.FC<WizardChild> = () => {
     resourceData.updateData("targetShardCount", value);
   };
 
-  // These will be used to multiply the currentShardCount, which will populate the choices
-  const multipliers = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
-
-  const values = multipliers.map(m => Math.ceil(stream.currentShardCount) * m);
-  const options = values.map((value, index) => {
-    return { label: `${value.toString()}(ceil of current * ${multipliers[index]})` };
+  const values = [
+    Math.ceil(stream.currentShardCount * 0.5),
+    Math.ceil(stream.currentShardCount * 0.75),
+    Math.ceil(stream.currentShardCount * 1),
+    Math.ceil(stream.currentShardCount * 1.25),
+    Math.ceil(stream.currentShardCount * 1.5),
+    Math.ceil(stream.currentShardCount * 1.75),
+    Math.ceil(stream.currentShardCount * 2),
+  ];
+  const options = _.uniq(values).map(value => {
+    return { label: value.toString() };
   });
   return (
     <WizardStep error={resourceData.error} isLoading={resourceData.isLoading}>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
![Screenshot 2022-12-05 at 10 24 54 AM](https://user-images.githubusercontent.com/66325812/205746039-a31c3c0a-4d06-4733-b649-6a49a383805a.png)
Right now, users could potentially be confused as to why the same shard count values are showing up multiple times in the select. This PR makes it so that only unique values are shown.


<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #


### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
