### PR TITLE
Housekeeping: Updated docs with paths for local development of features

### DIFF
--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -48,6 +48,10 @@ For the reasons stated above, the API defined below will largely look identical 
 
 Clutch uses protobuf for interface definitions. An empty definition is provided below.
 
+:::info
+When adding a feature directly in the clutch project, `path_to_gateway` should be `lyft/clutch`
+:::
+
 ```protobuf title="api/amiibo/v1/amiibo.proto"
 syntax = "proto3";
 
@@ -786,6 +790,10 @@ export default register;
 ```
 
 Next, open your `clutch.config.js` file and add the amiibo configuration highlighted below:
+
+:::info
+When adding a feature directly in the clutch project, the configuration file will be located in `frontend/packages/app/src/clutch.config.js`
+:::
 
 ```js title="{path_to_gateway}/frontend/src/clutch.config.js"
 module.exports = {


### PR DESCRIPTION
### Description
Adding a few paths that were unclear while following the Feature development guide. Both the path_to_gateway and the location of clutch.config.js differ when locally developing a feature without using a custom gateway.

![image](https://user-images.githubusercontent.com/5430603/207402996-81ff8f74-7579-48d5-ad94-46b412b72565.png)

![image](https://user-images.githubusercontent.com/5430603/207403224-80bc6126-8fdf-4e4c-80f7-6a712ff2095a.png)


### Testing Performed
manual