### PR TITLE
FE: Resize HPA: add a warning on confirmation if new min or max replicas are different by more than 50%

### DIFF
--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -137,12 +137,12 @@ const HPADetails: React.FC<WizardChild> = () => {
   );
 };
 
-// TODO (sperry): possibly show the previous size values
 const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const hpa = useDataLayout("hpaData").displayValue() as IClutch.k8s.v1.HPA;
   const resizeData = useDataLayout("resizeData");
   const oldHpaData = useDataLayout("oldHpaData").displayValue() as IClutch.k8s.v1.HPA;
 
+  React.useEffect(() => {
   // if new values are either 50% bigger or smaller than old values, add a warning note
   const maxUpperBound = 1.5 * oldHpaData?.sizing?.maxReplicas;
   const maxLowerBound = 0.5 * oldHpaData?.sizing?.maxReplicas;
@@ -153,14 +153,14 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const isMaxReplicasDiffTooBig =
     hpa?.sizing?.maxReplicas > maxUpperBound || hpa?.sizing?.maxReplicas < maxLowerBound;
   if (isMaxReplicasDiffTooBig || isMinReplicasDiffTooBig) {
-    notes.push({
+    notes.unshift({
       text:
         "The new min or max size is more than 50% different from the old size. This may cause a large number of pods to be created or deleted.",
       severity: "warning",
     });
   }
-  console.log(hpa)
-  console.log(oldHpaData)
+  }, []);
+
   return (
     <WizardStep error={resizeData.error} isLoading={resizeData.isLoading}>
       <Confirmation action="Resize" />

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -144,10 +144,13 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
 
   React.useEffect(() => {
     // if new values are either 50% bigger or smaller than old values, add a warning note
-    const maxUpperBound = 1.5 * oldHpaData.sizing.maxReplicas;
-    const maxLowerBound = 0.5 * oldHpaData.sizing.maxReplicas;
-    const minUpperBound = 1.5 * oldHpaData.sizing.minReplicas;
-    const minLowerBound = 0.5 * oldHpaData.sizing.minReplicas;
+    const alertLevel = 0.5;
+    const { maxReplicas, minReplicas } = oldHpaData.sizing;
+    const maxUpperBound = (1 + alertLevel) * maxReplicas;
+    const maxLowerBound = (1 - alertLevel) * maxReplicas;
+    const minUpperBound = (1 + alertLevel) * minReplicas;
+    const minLowerBound = (1 - alertLevel) * minReplicas;
+
     const isMinReplicasDiffTooBig =
       hpa.sizing.minReplicas > minUpperBound || hpa.sizing.minReplicas < minLowerBound;
     const isMaxReplicasDiffTooBig =

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -65,6 +65,8 @@ const HPADetails: React.FC<WizardChild> = () => {
     // save the original values of min and max replicas
     if (hpa) {
       oldHpaData.assign(hpaData);
+      console.log("hpa data is")
+      console.log(hpaData)
     }
   }, []);
 
@@ -144,14 +146,14 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const oldHpaData = useDataLayout("oldHpaData").displayValue() as IClutch.k8s.v1.HPA;
 
   // if new values are either 50% bigger or smaller than old values, add a warning note
-  const maxUpperBound = 1.5 * oldHpaData.sizing.maxReplicas;
-  const maxLowerBound = 0.5 * oldHpaData.sizing.maxReplicas;
-  const minUpperBound = 1.5 * oldHpaData.sizing.minReplicas;
-  const minLowerBound = 0.5 * oldHpaData.sizing.minReplicas;
+  const maxUpperBound = 1.5 * oldHpaData?.sizing?.maxReplicas;
+  const maxLowerBound = 0.5 * oldHpaData?.sizing?.maxReplicas;
+  const minUpperBound = 1.5 * oldHpaData?.sizing?.minReplicas;
+  const minLowerBound = 0.5 * oldHpaData?.sizing?.minReplicas;
   const isMinReplicasDiffTooBig =
-    hpa.sizing.minReplicas > minUpperBound || hpa.sizing.minReplicas < minLowerBound;
+    hpa?.sizing?.minReplicas > minUpperBound || hpa?.sizing?.minReplicas < minLowerBound;
   const isMaxReplicasDiffTooBig =
-    hpa.sizing.maxReplicas > maxUpperBound || hpa.sizing.maxReplicas < maxLowerBound;
+    hpa?.sizing?.maxReplicas > maxUpperBound || hpa?.sizing?.maxReplicas < maxLowerBound;
   if (isMaxReplicasDiffTooBig || isMinReplicasDiffTooBig) {
     notes.push({
       text:
@@ -159,6 +161,8 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
       severity: "warning",
     });
   }
+  console.log(hpa)
+  console.log(oldHpaData)
   return (
     <WizardStep error={resizeData.error} isLoading={resizeData.isLoading}>
       <Confirmation action="Resize" />
@@ -169,8 +173,8 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
           { name: "Cluster", value: hpa.cluster },
           { name: "New Min Size", value: hpa.sizing.minReplicas },
           { name: "New Max Size", value: hpa.sizing.maxReplicas },
-          { name: "Old Min Size", value: oldHpaData.sizing.minReplicas },
-          { name: "Old Max Size", value: oldHpaData.sizing.maxReplicas },
+          { name: "Old Min Size", value: oldHpaData?.sizing?.minReplicas },
+          { name: "Old Max Size", value: oldHpaData?.sizing?.maxReplicas },
         ]}
       />
       <NotePanel notes={notes} />

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -182,6 +182,7 @@ const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
   const dataLayout = {
     hpaData: {},
     inputData: {},
+    oldHpaData: {},
     resizeData: {
       deps: ["hpaData", "inputData"],
       hydrator: (hpaData: IClutch.k8s.v1.HPA, inputData: { clientset: string }) => {

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -64,9 +64,7 @@ const HPADetails: React.FC<WizardChild> = () => {
 
     // save the original values of min and max replicas
     if (hpa) {
-      oldHpaData.assign(hpaData);
-      console.log("hpa data is")
-      console.log(hpaData)
+      oldHpaData.assign(hpa);
     }
   }, []);
 

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -143,22 +143,22 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const oldHpaData = useDataLayout("oldHpaData").displayValue() as IClutch.k8s.v1.HPA;
 
   React.useEffect(() => {
-  // if new values are either 50% bigger or smaller than old values, add a warning note
-  const maxUpperBound = 1.5 * oldHpaData?.sizing?.maxReplicas;
-  const maxLowerBound = 0.5 * oldHpaData?.sizing?.maxReplicas;
-  const minUpperBound = 1.5 * oldHpaData?.sizing?.minReplicas;
-  const minLowerBound = 0.5 * oldHpaData?.sizing?.minReplicas;
-  const isMinReplicasDiffTooBig =
-    hpa?.sizing?.minReplicas > minUpperBound || hpa?.sizing?.minReplicas < minLowerBound;
-  const isMaxReplicasDiffTooBig =
-    hpa?.sizing?.maxReplicas > maxUpperBound || hpa?.sizing?.maxReplicas < maxLowerBound;
-  if (isMaxReplicasDiffTooBig || isMinReplicasDiffTooBig) {
-    notes.unshift({
-      text:
-        "The new min or max size is more than 50% different from the old size. This may cause a large number of pods to be created or deleted.",
-      severity: "warning",
-    });
-  }
+    // if new values are either 50% bigger or smaller than old values, add a warning note
+    const maxUpperBound = 1.5 * oldHpaData.sizing.maxReplicas;
+    const maxLowerBound = 0.5 * oldHpaData.sizing.maxReplicas;
+    const minUpperBound = 1.5 * oldHpaData.sizing.minReplicas;
+    const minLowerBound = 0.5 * oldHpaData.sizing.minReplicas;
+    const isMinReplicasDiffTooBig =
+      hpa.sizing.minReplicas > minUpperBound || hpa.sizing.minReplicas < minLowerBound;
+    const isMaxReplicasDiffTooBig =
+      hpa.sizing.maxReplicas > maxUpperBound || hpa.sizing.maxReplicas < maxLowerBound;
+    if (isMaxReplicasDiffTooBig || isMinReplicasDiffTooBig) {
+      notes.unshift({
+        text:
+          "The new min or max size is more than 50% different from the old size. This may cause a large number of pods to be created or deleted.",
+        severity: "warning",
+      });
+    }
   }, []);
 
   return (
@@ -171,8 +171,8 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
           { name: "Cluster", value: hpa.cluster },
           { name: "New Min Size", value: hpa.sizing.minReplicas },
           { name: "New Max Size", value: hpa.sizing.maxReplicas },
-          { name: "Old Min Size", value: oldHpaData?.sizing?.minReplicas },
-          { name: "Old Max Size", value: oldHpaData?.sizing?.maxReplicas },
+          { name: "Old Min Size", value: oldHpaData.sizing.minReplicas },
+          { name: "Old Max Size", value: oldHpaData.sizing.maxReplicas },
         ]}
       />
       <NotePanel notes={notes} />

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -172,10 +172,10 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
           { name: "Name", value: hpa.name },
           { name: "Namespace", value: hpa.namespace },
           { name: "Cluster", value: hpa.cluster },
+          { name: "Old Min Size", value: currentHpaData.sizing.minReplicas },
+          { name: "Old Max Size", value: currentHpaData.sizing.maxReplicas },
           { name: "New Min Size", value: hpa.sizing.minReplicas },
           { name: "New Max Size", value: hpa.sizing.maxReplicas },
-          { name: "Current Min Size", value: currentHpaData.sizing.minReplicas },
-          { name: "Current Max Size", value: currentHpaData.sizing.maxReplicas },
         ]}
       />
       <NotePanel notes={notes} />

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -44,7 +44,7 @@ const HPADetails: React.FC<WizardChild> = () => {
     hpaData.updateData(key, value);
   };
 
-  const oldHpaData = useDataLayout("oldHpaData");
+  const currentHpaData = useDataLayout("currentHpaData");
 
   const metadataAnnotations = [];
   const metadataLabels = [];
@@ -64,7 +64,7 @@ const HPADetails: React.FC<WizardChild> = () => {
 
     // save the original values of min and max replicas
     if (hpa) {
-      oldHpaData.assign(hpa);
+      currentHpaData.assign(hpa);
     }
   }, []);
 
@@ -140,12 +140,12 @@ const HPADetails: React.FC<WizardChild> = () => {
 const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   const hpa = useDataLayout("hpaData").displayValue() as IClutch.k8s.v1.HPA;
   const resizeData = useDataLayout("resizeData");
-  const oldHpaData = useDataLayout("oldHpaData").displayValue() as IClutch.k8s.v1.HPA;
+  const currentHpaData = useDataLayout("currentHpaData").displayValue() as IClutch.k8s.v1.HPA;
 
   React.useEffect(() => {
     // if new values are either 50% bigger or smaller than old values, add a warning note
     const alertLevel = 0.5;
-    const { maxReplicas, minReplicas } = oldHpaData.sizing;
+    const { maxReplicas, minReplicas } = currentHpaData.sizing;
     const maxUpperBound = (1 + alertLevel) * maxReplicas;
     const maxLowerBound = (1 - alertLevel) * maxReplicas;
     const minUpperBound = (1 + alertLevel) * minReplicas;
@@ -174,8 +174,8 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
           { name: "Cluster", value: hpa.cluster },
           { name: "New Min Size", value: hpa.sizing.minReplicas },
           { name: "New Max Size", value: hpa.sizing.maxReplicas },
-          { name: "Old Min Size", value: oldHpaData.sizing.minReplicas },
-          { name: "Old Max Size", value: oldHpaData.sizing.maxReplicas },
+          { name: "Current Min Size", value: currentHpaData.sizing.minReplicas },
+          { name: "Current Max Size", value: currentHpaData.sizing.maxReplicas },
         ]}
       />
       <NotePanel notes={notes} />
@@ -187,7 +187,7 @@ const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
   const dataLayout = {
     hpaData: {},
     inputData: {},
-    oldHpaData: {},
+    currentHpaData: {},
     resizeData: {
       deps: ["hpaData", "inputData"],
       hydrator: (hpaData: IClutch.k8s.v1.HPA, inputData: { clientset: string }) => {

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -189,8 +189,12 @@ const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
     inputData: {},
     currentHpaData: {},
     resizeData: {
-      deps: ["hpaData", "inputData"],
-      hydrator: (hpaData: IClutch.k8s.v1.HPA, inputData: { clientset: string }) => {
+      deps: ["hpaData", "inputData", "currentHpaData"],
+      hydrator: (
+        hpaData: IClutch.k8s.v1.HPA,
+        inputData: { clientset: string },
+        currentHpaData: IClutch.k8s.v1.HPA
+      ) => {
         const clientset = inputData.clientset ?? "unspecified";
 
         return client.post("/v1/k8s/resizeHPA", {
@@ -201,6 +205,10 @@ const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
           sizing: {
             min: hpaData.sizing.minReplicas,
             max: hpaData.sizing.maxReplicas,
+          },
+          currentSizing: {
+            min: currentHpaData.sizing.minReplicas,
+            max: currentHpaData.sizing.maxReplicas,
           },
         } as IClutch.k8s.v1.IResizeHPARequest);
       },


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
In the case where the new min or new max replicas are different than the old min or max by more than 50%, display a warning note indicating as such.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Tested on staging (see private PR for screenshot)

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
