### PR TITLE
frontend: hoist button related stories

### DIFF
--- a/frontend/packages/core/src/stories/button-group.stories.tsx
+++ b/frontend/packages/core/src/stories/button-group.stories.tsx
@@ -2,33 +2,33 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
-import type { ButtonGroupProps, ButtonProps } from "../button";
-import { Button, ButtonGroup } from "../button";
+import {
+  Button,
+  ButtonGroup as ButtonGroupComponent,
+  ButtonGroupProps,
+  ButtonProps,
+} from "../button";
 
 export default {
   title: "Core/Buttons/Button Group",
-  component: ButtonGroup,
+  component: ButtonGroupComponent,
 } as Meta;
 
 const Template = ({ children, ...props }: ButtonGroupProps) => (
-  <ButtonGroup {...props}>
+  <ButtonGroupComponent {...props}>
     <Button text="Back" variant="neutral" onClick={action("onClick event")} />
     {children as React.ReactElement<ButtonProps>}
-  </ButtonGroup>
+  </ButtonGroupComponent>
 );
 
 export const Primary = Template.bind({});
 Primary.args = {
   children: <Button text="Next" onClick={action("onClick event")} />,
-};
-
-export const BottomBorder = Template.bind({});
-BottomBorder.args = {
-  border: "bottom",
-  children: <Button text="Next" onClick={action("onClick event")} />,
+  border: "top",
 };
 
 export const Destructive = Template.bind({});
 Destructive.args = {
   children: <Button text="Terminate" variant="destructive" onClick={action("onClick event")} />,
+  border: "top",
 };

--- a/frontend/packages/core/src/stories/button.stories.tsx
+++ b/frontend/packages/core/src/stories/button.stories.tsx
@@ -1,43 +1,29 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
 
-import { Button, ButtonProps } from "../button";
+import { Button as ButtonComponent, ButtonProps } from "../button";
+
+const VARIANTS = ["neutral", "primary", "danger", "destructive", "secondary"];
 
 export default {
   title: "Core/Buttons/Button",
-  component: Button,
+  component: ButtonComponent,
   argTypes: {
     onClick: { action: "onClick event" },
+    variant: {
+      options: VARIANTS,
+      control: {
+        type: "select",
+      },
+    },
   },
 } as Meta;
 
-const Template = (props: ButtonProps) => <Button {...props} />;
+const Template = (props: ButtonProps) => <ButtonComponent {...props} />;
 
-export const Primary = Template.bind({});
-Primary.args = {
-  text: "Continue",
-};
-
-export const Destructive = Template.bind({});
-Destructive.args = {
-  text: "Delete",
-  variant: "destructive",
-};
-
-export const Neutral = Template.bind({});
-Neutral.args = {
-  text: "Back",
-  variant: "neutral",
-};
-
-export const Secondary = Template.bind({});
-Secondary.args = {
-  text: "Submit",
-  variant: "secondary",
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  ...Primary.args,
-  disabled: true,
+export const Button = Template.bind({});
+Button.args = {
+  text: "Text",
+  variant: "primary",
+  disabled: false,
 };

--- a/frontend/packages/core/src/stories/icon-button.stories.tsx
+++ b/frontend/packages/core/src/stories/icon-button.stories.tsx
@@ -3,11 +3,11 @@ import SearchIcon from "@mui/icons-material/Search";
 import type { Meta } from "@storybook/react";
 
 import type { IconButtonProps } from "../button";
-import { ICON_BUTTON_VARIANTS, IconButton } from "../button";
+import { ICON_BUTTON_VARIANTS, IconButton as IconButtonComponent } from "../button";
 
 export default {
   title: "Core/Buttons/Icon Button",
-  component: IconButton,
+  component: IconButtonComponent,
   argTypes: {
     onClick: { action: "onClick event" },
     size: {
@@ -18,14 +18,12 @@ export default {
 } as Meta;
 
 const Template = (props: IconButtonProps) => (
-  <IconButton {...props}>
+  <IconButtonComponent {...props}>
     <SearchIcon />
-  </IconButton>
+  </IconButtonComponent>
 );
 
-export const Primary = Template.bind({});
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
+export const IconButton = Template.bind({});
+IconButton.args = {
+  disabled: false,
 };


### PR DESCRIPTION
### Description
The stories for the Button component have redundant entries for props variations. Those entries were hoisted or simplified by using controls.

Before:
<img width="658" alt="image" src="https://user-images.githubusercontent.com/5430603/210437098-1051bfd4-6641-4d43-842d-102daf999bbb.png">

After:
<img width="678" alt="image" src="https://user-images.githubusercontent.com/5430603/210437427-9a7b9547-d8fe-4a90-9ea4-ed8b1b1c620c.png">


### Testing Performed
manual