### PR TITLE
Frontend: ToggleButtonGroup styles update

### DIFF
--- a/frontend/packages/core/src/Input/toggle-button-group.tsx
+++ b/frontend/packages/core/src/Input/toggle-button-group.tsx
@@ -14,15 +14,39 @@ export interface ToggleButtonGroupProps
   multiple?: boolean;
 }
 
-const StyledMuiToggleButtonGroup = styled(MuiToggleButtonGroup)({
+const StyledMuiToggleButtonGroup = styled(MuiToggleButtonGroup)(({ size }) => ({
+  border: "1px solid rgba(13, 16, 48, 0.45)",
+  padding: "8px",
+  gap: "8px",
+  background: "#FFFFFF",
   ".MuiToggleButton-root": {
-    "&.Mui-selected": {
-      color: "#3548D4",
-      backgroundColor: "rgba(53, 72, 212, 0.12)",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: size === "small" ? "7px 32px" : "14px 32px",
+    fontSize: size === "small" ? "14px" : "16px",
+    borderRadius: "4px !important",
+    border: "none",
+    width: "100%",
+    "&.MuiToggleButton-root:hover:not(.Mui-selected)": {
+      background: "#0D10300D",
     },
+    "&.MuiToggleButton-root:active:not(.Mui-selected)": {
+      background: "#0D10302E",
+    },
+    "&.Mui-selected": {
+      background: "#3548D4",
+      color: "#FFFFFF",
+    },
+    "&.Mui-disabled": {
+      background: "rgba(13, 16, 48, 0.03)",
+      color: "rgba(13, 16, 48, 0.48)",
+    },
+    background: "#FFFFFF",
+    color: "#0D1030",
     textTransform: "none",
   },
-});
+}));
 
 // TODO(smonero): add some tests
 // TODO(smonero): add another component that is a parent component


### PR DESCRIPTION
### Description
After meeting as a group, we decided to update the ToggleButtonGroup component styles from the base MaterialUI component, to a custom design that goes in line with the current UI.

Before:
![image](https://user-images.githubusercontent.com/5430603/207121889-af241912-f56d-4d85-8024-7cd4ca714228.png)

![image](https://user-images.githubusercontent.com/5430603/207121950-4d613729-619e-400d-9156-956c474790bd.png)


After:
![image](https://user-images.githubusercontent.com/5430603/207112283-4433e8a4-763c-426b-b524-3ad5046beb32.png)

![image](https://user-images.githubusercontent.com/5430603/207112358-e5ced52b-2642-4e4d-bfdb-6f5c3aac211e.png)


### Testing Performed
manual
