### PR TITLE
housekeeping: Documentation Update

### DIFF
--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -511,15 +511,15 @@ There are two new imports (`@clutch-sh/core` and `@clutch-sh/data-layout`) added
   },
   "dependencies": {
     // highlight-start
-    "@clutch-sh/core": "^1.0.0-beta",
-    "@clutch-sh/data-layout": "^1.0.0-beta",
+    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^2.0.0-beta",
     // highlight-end
-    "@clutch-sh/wizard": "^1.0.0-beta",
+    "@clutch-sh/wizard": "^2.0.0-beta",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^1.0.0-beta"
+    "@clutch-sh/tools": "^2.0.0-beta"
   },
   "engines": {
     "node": ">=16.0.0 <17",
@@ -629,16 +629,16 @@ There is another new import (`lodash`) added in the code above. Let's also add t
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^1.0.0-beta",
-    "@clutch-sh/data-layout": "^1.0.0-beta",
-    "@clutch-sh/wizard": "^1.0.0-beta",
+    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^2.0.0-beta",
     // highlight-next-line
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^1.0.0-beta"
+    "@clutch-sh/tools": "^2.0.0-beta"
   },
   "engines": {
     "node": ">=16.0.0 <17",

--- a/examples/amiibo/frontend/workflows/amiibo/package.json
+++ b/examples/amiibo/frontend/workflows/amiibo/package.json
@@ -18,15 +18,15 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^1.0.0-beta",
-    "@clutch-sh/data-layout": "^1.0.0-beta",
-    "@clutch-sh/wizard": "^1.0.0-beta",
+    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^2.0.0-beta",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@clutch-sh/tools": "^1.0.0-beta"
+    "@clutch-sh/tools": "^2.0.0-beta"
   },
   "engines": {
     "node": ">=16.0.0 <17",


### PR DESCRIPTION
### Description
Noticed the documentation was still referencing `1.0.0-beta` which was material ui 4, now that we've upgraded to material-ui 5 this should reflect `2.0.0-beta`.
