### PR TITLE
Frontend: reduced top padding in Confirmation

### DIFF
--- a/frontend/packages/core/src/confirmation.tsx
+++ b/frontend/packages/core/src/confirmation.tsx
@@ -5,7 +5,7 @@ import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import { Grid } from "@mui/material";
 
 const IconContainer = styled(Grid)({
-  paddingTop: "20px",
+  paddingTop: "4px",
   display: "flex",
   flexDirection: "column",
   justifyContent: "center",


### PR DESCRIPTION
### Description
The padding above the confirmation component's icon was reduced to optimise space usage.

Before:
<img width="510" alt="image" src="https://user-images.githubusercontent.com/5430603/208153321-5be6d0af-9992-4ea8-a744-df29ee600cf1.png">

After:
<img width="507" alt="image" src="https://user-images.githubusercontent.com/5430603/208153463-61fb32bb-689d-4955-ac1e-23783ab5f070.png">


### Testing Performed
Manual