### PR TITLE
frontend: Button Sizing Extension

### DIFF
--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -95,18 +95,34 @@ const colorCss = (palette: ButtonPalette) => {
   };
 };
 
-const StyledButton = styled(MuiButton)<{ palette: ButtonPalette }>(
+const BUTTON_SIZE_MAP = {
+  small: {
+    height: "32px",
+    padding: "7px 32px",
+  },
+  medium: {
+    height: "48px",
+    padding: "14px 32px",
+  },
+  large: {
+    height: "64px",
+    padding: "21px 32px",
+  },
+};
+
+const StyledButton = styled(MuiButton)<{ palette: ButtonPalette; size: MuiButtonProps["size"] }>(
   {
     borderRadius: "4px",
     fontWeight: 500,
     lineHeight: "20px",
     fontSize: "16px",
     textTransform: "none",
-    height: "48px",
-    padding: "14px 32px",
     margin: "12px 8px",
   },
-  props => colorCss(props.palette)
+  props => ({
+    ...colorCss(props.palette),
+    ...BUTTON_SIZE_MAP[props.size],
+  })
 );
 
 const StyledBorderButton = styled(StyledButton)({
@@ -144,7 +160,10 @@ const variantPalette = (variant: ButtonVariant): ButtonPalette => {
 };
 
 export interface ButtonProps
-  extends Pick<MuiButtonProps, "disabled" | "endIcon" | "onClick" | "startIcon" | "type"> {
+  extends Pick<
+    MuiButtonProps,
+    "id" | "disabled" | "endIcon" | "onClick" | "startIcon" | "type" | "size"
+  > {
   /** Case-sensitive button text. */
   text: string;
   /** The button variantion. Defaults to primary. */
@@ -152,12 +171,12 @@ export interface ButtonProps
 }
 
 /** A button with default themes based on use case. */
-const Button = ({ text, variant = "primary", ...props }: ButtonProps) => {
+const Button = ({ text, variant = "primary", size = "medium", ...props }: ButtonProps) => {
   const palette = variantPalette(variant);
   const ButtonVariant = variant === "neutral" ? StyledBorderButton : StyledButton;
 
   return (
-    <ButtonVariant variant="contained" disableElevation palette={palette} {...props}>
+    <ButtonVariant variant="contained" disableElevation palette={palette} size={size} {...props}>
       {text}
     </ButtonVariant>
   );

--- a/frontend/packages/core/src/stories/button.stories.tsx
+++ b/frontend/packages/core/src/stories/button.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import type { ButtonProps } from "../button";
-import { Button } from "../button";
+import { Button, ButtonProps } from "../button";
 
 export default {
   title: "Core/Buttons/Button",

--- a/frontend/packages/core/src/tests/__snapshots__/button.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/button.test.tsx.snap
@@ -1,19 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Destructive Button component renders correctly 1`] = `
-"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}} size=\\"medium\\">
-  test
-</Styled(Component)>"
-`;
+exports[`Destructive Button Component 1`] = `"<button class=\\"MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButtonBase-root css-56t2ig-MuiButtonBase-root-MuiButton-root\\" tabindex=\\"0\\" type=\\"button\\" palette=\\"[object Object]\\">test</button>"`;
 
-exports[`Neutral Button component renders correctly 1`] = `
-"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}} size=\\"medium\\">
-  test
-</Styled(Component)>"
-`;
+exports[`Large Button Component 1`] = `"<button class=\\"MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-disableElevation MuiButtonBase-root css-1yxqof8-MuiButtonBase-root-MuiButton-root\\" tabindex=\\"0\\" type=\\"button\\" palette=\\"[object Object]\\">test</button>"`;
 
-exports[`Primary Button component renders correctly 1`] = `
-"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}} size=\\"medium\\">
-  test
-</Styled(Component)>"
-`;
+exports[`Neutral Button Component 1`] = `"<button class=\\"MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButtonBase-root css-iry732-MuiButtonBase-root-MuiButton-root\\" tabindex=\\"0\\" type=\\"button\\" palette=\\"[object Object]\\">test</button>"`;
+
+exports[`Primary Button Component 1`] = `"<button class=\\"MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButtonBase-root css-1bnnxp5-MuiButtonBase-root-MuiButton-root\\" tabindex=\\"0\\" type=\\"button\\" palette=\\"[object Object]\\">test</button>"`;
+
+exports[`Small Button Component 1`] = `"<button class=\\"MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonBase-root css-16s2k8f-MuiButtonBase-root-MuiButton-root\\" tabindex=\\"0\\" type=\\"button\\" palette=\\"[object Object]\\">test</button>"`;

--- a/frontend/packages/core/src/tests/__snapshots__/button.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/button.test.tsx.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Destructive Button component renders correctly 1`] = `
-"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}}>
+"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}} size=\\"medium\\">
   test
 </Styled(Component)>"
 `;
 
 exports[`Neutral Button component renders correctly 1`] = `
-"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}}>
+"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}} size=\\"medium\\">
   test
 </Styled(Component)>"
 `;
 
 exports[`Primary Button component renders correctly 1`] = `
-"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}}>
+"<Styled(Component) variant=\\"contained\\" disableElevation={true} palette={{...}} size=\\"medium\\">
   test
 </Styled(Component)>"
 `;

--- a/frontend/packages/core/src/tests/button.test.tsx
+++ b/frontend/packages/core/src/tests/button.test.tsx
@@ -1,40 +1,49 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { render, unmountComponentAtNode } from "react-dom";
+
+import "@testing-library/jest-dom";
 
 import { Button } from "../button";
 
-describe("Primary Button component", () => {
-  let component;
-
-  beforeAll(() => {
-    component = shallow(<Button text="test" />);
-  });
-
-  it("renders correctly", () => {
-    expect(component.debug()).toMatchSnapshot();
-  });
+let container: HTMLElement;
+beforeEach(() => {
+  // setup a DOM element as a render target
+  container = document.createElement("div");
+  document.body.appendChild(container);
 });
 
-describe("Neutral Button component", () => {
-  let component;
-
-  beforeAll(() => {
-    component = shallow(<Button variant="neutral" text="test" />);
-  });
-
-  it("renders correctly", () => {
-    expect(component.debug()).toMatchSnapshot();
-  });
+afterEach(() => {
+  // cleanup on exiting
+  unmountComponentAtNode(container);
+  container.remove();
 });
 
-describe("Destructive Button component", () => {
-  let component;
+test("Primary Button Component", () => {
+  render(<Button text="test" />, container);
 
-  beforeAll(() => {
-    component = shallow(<Button variant="destructive" text="test" />);
-  });
+  expect(container.innerHTML).toMatchSnapshot();
+});
 
-  it("renders correctly", () => {
-    expect(component.debug()).toMatchSnapshot();
-  });
+test("Neutral Button Component", () => {
+  render(<Button variant="neutral" text="test" />, container);
+
+  expect(container.innerHTML).toMatchSnapshot();
+});
+
+test("Destructive Button Component", () => {
+  render(<Button variant="destructive" text="test" />, container);
+
+  expect(container.innerHTML).toMatchSnapshot();
+});
+
+test("Small Button Component", () => {
+  render(<Button size="small" text="test" />, container);
+
+  expect(container.innerHTML).toMatchSnapshot();
+});
+
+test("Large Button Component", () => {
+  render(<Button size="large" text="test" />, container);
+
+  expect(container.innerHTML).toMatchSnapshot();
 });


### PR DESCRIPTION
### Description
MUI supports multiple button sizes (https://mui.com/material-ui/react-button/#sizes) which we did not currently support. Adding support for them here as well as rotating the tests to use React Testing Library.

This will also be utilized as part of the NPS Banner component.

#### Small
![Screenshot 2022-12-13 at 9 47 17 AM](https://user-images.githubusercontent.com/8338893/207407171-988607da-318a-4c4f-a86f-f295b5faf141.png)

#### Medium (current default)
![Screenshot 2022-12-13 at 9 47 20 AM](https://user-images.githubusercontent.com/8338893/207407155-87b7c701-df31-4e0b-aff9-de1bb5efef21.png)

#### Large
![Screenshot 2022-12-13 at 9 47 23 AM](https://user-images.githubusercontent.com/8338893/207407146-ef6280c7-09b1-431c-a0cc-7328583c560d.png)

### Testing Performed
manual
