### PR TITLE
frontend: hoist single storybook stories up a level

### DIFF
--- a/frontend/packages/core/src/AppLayout/stories/header.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/header.stories.tsx
@@ -3,15 +3,15 @@ import { MemoryRouter } from "react-router";
 import type { Meta } from "@storybook/react";
 
 import { ApplicationContext } from "../../Contexts/app-context";
-import Header from "../header";
+import HeaderComponent from "../header";
 
 export default {
   title: "Core/AppLayout/Header",
-  component: Header,
+  component: HeaderComponent,
   decorators: [
     () => (
       <MemoryRouter>
-        <Header />
+        <HeaderComponent />
       </MemoryRouter>
     ),
     StoryFn => {
@@ -58,4 +58,4 @@ export default {
   },
 } as Meta;
 
-export const Primary: React.FC<{}> = () => <Header />;
+export const Header: React.FC<{}> = () => <HeaderComponent />;

--- a/frontend/packages/core/src/AppLayout/stories/logo.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/logo.stories.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
 
-import Logo from "../logo";
+import LogoComponent from "../logo";
 
 export default {
   title: "Core/AppLayout/Logo",
-  component: Logo,
+  component: LogoComponent,
 } as Meta;
 
-export const Primary: React.FC<{}> = () => <Logo />;
+export const Logo: React.FC<{}> = () => <LogoComponent />;

--- a/frontend/packages/core/src/AppLayout/stories/notifications.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/notifications.stories.tsx
@@ -4,11 +4,11 @@ import { Grid as MuiGrid } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
 import type { NotificationsProp } from "../notifications";
-import Notifications from "../notifications";
+import NotificationsComponent from "../notifications";
 
 export default {
   title: "Core/AppLayout/Notifications",
-  component: Notifications,
+  component: NotificationsComponent,
 } as Meta;
 
 const Grid = styled(MuiGrid)({
@@ -18,11 +18,11 @@ const Grid = styled(MuiGrid)({
 
 const Template = (props: NotificationsProp) => (
   <Grid container alignItems="center" justifyContent="center">
-    <Notifications {...props} />
+    <NotificationsComponent {...props} />
   </Grid>
 );
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Notifications = Template.bind({});
+Notifications.args = {
   data: [{ value: "New K8s workflow!" }, { value: "Clutch v1.18 release" }],
 };

--- a/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
@@ -5,11 +5,11 @@ import { Box, Grid as MuiGrid } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
 import { ApplicationContext } from "../../Contexts/app-context";
-import SearchField from "../search";
+import SearchFieldComponent from "../search";
 
 export default {
   title: "Core/AppLayout/Search Field",
-  component: SearchField,
+  component: SearchFieldComponent,
   decorators: [
     Search => {
       return (
@@ -67,9 +67,9 @@ const Grid = styled(MuiGrid)({
 const Template = () => (
   <Grid container alignItems="center" justifyContent="center">
     <Box>
-      <SearchField />
+      <SearchFieldComponent />
     </Box>
   </Grid>
 );
 
-export const Primary = Template.bind({});
+export const SearchField = Template.bind({});

--- a/frontend/packages/core/src/AppLayout/stories/user-information.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/user-information.stories.tsx
@@ -4,11 +4,11 @@ import { Grid as MuiGrid } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
 import type { UserInformationProps } from "../user";
-import { UserInformation } from "../user";
+import { UserInformation as UserInformationComponent } from "../user";
 
 export default {
   title: "Core/AppLayout/User Information",
-  component: UserInformation,
+  component: UserInformationComponent,
 } as Meta;
 
 const Grid = styled(MuiGrid)({
@@ -18,11 +18,11 @@ const Grid = styled(MuiGrid)({
 
 const Template = (props: UserInformationProps) => (
   <Grid container alignItems="center" justifyContent="center">
-    <UserInformation {...props} />
+    <UserInformationComponent {...props} />
   </Grid>
 );
-export const Primary = Template.bind({});
-Primary.args = {
+export const UserInformation = Template.bind({});
+UserInformation.args = {
   data: [{ value: "Dashboard" }, { value: "Settings" }],
   user: "fooBar@example.com",
 };

--- a/frontend/packages/core/src/Assets/stories/icons.stories.tsx
+++ b/frontend/packages/core/src/Assets/stories/icons.stories.tsx
@@ -11,7 +11,7 @@ import RocketIcon from "../icons/RocketIcon";
 import SirenIcon from "../icons/SirenIcon";
 import SlackIcon from "../icons/SlackIcon";
 
-export const AllIcons: React.FC<SVGProps> = ({ size }) => (
+export const Icons: React.FC<SVGProps> = ({ size }) => (
   <div>
     <FireIcon size={size} />
     <PlusIcon />
@@ -24,7 +24,7 @@ export const AllIcons: React.FC<SVGProps> = ({ size }) => (
 );
 export default {
   title: "Core/Assets/Icons",
-  component: AllIcons,
+  component: Icons,
   argTypes: {
     size: {
       options: VARIANTS,

--- a/frontend/packages/core/src/Input/stories/checkbox-panel.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/checkbox-panel.stories.tsx
@@ -2,20 +2,20 @@ import * as React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { CheckboxPanelProps } from "../checkbox";
-import { CheckboxPanel } from "../checkbox";
+import { CheckboxPanel as CheckboxPanelComponent } from "../checkbox";
 
 export default {
   title: "Core/Input/CheckboxPanel",
-  component: CheckboxPanel,
+  component: CheckboxPanelComponent,
   argTypes: {
     onChange: { action: "onChange event" },
   },
 } as Meta;
 
-const Template = (props: CheckboxPanelProps) => <CheckboxPanel {...props} />;
+const Template = (props: CheckboxPanelProps) => <CheckboxPanelComponent {...props} />;
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const CheckboxPanel = Template.bind({});
+CheckboxPanel.args = {
   header: "Select all that apply:",
   options: {
     "Option 1": false,

--- a/frontend/packages/core/src/stories/card.stories.tsx
+++ b/frontend/packages/core/src/stories/card.stories.tsx
@@ -2,16 +2,16 @@ import * as React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { CardProps } from "../card";
-import { Card, CardContent } from "../card";
+import { Card as CardComponent, CardContent } from "../card";
 
 export default {
   title: "Core/Card/Basic",
-  component: Card,
+  component: CardComponent,
 } as Meta;
 
-const Template = (props: CardProps) => <Card {...props} />;
+const Template = (props: CardProps) => <CardComponent {...props} />;
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Basic = Template.bind({});
+Basic.args = {
   children: <CardContent>Hello world!</CardContent>,
 };

--- a/frontend/packages/core/src/stories/clipboard-button.stories.tsx
+++ b/frontend/packages/core/src/stories/clipboard-button.stories.tsx
@@ -2,16 +2,16 @@ import React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { ClipboardButtonProps } from "../button";
-import { ClipboardButton } from "../button";
+import { ClipboardButton as ClipboardButtonComponent } from "../button";
 
 export default {
   title: "Core/Buttons/Clipboard Button",
-  component: ClipboardButton,
+  component: ClipboardButtonComponent,
 } as Meta;
 
-const Template = (props: ClipboardButtonProps) => <ClipboardButton {...props} />;
+const Template = (props: ClipboardButtonProps) => <ClipboardButtonComponent {...props} />;
 
-export const Default = Template.bind({});
-Default.args = {
+export const ClipboardButton = Template.bind({});
+ClipboardButton.args = {
   text: "https://clutch.sh",
 };

--- a/frontend/packages/core/src/stories/confirmation.stories.tsx
+++ b/frontend/packages/core/src/stories/confirmation.stories.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
 
-import Confirmation from "../confirmation";
+import ConfirmationComponent from "../confirmation";
 
 export default {
   title: "Core/Confirmation",
-  component: Confirmation,
+  component: ConfirmationComponent,
 } as Meta;
 
-const Template = (props: { action: string }) => <Confirmation {...props} />;
+const Template = (props: { action: string }) => <ConfirmationComponent {...props} />;
 
-export const Default = Template.bind({});
-Default.args = {
+export const Confirmation = Template.bind({});
+Confirmation.args = {
   action: "Deletion",
 };

--- a/frontend/packages/core/src/stories/landing-card.stories.tsx
+++ b/frontend/packages/core/src/stories/landing-card.stories.tsx
@@ -2,17 +2,17 @@ import * as React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { LandingCardProps } from "../card";
-import { LandingCard } from "../card";
+import { LandingCard as LandingCardComponent } from "../card";
 
 export default {
   title: "Core/Card/Landing Card",
-  component: LandingCard,
+  component: LandingCardComponent,
 } as Meta;
 
-const Template = (props: LandingCardProps) => <LandingCard {...props} />;
+const Template = (props: LandingCardProps) => <LandingCardComponent {...props} />;
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const LandingCard = Template.bind({});
+LandingCard.args = {
   group: "AWS",
   title: "EC2: Terminate Instance",
   description: "Search for and terminate an EC2 instance.",

--- a/frontend/packages/core/src/stories/landing.stories.tsx
+++ b/frontend/packages/core/src/stories/landing.stories.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 import type { Meta } from "@storybook/react";
 
 import { ApplicationContext } from "../Contexts/app-context";
-import Landing from "../landing";
+import LandingComponent from "../landing";
 
 export default {
   title: "Core/Landing",
@@ -15,9 +15,9 @@ export default {
       </ApplicationContext.Provider>
     ),
   ],
-  component: Landing,
+  component: LandingComponent,
 } as Meta;
 
-const Template = () => <Landing />;
+const Template = () => <LandingComponent />;
 
-export const Primary = Template.bind({});
+export const Landing = Template.bind({});

--- a/frontend/packages/core/src/stories/link.stories.tsx
+++ b/frontend/packages/core/src/stories/link.stories.tsx
@@ -2,16 +2,16 @@ import * as React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { LinkProps } from "../link";
-import { Link } from "../link";
+import { Link as LinkComponent } from "../link";
 
 export default {
   title: "Core/Link",
-  component: Link,
+  component: LinkComponent,
 } as Meta;
 
-const Template = (props: LinkProps) => <Link {...props}>Clutch Homepage</Link>;
+const Template = (props: LinkProps) => <LinkComponent {...props}>Clutch Homepage</LinkComponent>;
 
-export const Default = Template.bind({});
-Default.args = {
+export const Link = Template.bind({});
+Link.args = {
   href: "https://www.clutch.sh",
 };

--- a/frontend/packages/core/src/stories/not-found.stories.tsx
+++ b/frontend/packages/core/src/stories/not-found.stories.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
 
-import NotFound from "../not-found";
+import NotFoundComponent from "../not-found";
 
 export default {
   title: "Core/NotFound",
-  component: NotFound,
+  component: NotFoundComponent,
 } as Meta;
 
-const Template = () => <NotFound />;
-export const Default = Template.bind({});
+const Template = () => <NotFoundComponent />;
+export const NotFound = Template.bind({});

--- a/frontend/packages/core/src/stories/paper.stories.tsx
+++ b/frontend/packages/core/src/stories/paper.stories.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import Paper from "../paper";
+import PaperComponent from "../paper";
 
 export default {
   title: "Core/Paper",
-  component: Paper,
+  component: PaperComponent,
 } as Meta;
 
-export const Primary = () => (
-  <Paper>
+export const Paper = () => (
+  <PaperComponent>
     <div>Some text in paper</div>
-  </Paper>
+  </PaperComponent>
 );

--- a/frontend/packages/core/src/stories/text.stories.tsx
+++ b/frontend/packages/core/src/stories/text.stories.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import Code from "../text";
+import CodeComponent from "../text";
 
 export default {
   title: "Core/Text/Code",
-  component: Code,
+  component: CodeComponent,
 } as Meta;
 
-const Template = ({ value }) => <Code>{value}</Code>;
+const Template = ({ value }) => <CodeComponent>{value}</CodeComponent>;
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Code = Template.bind({});
+Code.args = {
   value: "{key1: [0, 1, 2], key2: 'value', key3: {foo: 'bar'}}",
 };

--- a/frontend/packages/core/src/stories/timeago.stories.tsx
+++ b/frontend/packages/core/src/stories/timeago.stories.tsx
@@ -1,18 +1,20 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import TimeAgo from "../timeago";
+import TimeAgoComponent from "../timeago";
 
 export default {
   title: "Core/TimeAgo",
-  component: TimeAgo,
+  component: TimeAgoComponent,
 } as Meta;
 
-const Template = ({ date, live, short }) => <TimeAgo date={date} live={live} short={short} />;
+const Template = ({ date, live, short }) => (
+  <TimeAgoComponent date={date} live={live} short={short} />
+);
 
-export const Default = Template.bind({});
+export const TimeAgo = Template.bind({});
 
-Default.args = {
+TimeAgo.args = {
   date: 1668788531 * 1000,
   short: false,
   live: false,

--- a/frontend/packages/core/src/stories/typography.stories.tsx
+++ b/frontend/packages/core/src/stories/typography.stories.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import type { Meta, Story } from "@storybook/react";
 
 import type { TypographyProps } from "../typography";
-import { Typography, VARIANTS } from "../typography";
+import { Typography as TypographyComponent, VARIANTS } from "../typography";
 
 export default {
   title: "Core/Typography",
-  component: Typography,
+  component: TypographyComponent,
   argTypes: {
     variant: {
       options: VARIANTS,
@@ -19,13 +19,13 @@ export default {
 } as Meta;
 
 const Template: Story<TypographyProps> = ({ variant, children, ...props }) => (
-  <Typography variant={variant} {...props}>
+  <TypographyComponent variant={variant} {...props}>
     {children}
-  </Typography>
+  </TypographyComponent>
 );
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Typography = Template.bind({});
+Typography.args = {
   children: "Some text",
   variant: "h1",
 };


### PR DESCRIPTION
### Description
There is a number of stories with no siblings in Storybook, this adds unnecessary nesting. Stories matching this pattern were hoisted to simplify the navigation.

Before:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/5430603/209704852-e57943b2-2f56-4fa0-8fc0-cd150eb52f78.png">

After:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/5430603/209704906-cd5390b2-478c-4ead-9674-9359446e0dae.png">


### Testing Performed
manual