### PR TITLE
Frontend: Add set height for Card component

### DIFF
--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -176,6 +176,7 @@ interface CardContentProps extends SpacingProps {
   collapseAction?: CardContentCollapsibleProps;
   /** The max height of the card content. The default is none. */
   maxHeight?: number | "none";
+  className?: string;
 }
 
 const CardContent = ({
@@ -244,7 +245,7 @@ const StyledLandingCard = styled(Card)({
   height: "214px",
   maxHeight: "100%",
 
-  "& .cardActionArea, & .cardActionArea > div, & .cardActionArea > div > div": {
+  "& .cardActionArea": {
     height: "inherit",
     maxHeight: "inherit",
   },
@@ -296,7 +297,7 @@ export const LandingCard = ({ group, title, description, onClick, ...props }: La
           <span>{group}</span>
         </div>
         <div>
-          <Typography variant="h3">{title}</Typography>
+          <TruncatedText variant="h3">{title}</TruncatedText>
           <TruncatedText color="rgba(13, 16, 48, 0.6)" variant="body2">
             {description}
           </TruncatedText>

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -272,6 +272,11 @@ const TruncatedText = styled(Typography)({
   overflow: "hidden",
   "-webkit-box-orient": "vertical",
   "-webkit-line-clamp": "3",
+  [`@media screen and (max-width: 595px),
+  screen and (min-width: 900px) and (max-width: 950px),
+  screen and (min-width: 1200px) and (max-width: 1250px)`]: {
+    "-webkit-line-clamp": "2",
+  },
 });
 
 export interface LandingCardProps extends Pick<CardActionAreaProps, "onClick"> {

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -267,6 +267,13 @@ const StyledLandingCard = styled(Card)({
   },
 });
 
+const TruncatedText = styled(Typography)({
+  display: "-webkit-box",
+  overflow: "hidden",
+  "-webkit-box-orient": "vertical",
+  "-webkit-line-clamp": "3",
+});
+
 export interface LandingCardProps extends Pick<CardActionAreaProps, "onClick"> {
   group: string;
   title: string;
@@ -285,9 +292,9 @@ export const LandingCard = ({ group, title, description, onClick, ...props }: La
         </div>
         <div>
           <Typography variant="h3">{title}</Typography>
-          <Typography color="rgba(13, 16, 48, 0.6)" variant="body2">
+          <TruncatedText color="rgba(13, 16, 48, 0.6)" variant="body2">
             {description}
-          </Typography>
+          </TruncatedText>
         </div>
       </CardContent>
     </StyledCardActionArea>

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -241,6 +241,13 @@ const CardContent = ({
 
 const StyledLandingCard = styled(Card)({
   border: "none",
+  height: "214px",
+  maxHeight: "100%",
+
+  "& .cardActionArea, & .cardActionArea > div, & .cardActionArea > div > div": {
+    height: "inherit",
+    maxHeight: "inherit",
+  },
 
   "& .header": {
     display: "inline-flex",
@@ -268,7 +275,7 @@ export interface LandingCardProps extends Pick<CardActionAreaProps, "onClick"> {
 
 export const LandingCard = ({ group, title, description, onClick, ...props }: LandingCardProps) => (
   <StyledLandingCard {...props}>
-    <StyledCardActionArea onClick={onClick}>
+    <StyledCardActionArea className="cardActionArea" onClick={onClick}>
       <CardContent padding={4}>
         <div className="header">
           <div className="icon">


### PR DESCRIPTION
### Description
Card components in the landing page adjusted their height according to the card's description length. That caused disparity in the cards sizes. This update sets the Card height to a fixed 214px.

Before:
![image](https://user-images.githubusercontent.com/5430603/207119305-83939d28-2aa4-47cb-808b-adbddbb98dc8.png)

After:
![image](https://user-images.githubusercontent.com/5430603/207120110-1eeb3b19-1670-4360-8ff1-33cd1d234422.png)


### Testing Performed
manual