### PR TITLE
FE: Metadata Table: add tool tip prop for disabled text field

### DIFF
--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -11,13 +11,13 @@ import {
   TableCell as MuiTableCell,
   TableContainer as MuiTableContainer,
   TableRow,
-  Tooltip,
 } from "@mui/material";
 import _ from "lodash";
 import type { BaseSchema } from "yup";
 import { object } from "yup";
 
 import { useWizardContext } from "../Contexts";
+import { Tooltip } from "../Feedback/tooltip";
 import TextField from "../Input/text-field";
 import styled from "../styled";
 
@@ -33,7 +33,6 @@ interface RowData {
   };
   name: string;
   value: unknown;
-  disabledFieldlabel?: string;
   disabledFieldTooltip?: string;
 }
 
@@ -160,7 +159,7 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
       id={data.id}
       name={data.name}
       defaultValue={data.value}
-      label={data.textFieldLabels?.disabledField ?? data.textFieldLabels?.disabledField}
+      label={data.textFieldLabels?.disabledField}
     />
   );
 
@@ -180,7 +179,7 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
           <TextField
             id={data.id}
             name={data.name}
-            label={data.textFieldLabels?.updatedField ?? data.textFieldLabels?.updatedField}
+            label={data.textFieldLabels?.updatedField}
             defaultValue={data.value}
             type={data?.input?.type}
             onChange={updateCallback}

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -169,11 +169,10 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
       <TableCell>
         <Grid>
           <div className="textfield-disabled">
-            {data.disabledFieldTooltip ? (
-              <Tooltip title={data.disabledFieldTooltip}>{disabledTextFieldComponent}</Tooltip>
-            ) : (
-              disabledTextFieldComponent
-            )}
+            {/* // In the case where a disabledFieldTooltip is not provided, the value itself will be the tooltip */}
+            <Tooltip title={data.disabledFieldTooltip ?? data.value}>
+              {disabledTextFieldComponent}
+            </Tooltip>
           </div>
           <ChevronRightIcon />
           <TextField

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -171,7 +171,7 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
         <Grid>
           <div className="textfield-disabled">
             {data.disabledFieldTooltip ? (
-              <Tooltip title={data.disabledTextFieldTooltip}>{disabledTextFieldComponent}</Tooltip>
+              <Tooltip title={data.disabledFieldTooltip}>{disabledTextFieldComponent}</Tooltip>
             ) : (
               disabledTextFieldComponent
             )}

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -11,6 +11,7 @@ import {
   TableCell as MuiTableCell,
   TableContainer as MuiTableContainer,
   TableRow,
+  Tooltip,
 } from "@mui/material";
 import _ from "lodash";
 import type { BaseSchema } from "yup";
@@ -33,6 +34,7 @@ interface RowData {
   name: string;
   value: unknown;
   disabledFieldlabel?: string;
+  disabledFieldTooltip?: string;
 }
 
 interface IdentifiableRowData extends RowData {
@@ -152,19 +154,27 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
   const updateCallback = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
     error ? () => {} : onUpdate(e);
 
+  const disabledTextFieldComponent = (
+    <TextField
+      disabled
+      id={data.id}
+      name={data.name}
+      defaultValue={data.value}
+      label={data.textFieldLabels?.disabledField ?? data.textFieldLabels?.disabledField}
+    />
+  );
+
   return (
     <TableRow key={data.id}>
       <KeyCell data={data} />
       <TableCell>
         <Grid>
           <div className="textfield-disabled">
-            <TextField
-              disabled
-              id={data.id}
-              name={data.name}
-              defaultValue={data.value}
-              label={data.textFieldLabels?.disabledField ?? data.textFieldLabels?.disabledField}
-            />
+            {data.disabledFieldTooltip ? (
+              <Tooltip title={data.disabledTextFieldTooltip}>{disabledTextFieldComponent}</Tooltip>
+            ) : (
+              disabledTextFieldComponent
+            )}
           </div>
           <ChevronRightIcon />
           <TextField

--- a/frontend/packages/core/src/Table/stories/metadata-table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/metadata-table.stories.tsx
@@ -62,6 +62,7 @@ WithMutableRows.args = {
         type: "number",
         key: "size.min",
       },
+      disabledFieldTooltip: "A tooltip for this field",
     },
     {
       name: "Max Size",


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->


![Screenshot 2022-12-06 at 12 42 04 PM](https://user-images.githubusercontent.com/66325812/206018946-11d75dc9-c109-4e10-a57f-947f5cc344a9.png)

Its nice to be able to have a tooltip for a disabled text field.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
