### PR TITLE
frontend: Storybook - Updating Select Documentation

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -191,7 +191,7 @@ export interface SelectProps extends Pick<MuiSelectProps, "disabled" | "error"> 
   onChange?: (value: string) => void;
 }
 
-const Select = ({
+export const Select = ({
   defaultOption = 0,
   disabled,
   error,

--- a/frontend/packages/core/src/Input/stories/select.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/select.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { SelectProps } from "../select";
-import Select from "../select";
+import { Select } from "../select";
 
 export default {
   title: "Core/Input/Select",
@@ -15,8 +15,8 @@ export default {
 
 const Template = (props: SelectProps) => <Select name="storybookDemo" {...props} />;
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Default = Template.bind({});
+Default.args = {
   label: "My Label",
   options: [
     {
@@ -24,47 +24,14 @@ Primary.args = {
     },
     {
       label: "Option 2",
+      value: "Other Value",
     },
   ],
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  ...Primary.args,
-  disabled: true,
-};
-
-export const Error = Template.bind({});
-Error.args = {
-  ...Primary.args,
-  error: true,
-  helperText: "There was a problem!",
-};
-
-export const CustomValues = Template.bind({});
-CustomValues.args = {
-  ...Primary.args,
-  options: [
-    {
-      label: "Option 1",
-      value: "VALUE_ONE",
-    },
-    {
-      label: "Option 2",
-      value: "VALUE_TWO",
-    },
-  ],
-};
-
-export const WithoutLabel = Template.bind({});
-WithoutLabel.args = {
-  ...Primary.args,
-  label: null,
 };
 
 export const WithStartAdornment = Template.bind({});
 WithStartAdornment.args = {
-  ...Primary.args,
+  ...Default.args,
   options: [
     {
       label: "Option 1",
@@ -75,7 +42,7 @@ WithStartAdornment.args = {
 
 export const WithGrouping = Template.bind({});
 WithGrouping.args = {
-  ...Primary.args,
+  ...Default.args,
   options: [
     {
       label: "Option 1",

--- a/frontend/packages/core/src/Input/tests/select.test.tsx
+++ b/frontend/packages/core/src/Input/tests/select.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import Select from "../select";
+import { Select } from "../select";
 
 describe("Select", () => {
   describe("default option", () => {

--- a/frontend/packages/core/src/Resolver/hydrator.tsx
+++ b/frontend/packages/core/src/Resolver/hydrator.tsx
@@ -3,8 +3,7 @@ import type { FieldValues, UseFormReturn } from "react-hook-form";
 import type { clutch } from "@clutch-sh/api";
 import _ from "lodash";
 
-import Select from "../Input/select";
-import TextField from "../Input/text-field";
+import { Select, TextField } from "../Input";
 
 export interface ResolverChangeEvent {
   target: {


### PR DESCRIPTION
### Description
Updating storybook for select, came from changes in https://github.com/lyft/clutch/pull/2493. This modifies the documentation section of storybook to be auto-generated based on the inputs for Select, allowing it to be interacted with at a deeper level without a need for multiple stories. 

#### Before
<img width="1075" alt="Screenshot 2022-12-15 at 12 49 40 PM" src="https://user-images.githubusercontent.com/8338893/207964828-c90e1f32-71d1-4261-9ff0-436808aa58bc.png">

#### After
<img width="1099" alt="Screenshot 2022-12-15 at 12 49 11 PM" src="https://user-images.githubusercontent.com/8338893/207964841-067df44f-bb8b-4af1-9d44-a245352f42b5.png">

### Testing Performed
manual
