### PR TITLE
frontend: hoist note stories

### DIFF
--- a/frontend/packages/core/src/Assets/global.ts
+++ b/frontend/packages/core/src/Assets/global.ts
@@ -32,3 +32,5 @@ export const StyledSVG = styled.svg<{ size?: IconSizeVariant }>(props => ({
 export interface SVGProps extends React.SVGProps<SVGSVGElement> {
   size?: IconSizeVariant;
 }
+
+export const SEVERITIES = ["error", "info", "success", "warning"];

--- a/frontend/packages/core/src/Assets/global.ts
+++ b/frontend/packages/core/src/Assets/global.ts
@@ -32,5 +32,3 @@ export const StyledSVG = styled.svg<{ size?: IconSizeVariant }>(props => ({
 export interface SVGProps extends React.SVGProps<SVGSVGElement> {
   size?: IconSizeVariant;
 }
-
-export const SEVERITIES = ["error", "info", "success", "warning"];

--- a/frontend/packages/core/src/Feedback/stories/note.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/note.stories.tsx
@@ -1,32 +1,26 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
 
+import { SEVERITIES } from "../../Assets/global";
 import type { NoteProps } from "../note";
-import { Note } from "../note";
+import { Note as NoteComponent } from "../note";
 
 export default {
-  title: "Core/Feedback/Note",
-  component: Note,
+  title: "Core/Feedback/Single",
+  component: NoteComponent,
+  argTypes: {
+    severity: {
+      options: SEVERITIES,
+      control: {
+        type: "select",
+      },
+    },
+  },
 } as Meta;
 
-const Template = (props: NoteProps) => <Note {...props}>This is a note</Note>;
+const Template = (props: NoteProps) => <NoteComponent {...props}>This is a note</NoteComponent>;
 
-export const Success = Template.bind({});
-Success.args = {
+export const Single = Template.bind({});
+Single.args = {
   severity: "success",
-};
-
-export const Error = Template.bind({});
-Error.args = {
-  severity: "error",
-};
-
-export const Info = Template.bind({});
-Info.args = {
-  severity: "info",
-};
-
-export const Warning = Template.bind({});
-Warning.args = {
-  severity: "warning",
 };

--- a/frontend/packages/core/src/Feedback/stories/note.stories.tsx
+++ b/frontend/packages/core/src/Feedback/stories/note.stories.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import type { Meta } from "@storybook/react";
 
-import { SEVERITIES } from "../../Assets/global";
 import type { NoteProps } from "../note";
 import { Note as NoteComponent } from "../note";
+
+const SEVERITIES = ["error", "info", "success", "warning"];
 
 export default {
   title: "Core/Feedback/Single",


### PR DESCRIPTION
### Description
The Note component is subdivided by severity in Storybook, adding items to the stories navigation panel. By using controls the stories were unified to a single entry with the same severities options.

Before:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/5430603/209997769-9dcc8c7a-0352-4f0a-8164-1824cfcf1d14.png">

After:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/5430603/209997838-48b232a5-b422-4d49-8b5a-2563962fe3dd.png">


### Testing Performed
Manual