### PR TITLE
frontend: hoist alert stories

### DIFF
--- a/frontend/packages/core/src/Assets/global.ts
+++ b/frontend/packages/core/src/Assets/global.ts
@@ -32,3 +32,5 @@ export const StyledSVG = styled.svg<{ size?: IconSizeVariant }>(props => ({
 export interface SVGProps extends React.SVGProps<SVGSVGElement> {
   size?: IconSizeVariant;
 }
+
+export const SEVERITIES = ["error", "info", "success", "warning"];

--- a/frontend/packages/core/src/Assets/global.ts
+++ b/frontend/packages/core/src/Assets/global.ts
@@ -32,5 +32,3 @@ export const StyledSVG = styled.svg<{ size?: IconSizeVariant }>(props => ({
 export interface SVGProps extends React.SVGProps<SVGSVGElement> {
   size?: IconSizeVariant;
 }
-
-export const SEVERITIES = ["error", "info", "success", "warning"];

--- a/frontend/packages/core/src/Feedback/alert.tsx
+++ b/frontend/packages/core/src/Feedback/alert.tsx
@@ -72,6 +72,8 @@ const iconMappings = {
   warning: <WarningIcon />,
 };
 
+export const SEVERITIES = Object.keys(iconMappings);
+
 export interface AlertProps
   extends Pick<MuiAlertProps, "severity" | "action" | "onClose" | "elevation" | "variant"> {
   title?: React.ReactNode;

--- a/frontend/packages/core/src/Feedback/alert.tsx
+++ b/frontend/packages/core/src/Feedback/alert.tsx
@@ -8,6 +8,8 @@ import { Alert as MuiAlert, AlertTitle as MuiAlertTitle, Grid } from "@mui/mater
 
 import styled from "../styled";
 
+export const SEVERITIES = ["error", "info", "success", "warning"];
+
 const backgroundColors = {
   error: "linear-gradient(to right, #DB3615 8px, #FDE9E7 0%)",
   info: "linear-gradient(to right, #3548D4 8px, #EBEDFB 0%)",

--- a/frontend/packages/core/src/Feedback/alert.tsx
+++ b/frontend/packages/core/src/Feedback/alert.tsx
@@ -8,8 +8,6 @@ import { Alert as MuiAlert, AlertTitle as MuiAlertTitle, Grid } from "@mui/mater
 
 import styled from "../styled";
 
-export const SEVERITIES = ["error", "info", "success", "warning"];
-
 const backgroundColors = {
   error: "linear-gradient(to right, #DB3615 8px, #FDE9E7 0%)",
   info: "linear-gradient(to right, #3548D4 8px, #EBEDFB 0%)",

--- a/frontend/packages/core/src/Feedback/stories/alert.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/alert.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import { Alert as AlertComponent, AlertProps, SEVERITIES } from "../alert";
+import { SEVERITIES } from "../../Assets/global";
+import { Alert as AlertComponent, AlertProps } from "../alert";
 
 export default {
   title: "Core/Feedback/Alert",

--- a/frontend/packages/core/src/Feedback/stories/alert.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/alert.stories.tsx
@@ -1,37 +1,30 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import type { AlertProps } from "../alert";
-import { Alert } from "../alert";
+import { Alert as AlertComponent, AlertProps, SEVERITIES } from "../alert";
 
 export default {
   title: "Core/Feedback/Alert",
-  component: Alert,
+  component: AlertComponent,
+  argTypes: {
+    title: {
+      control: {
+        type: "text",
+      },
+    },
+    severity: {
+      options: SEVERITIES,
+      control: {
+        type: "select",
+      },
+    },
+  },
 } as Meta;
 
-const Template = (props: AlertProps) => <Alert {...props}>This is a note</Alert>;
+const Template = (props: AlertProps) => <AlertComponent {...props}>This is a note</AlertComponent>;
 
-export const WithTitle = Template.bind({});
-WithTitle.args = {
+export const Alert = Template.bind({});
+Alert.args = {
   title: "A Title",
-};
-
-export const Success = Template.bind({});
-Success.args = {
   severity: "success",
-};
-
-export const Error = Template.bind({});
-Error.args = {
-  severity: "error",
-};
-
-export const Info = Template.bind({});
-Info.args = {
-  severity: "info",
-};
-
-export const Warning = Template.bind({});
-Warning.args = {
-  severity: "warning",
 };

--- a/frontend/packages/core/src/Feedback/stories/alert.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/alert.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import { SEVERITIES } from "../../Assets/global";
-import { Alert as AlertComponent, AlertProps } from "../alert";
+import { Alert as AlertComponent, AlertProps, SEVERITIES } from "../alert";
 
 export default {
   title: "Core/Feedback/Alert",


### PR DESCRIPTION
### Description
The Alert component is subdivided by severity and title in Storybook, adding items to the stories navigation panel. By using controls the stories were unified to a single entry with the same title/severities options.

Before:
<img width="710" alt="image" src="https://user-images.githubusercontent.com/5430603/209858577-dd93366a-197f-4252-83bd-0b7b43cbf815.png">

After:
<img width="708" alt="image" src="https://user-images.githubusercontent.com/5430603/209858641-5b4fb480-4796-489e-b00f-3964e13086c1.png">


### Testing Performed
Manual