### PR TITLE
Frontend: Set a style for the ToggleButtonGroup hover when selected

### DIFF
--- a/frontend/packages/core/src/Input/toggle-button-group.tsx
+++ b/frontend/packages/core/src/Input/toggle-button-group.tsx
@@ -34,7 +34,7 @@ const StyledMuiToggleButtonGroup = styled(MuiToggleButtonGroup)(({ size }) => ({
     "&.MuiToggleButton-root:active:not(.Mui-selected)": {
       background: "#0D10302E",
     },
-    "&.Mui-selected": {
+    "&.Mui-selected, &.Mui-selected:hover": {
       background: "#3548D4",
       color: "#FFFFFF",
     },


### PR DESCRIPTION
### Description
The hover state for the ToggleButtonGroup when selected had a background change that made reading the text in the button difficult. The behaviour was updated to go in line with the current design system. 

Before:
![image](https://user-images.githubusercontent.com/5430603/208144327-b2bc5a71-3d7c-40e0-ad01-9766786e1cd6.png)

After:
![image](https://user-images.githubusercontent.com/5430603/208144589-3113a127-393d-4ac0-bbe9-be85d162e877.png)

### Testing Performed
Manual