### PR TITLE
frontend: add ellipsis prop to text fields

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -44,9 +44,7 @@ const StyledAutocomplete = styled(Autocomplete)({
   },
 });
 
-interface StyledTextFieldProps extends Pick<TextFieldProps, "truncateWithEllipsis"> {}
-
-const StyledTextField = styled(BaseTextField)(({ truncateWithEllipsis }: StyledTextFieldProps) => ({
+const StyledTextField = styled(BaseTextField)({
   "--error-color": "#DB3615",
   height: "unset",
 
@@ -85,7 +83,7 @@ const StyledTextField = styled(BaseTextField)(({ truncateWithEllipsis }: StyledT
       backgroundColor: "rgba(13, 16, 48, 0.12)",
     },
     "& .MuiInputBase-input": {
-      textOverflow: truncateWithEllipsis ? "ellipsis" : "initial",
+      textOverflow: "ellipsis",
     },
     "> .MuiInputBase-input": {
       "--input-padding": "14px 16px",
@@ -126,7 +124,7 @@ const StyledTextField = styled(BaseTextField)(({ truncateWithEllipsis }: StyledT
       marginRight: "4px",
     },
   },
-}));
+});
 
 // popper containing the search result options
 const Popper = styled(MuiPopper)({
@@ -214,7 +212,6 @@ export interface TextFieldProps
   onReturn?: () => void;
   autocompleteCallback?: (v: string) => Promise<{ results: { id?: string; label: string }[] }>;
   formRegistration?: UseFormRegister<FieldValues>;
-  truncateWithEllipsis?: boolean;
 }
 
 const TextFieldRef = (
@@ -233,7 +230,6 @@ const TextFieldRef = (
     required,
     formRegistration,
     inputRef,
-    truncateWithEllipsis,
     ...props
   }: TextFieldProps,
   ref
@@ -382,7 +378,6 @@ const TextFieldRef = (
       onChange={onChange}
       {...props}
       {...{ ref }}
-      truncateWithEllipsis={truncateWithEllipsis}
     />
   );
 };

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -44,7 +44,9 @@ const StyledAutocomplete = styled(Autocomplete)({
   },
 });
 
-const StyledTextField = styled(BaseTextField)({
+interface StyledTextFieldProps extends Pick<TextFieldProps, "truncateWithEllipsis"> {}
+
+const StyledTextField = styled(BaseTextField)(({ truncateWithEllipsis }: StyledTextFieldProps) => ({
   "--error-color": "#DB3615",
   height: "unset",
 
@@ -81,6 +83,9 @@ const StyledTextField = styled(BaseTextField)({
     },
     "&.Mui-disabled fieldset": {
       backgroundColor: "rgba(13, 16, 48, 0.12)",
+    },
+    "& .MuiInputBase-input": {
+      textOverflow: truncateWithEllipsis ? "ellipsis" : "initial",
     },
     "> .MuiInputBase-input": {
       "--input-padding": "14px 16px",
@@ -121,7 +126,7 @@ const StyledTextField = styled(BaseTextField)({
       marginRight: "4px",
     },
   },
-});
+}));
 
 // popper containing the search result options
 const Popper = styled(MuiPopper)({
@@ -209,6 +214,7 @@ export interface TextFieldProps
   onReturn?: () => void;
   autocompleteCallback?: (v: string) => Promise<{ results: { id?: string; label: string }[] }>;
   formRegistration?: UseFormRegister<FieldValues>;
+  truncateWithEllipsis?: boolean;
 }
 
 const TextFieldRef = (
@@ -227,6 +233,7 @@ const TextFieldRef = (
     required,
     formRegistration,
     inputRef,
+    truncateWithEllipsis,
     ...props
   }: TextFieldProps,
   ref
@@ -375,6 +382,7 @@ const TextFieldRef = (
       onChange={onChange}
       {...props}
       {...{ ref }}
+      truncateWithEllipsis={truncateWithEllipsis}
     />
   );
 };

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -34,6 +34,7 @@ interface RowData {
   name: string;
   value: unknown;
   disabledFieldTooltip?: string;
+  truncateWithEllipsis?: boolean;
 }
 
 interface IdentifiableRowData extends RowData {
@@ -160,6 +161,7 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
       name={data.name}
       defaultValue={data.value}
       label={data.textFieldLabels?.disabledField}
+      truncateWithEllipsis={data.truncateWithEllipsis}
     />
   );
 
@@ -187,6 +189,7 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
             helperText={error?.message || ""}
             error={!!error || false}
             formRegistration={validation.register}
+            truncateWithEllipsis={data.truncateWithEllipsis}
           />
         </Grid>
       </TableCell>

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -34,7 +34,6 @@ interface RowData {
   name: string;
   value: unknown;
   disabledFieldTooltip?: string;
-  truncateWithEllipsis?: boolean;
 }
 
 interface IdentifiableRowData extends RowData {
@@ -161,7 +160,6 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
       name={data.name}
       defaultValue={data.value}
       label={data.textFieldLabels?.disabledField}
-      truncateWithEllipsis={data.truncateWithEllipsis}
     />
   );
 
@@ -189,7 +187,6 @@ const MutableRow: React.FC<MutableRowProps> = ({ data, onUpdate, onReturn, valid
             helperText={error?.message || ""}
             error={!!error || false}
             formRegistration={validation.register}
-            truncateWithEllipsis={data.truncateWithEllipsis}
           />
         </Grid>
       </TableCell>


### PR DESCRIPTION
### Description
The numeric input fields, both disabled and enabled truncated their contents with no indication that additional text could be hidden after the cut. This could lead to a wrong reading of the stored value.
A prop `truncateWithEllipsis` was added to the TextField component to add an ellipsis (`...`) whenever the content of the input overflows. The prop is leveraged by MetadataTable by passing a flag `truncateWithEllipsis` in the body of `RowData`.

Max Size without the flag enabled, Desired Size with the flag enabled
<img width="620" alt="image" src="https://user-images.githubusercontent.com/5430603/208539711-0ed438b5-6c9a-45bc-9b30-556294b00bb5.png">

### Testing Performed
Manual