### PR TITLE
frontend: Scaffolding - Fixing Workflow

### DIFF
--- a/tools/scaffolding/templates/frontend/package.json
+++ b/tools/scaffolding/templates/frontend/package.json
@@ -28,7 +28,11 @@
     "react-is": "^17.0.2"
   },
   "resolutions": {
-    "@types/react": "^17.0.2"
+    "@types/react": "^17.0.2",
+    "@mui/material": "5.8.5",
+    "@mui/lab": "5.0.0-alpha.87",
+    "@mui/styles": "5.8.4",
+    "@mui/system": "5.8.5"
   },
   "devDependencies": {
     "@clutch-sh/tools": "^2.0.0-beta"


### PR DESCRIPTION
### Description
`make scaffold-workflow` was throwing an error during compilation. Rooted it out to the `@mui` packages being updated past what they're locked to in core. Locking the versions in the resolutions fixes the issue

#### Error
```
$ /private/var/folders/94/f35bk_5d3fb_5knz5ytdb2h00000gn/T/clutch-scaffolding-1026524175/node_modules/.bin/tsc
node_modules/@clutch-sh/core/dist/Input/date-time.d.ts(3,51): error TS2314: Generic type 'DateTimePickerProps' requires 1 type argument(s).
node_modules/@mui/lab/Timeline/Timeline.d.ts(48,77): error TS2344: Type '"hidden" | "color" | "style" | "position" | "translate" | "slot" | "title" | "children" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | ... 247 more ... | "onResizeCapture"' does not satisfy the constraint 'keyof TimelineProps'.
  Type '"onResize"' is not assignable to type 'keyof TimelineProps'. Did you mean '"onReset"'?
node_modules/@mui/material/Popper/Popper.d.ts(36,73): error TS2344: Type '"hidden" | "color" | "style" | "open" | "translate" | "transition" | "slot" | "title" | "children" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | ... 260 more ... | "componentsProps"' does not satisfy the constraint '"hidden" | "color" | "style" | "open" | "translate" | "transition" | "slot" | "title" | "children" | "ref" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | ... 258 more ... | "componentsProps"'.
  Type '"onResize"' is not assignable to type '"hidden" | "color" | "style" | "open" | "translate" | "transition" | "slot" | "title" | "children" | "ref" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | ... 258 more ... | "componentsProps"'. Did you mean '"onReset"'?
error Command failed with exit code 2.
```

### Testing Performed
manual
