### PR TITLE
frontend: hoist accordion stories

### DIFF
--- a/frontend/packages/core/src/stories/accordion-group.stories.tsx
+++ b/frontend/packages/core/src/stories/accordion-group.stories.tsx
@@ -2,15 +2,24 @@ import * as React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { AccordionGroupProps } from "../accordion";
-import { Accordion, AccordionDetails, AccordionGroup } from "../accordion";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionGroup as AccordionGroupComponent,
+} from "../accordion";
 
 export default {
   title: "Core/Accordion/Accordion Group",
-  component: AccordionGroup,
+  component: AccordionGroupComponent,
+  argTypes: {
+    defaultExpandedIdx: {
+      description: "The index of the tab expanded by default on mount.",
+    },
+  },
 } as Meta;
 
 const Template = (props: AccordionGroupProps) => (
-  <AccordionGroup {...props}>
+  <AccordionGroupComponent {...props}>
     <Accordion title="First Accordion">
       <AccordionDetails>This is the first accordion.</AccordionDetails>
     </Accordion>
@@ -20,13 +29,8 @@ const Template = (props: AccordionGroupProps) => (
     <Accordion title="Third Accordion">
       <AccordionDetails>This is the third accordion.</AccordionDetails>
     </Accordion>
-  </AccordionGroup>
+  </AccordionGroupComponent>
 );
 
-export const Primary = Template.bind({});
-Primary.args = {};
-
-export const WithDefaultExpanded = Template.bind({});
-WithDefaultExpanded.args = {
-  defaultExpandedIdx: 0,
-};
+export const AccordionGroup = Template.bind({});
+AccordionGroup.args = {};

--- a/frontend/packages/core/src/stories/accordion.stories.tsx
+++ b/frontend/packages/core/src/stories/accordion.stories.tsx
@@ -2,16 +2,28 @@ import * as React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { AccordionProps } from "../accordion";
-import { Accordion, AccordionActions, AccordionDetails, AccordionDivider } from "../accordion";
+import {
+  Accordion as AccordionComponent,
+  AccordionActions,
+  AccordionDetails,
+  AccordionDivider,
+} from "../accordion";
 import { Button } from "../button";
 
 export default {
   title: "Core/Accordion/Accordion",
-  component: Accordion,
+  component: AccordionComponent,
+  argTypes: {
+    expanded: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 } as Meta;
 
 const Template = (props: AccordionProps) => (
-  <Accordion {...props}>
+  <AccordionComponent {...props}>
     <AccordionDetails>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
       labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
@@ -23,23 +35,12 @@ const Template = (props: AccordionProps) => (
     <AccordionActions>
       <Button text="Okay" />
     </AccordionActions>
-  </Accordion>
+  </AccordionComponent>
 );
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Accordion = Template.bind({});
+Accordion.args = {
   title: "Hello world!",
-  defaultExpanded: true,
-};
-
-export const CollapsedByDefault = Template.bind({});
-CollapsedByDefault.args = {
-  ...Primary.args,
   defaultExpanded: false,
-};
-
-export const NotCollapsible = Template.bind({});
-NotCollapsible.args = {
-  ...Primary.args,
   collapsible: false,
 };

--- a/frontend/packages/core/src/stories/panel.stories.tsx
+++ b/frontend/packages/core/src/stories/panel.stories.tsx
@@ -2,27 +2,21 @@ import React from "react";
 import type { Meta } from "@storybook/react";
 
 import type { AccordionProps } from "../panel";
-import Accordion from "../panel";
+import AccordionComponent from "../panel";
 
 export default {
   title: "Core/Accordion",
-  component: Accordion,
+  component: AccordionComponent,
 } as Meta;
 
 const Template = (props: AccordionProps) => (
-  <Accordion {...props}>
+  <AccordionComponent {...props}>
     <img alt="clutch logo" src="https://clutch.sh/img/navigation/logo.svg" height="100px" />
-  </Accordion>
+  </AccordionComponent>
 );
 
 export const Primary = Template.bind({});
 Primary.args = {
   heading: "Check this out!",
   summary: "This is an expansion panel.",
-};
-
-export const Expanded = Template.bind({});
-Expanded.args = {
-  ...Primary.args,
-  expanded: true,
 };


### PR DESCRIPTION
### Description
The accordion stories are subdivided by states of the components. Controls were used to reduce the number of stories.

Before:
<img width="731" alt="image" src="https://user-images.githubusercontent.com/5430603/210665911-418bdd57-6266-4c07-a6c4-5d554653611d.png">

After:
<img width="717" alt="image" src="https://user-images.githubusercontent.com/5430603/210665984-43cc1816-2cda-4c68-a413-e97581229763.png">


### Testing Performed
manual