### PR TITLE
frontend: Housekeeping - Converting all usage of @emotion/styled to internal

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -45,7 +45,7 @@ jobs:
           key: ${{ runner.os }}-fe-build-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn --cwd frontend install
+        run: make yarn-install
       - name: build
         run: yarn --cwd frontend build
   lint:
@@ -68,7 +68,7 @@ jobs:
           key: ${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn --cwd frontend install
+        run: make yarn-install
       - name: Compile packages
         run: yarn --cwd frontend compile:dev
       - run: make frontend-lint
@@ -123,7 +123,7 @@ jobs:
             ${{ runner.os }}-go-build-
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn --cwd frontend install
+        run: make yarn-install
       - name: Compile packages
         run: yarn --cwd frontend compile:dev
       - name: Test [e2e]
@@ -156,7 +156,7 @@ jobs:
           key: ${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn --cwd frontend install
+        run: make yarn-install
       - name: Compile packages
         run: yarn --cwd frontend compile:dev
       - name: Test [unit]
@@ -184,7 +184,7 @@ jobs:
           key: ${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn --cwd frontend install
+        run: make yarn-install
       - name: publish
         run: yarn --cwd frontend publishBeta
         env:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
-    "@mui/lab": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.5",
     "@storybook/addon-a11y": "^6.5.0",
     "@storybook/addon-actions": "^6.5.0",
@@ -77,7 +76,6 @@
     "eslint": "^8.3.0",
     "lerna": "^4.0.0",
     "license-checker": "^25.0.1",
-    "material-table": "^2.0.3",
     "prettier": "^2.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
+    "@mui/lab": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.5",
     "@storybook/addon-a11y": "^6.5.0",
     "@storybook/addon-actions": "^6.5.0",

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@date-io/core": "^1.3.6",
-    "@emotion/jest": "^11.5.0",
-    "@emotion/react": "^11.9.0",
-    "@emotion/styled": "^11.8.1",
+    "@emotion/jest": "^11.0.0",
+    "@emotion/react": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
     "@hookform/devtools": "^4.0.2",
     "@hookform/resolvers": "2.8.8",
     "@mui/icons-material": "^5.8.4",

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@date-io/core": "^1.3.6",
-    "@emotion/jest": "^11.0.0",
-    "@emotion/react": "^11.0.0",
-    "@emotion/styled": "^11.0.0",
+    "@emotion/jest": "^11.5.0",
+    "@emotion/react": "^11.9.0",
+    "@emotion/styled": "^11.8.1",
     "@hookform/devtools": "^4.0.2",
     "@hookform/resolvers": "2.8.8",
     "@mui/icons-material": "^5.8.4",

--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
-import styled from "@emotion/styled";
 import {
   Avatar as MuiAvatar,
   Drawer as MuiDrawer,
@@ -14,6 +13,7 @@ import type { Workflow } from "../AppProvider/workflow";
 import { useAppContext } from "../Contexts";
 import type { PopperItemProps } from "../popper";
 import { Popper, PopperItem } from "../popper";
+import styled from "../styled";
 
 import { routesByGrouping, sortedGroupings, workflowByRoute } from "./utils";
 

--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import styled from "@emotion/styled";
 import { AppBar as MuiAppBar, Box, Grid, Toolbar, Typography } from "@mui/material";
 
 import type { AppConfiguration } from "../AppProvider";
 import { FeatureOn, SimpleFeatureFlag } from "../flags";
 import { NPSHeader } from "../NPS";
+import styled from "../styled";
 
 import Logo from "./logo";
 import Notifications from "./notifications";
@@ -23,7 +23,7 @@ const AppBar = styled(MuiAppBar)({
 });
 
 // Since the AppBar is fixed we need a div to take up its height in order to push other content down.
-const ClearAppBar = styled.div({ height: APP_BAR_HEIGHT });
+const ClearAppBar = styled("div")({ height: APP_BAR_HEIGHT });
 
 const Title = styled(Typography)({
   margin: "12px 0px 12px 8px",

--- a/frontend/packages/core/src/AppLayout/index.tsx
+++ b/frontend/packages/core/src/AppLayout/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
-import styled from "@emotion/styled";
 import { Grid as MuiGrid } from "@mui/material";
 
 import type { AppConfiguration } from "../AppProvider";
 import Loadable from "../loading";
+import styled from "../styled";
 
 import Drawer from "./drawer";
 import Header, { APP_BAR_HEIGHT } from "./header";
@@ -18,7 +18,7 @@ const ContentGrid = styled(MuiGrid)({
   maxHeight: `calc(100vh - ${APP_BAR_HEIGHT})`,
 });
 
-const MainContent = styled.div({ overflowY: "auto", width: "100%" });
+const MainContent = styled("div")({ overflowY: "auto", width: "100%" });
 
 interface AppLayoutProps {
   isLoading?: boolean;

--- a/frontend/packages/core/src/AppLayout/logo.tsx
+++ b/frontend/packages/core/src/AppLayout/logo.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { keyframes } from "@emotion/react";
-import styled from "@emotion/styled";
+
+import styled from "../styled";
 
 const rotate = keyframes`
   from {
@@ -11,7 +12,7 @@ const rotate = keyframes`
   }
 `;
 
-const StyledSvg = styled.svg({
+const StyledSvg = styled("svg")({
   height: "48px",
   width: "48px",
   padding: "1px",

--- a/frontend/packages/core/src/AppLayout/notifications.tsx
+++ b/frontend/packages/core/src/AppLayout/notifications.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "@emotion/styled";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import {
   ClickAwayListener,
@@ -11,6 +10,8 @@ import {
   Paper as MuiPaper,
   Popper as MuiPopper,
 } from "@mui/material";
+
+import styled from "../styled";
 
 const StyledNotificationsIcon = styled(IconButton)({
   color: "#ffffff",

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "@emotion/styled";
 import CloseIcon from "@mui/icons-material/Close";
 import SearchIcon from "@mui/icons-material/Search";
 import {
@@ -19,6 +18,7 @@ import _ from "lodash";
 
 import { useAppContext } from "../Contexts";
 import { useNavigate } from "../navigation";
+import styled from "../styled";
 
 import type { SearchIndex } from "./utils";
 import { searchIndexes } from "./utils";

--- a/frontend/packages/core/src/AppLayout/stories/notifications.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/notifications.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import { Grid as MuiGrid } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
+import styled from "../../styled";
 import type { NotificationsProp } from "../notifications";
 import NotificationsComponent from "../notifications";
 

--- a/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { MemoryRouter } from "react-router";
-import styled from "@emotion/styled";
 import { Box, Grid as MuiGrid } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
 import { ApplicationContext } from "../../Contexts/app-context";
+import styled from "../../styled";
 import SearchFieldComponent from "../search";
 
 export default {

--- a/frontend/packages/core/src/AppLayout/stories/user-information.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/user-information.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import { Grid as MuiGrid } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
+import styled from "../../styled";
 import type { UserInformationProps } from "../user";
 import { UserInformation as UserInformationComponent } from "../user";
 

--- a/frontend/packages/core/src/AppLayout/user.tsx
+++ b/frontend/packages/core/src/AppLayout/user.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "@emotion/styled";
 import {
   Avatar as MuiAvatar,
   ClickAwayListener,
@@ -15,6 +14,8 @@ import {
 } from "@mui/material";
 import Cookies from "js-cookie";
 import jwtDecode from "jwt-decode";
+
+import styled from "../styled";
 
 const UserPhoto = styled(IconButton)({
   padding: "12px",

--- a/frontend/packages/core/src/Assets/global.ts
+++ b/frontend/packages/core/src/Assets/global.ts
@@ -1,4 +1,4 @@
-import styled from "@emotion/styled";
+import styled from "../styled";
 
 const XSMALL = 18;
 const SMALL = 24;
@@ -24,7 +24,7 @@ export const VARIANTS = Object.keys(STYLE_MAP);
 
 export type IconSizeVariant = keyof typeof STYLE_MAP;
 
-export const StyledSVG = styled.svg<{ size?: IconSizeVariant }>(props => ({
+export const StyledSVG = styled("svg")<{ size?: IconSizeVariant }>(props => ({
   width: `${STYLE_MAP[props.size]?.size || STYLE_MAP.small.size}px`,
   height: `${STYLE_MAP[props.size]?.size || STYLE_MAP.small.size}px`,
 }));

--- a/frontend/packages/core/src/Assets/icons/helpers.tsx
+++ b/frontend/packages/core/src/Assets/icons/helpers.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
+import styled from "../../styled";
 
-const StyledSvg: React.ElementType = styled.svg((props: { hoverFill: string }) => ({
+const StyledSvg: React.ElementType = styled("svg")((props: { hoverFill: string }) => ({
   path: {
     "&:hover": {
       fill: props.hoverFill,

--- a/frontend/packages/core/src/Feedback/error/index.tsx
+++ b/frontend/packages/core/src/Feedback/error/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "@emotion/styled";
 import MuiOpenInNewIcon from "@mui/icons-material/OpenInNew";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { IconButton } from "@mui/material";
@@ -7,17 +6,18 @@ import { IconButton } from "@mui/material";
 import { Link } from "../../link";
 import type { ClutchError } from "../../Network/errors";
 import { isHelpDetails } from "../../Network/errors";
+import styled from "../../styled";
 import { Alert } from "../alert";
 
 import ErrorDetails from "./details";
 
-const ErrorSummaryContainer = styled.div({
+const ErrorSummaryContainer = styled("div")({
   width: "100%",
   display: "flex",
   flexDirection: "column",
 });
 
-const ErrorSummaryMessage = styled.div({
+const ErrorSummaryMessage = styled("div")({
   lineHeight: "24px",
   margin: "4px 0",
   flex: "1",

--- a/frontend/packages/core/src/Feedback/hint.tsx
+++ b/frontend/packages/core/src/Feedback/hint.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import styled from "@emotion/styled";
 import HelpIcon from "@mui/icons-material/Help";
 import { Popover, Typography } from "@mui/material";
 
-const HelpIconContainer = styled.div({
+import styled from "../styled";
+
+const HelpIconContainer = styled("div")({
   display: "flex",
   color: "#D7DADB",
   padding: "5px",

--- a/frontend/packages/core/src/Feedback/note.tsx
+++ b/frontend/packages/core/src/Feedback/note.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import styled from "@emotion/styled";
 import { Grid, Paper } from "@mui/material";
 import type { AlertColor as Color } from "@mui/material/Alert";
 
 import { Link } from "../link";
+import styled from "../styled";
 
 import { Alert } from "./alert";
 

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import type { TooltipProps as MuiTooltipProps } from "@mui/material";
 import { Tooltip as MuiTooltip } from "@mui/material";
+
+import styled from "../styled";
 
 const BaseTooltip = ({ className, ...props }: MuiTooltipProps) => (
   <MuiTooltip classes={{ tooltip: className }} {...props} />
@@ -45,7 +46,7 @@ const Tooltip = ({ children, maxWidth = "300px", title, ...props }: TooltipProps
 };
 
 // sets the spacing between multiline content
-const TooltipContainer = styled.div({
+const TooltipContainer = styled("div")({
   margin: "4px 0px",
 });
 

--- a/frontend/packages/core/src/Input/form.tsx
+++ b/frontend/packages/core/src/Input/form.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
+import styled from "../styled";
 
-const Form = styled.form({
+const Form = styled("form")({
   width: "inherit",
   "> *": {
     margin: "8px 0",
@@ -10,7 +10,7 @@ const Form = styled.form({
   },
 });
 
-const FormRow = styled.div({
+const FormRow = styled("div")({
   display: "flex",
   "> *": {
     margin: "0 8px",

--- a/frontend/packages/core/src/Input/radio-group.tsx
+++ b/frontend/packages/core/src/Input/radio-group.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import {
   FormControl as MuiFormControl,
   FormControlLabel,
   FormLabel as MuiFormLabel,
   RadioGroup as MuiRadioGroup,
 } from "@mui/material";
+
+import styled from "../styled";
 
 import Radio from "./radio";
 

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import ErrorIcon from "@mui/icons-material/Error";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import type { SelectProps as MuiSelectProps } from "@mui/material";
@@ -12,6 +11,8 @@ import {
   Select as MuiSelect,
 } from "@mui/material";
 import { flatten } from "lodash";
+
+import styled from "../styled";
 
 const StyledFormHelperText = styled(MuiFormHelperText)({
   alignItems: "center",

--- a/frontend/packages/core/src/Input/switchToggle.tsx
+++ b/frontend/packages/core/src/Input/switchToggle.tsx
@@ -5,9 +5,10 @@
 */
 
 import * as React from "react";
-import styled from "@emotion/styled";
 import type { SwitchProps as MuiSwitchProps } from "@mui/material";
 import { Switch as MuiSwitch } from "@mui/material";
+
+import styled from "../styled";
 
 const SwitchContainer = styled(MuiSwitch)({
   ".MuiSwitch-switchBase": {

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import type { FieldValues, UseFormRegister } from "react-hook-form";
-import styled from "@emotion/styled";
 import ErrorIcon from "@mui/icons-material/Error";
 import type {
   InputProps as MuiInputProps,
@@ -15,6 +14,8 @@ import {
   Typography,
 } from "@mui/material";
 import _ from "lodash";
+
+import styled from "../styled";
 
 const KEY_ENTER = 13;
 

--- a/frontend/packages/core/src/Input/toggle-button-group.tsx
+++ b/frontend/packages/core/src/Input/toggle-button-group.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import type { ToggleButtonGroupProps as MuiToggleButtonGroupProps } from "@mui/lab";
 import { ToggleButtonGroup as MuiToggleButtonGroup } from "@mui/material";
+
+import styled from "../styled";
 
 export { ToggleButton } from "@mui/material";
 

--- a/frontend/packages/core/src/Resolver/index.tsx
+++ b/frontend/packages/core/src/Resolver/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "@emotion/styled";
 import _ from "lodash";
 
 import { AccordionGroup } from "../accordion";
@@ -10,13 +9,14 @@ import { HorizontalRule } from "../horizontal-rule";
 import Loadable from "../loading";
 import { useSearchParams } from "../navigation";
 import type { ClutchError } from "../Network/errors";
+import styled from "../styled";
 
 import { fetchResourceSchemas, resolveResource } from "./fetch";
 import { QueryResolver, SchemaResolver } from "./input";
 import type { DispatchAction } from "./state";
 import { ResolverAction, useResolverState } from "./state";
 
-const SchemaLabel = styled.div({
+const SchemaLabel = styled("div")({
   alignSelf: "flex-start",
   fontSize: "20px",
   fontWeight: 700,

--- a/frontend/packages/core/src/Resolver/input.tsx
+++ b/frontend/packages/core/src/Resolver/input.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import type { clutch } from "@clutch-sh/api";
-import styled from "@emotion/styled";
 import { DevTool } from "@hookform/devtools";
 import SearchIcon from "@mui/icons-material/Search";
 
@@ -17,11 +16,12 @@ import { Alert } from "../Feedback";
 import TextField from "../Input/text-field";
 import { useSearchParams } from "../navigation";
 import { client } from "../Network";
+import styled from "../styled";
 
 import type { ChangeEventTarget } from "./hydrator";
 import { convertChangeEvent, hydrateField } from "./hydrator";
 
-const Form = styled.form({});
+const Form = styled("form")({});
 
 interface QueryResolverProps {
   /**

--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import AddIcon from "@mui/icons-material/Add";
 import RemoveIcon from "@mui/icons-material/Remove";
 import type { AccordionProps as MuiAccordionProps } from "@mui/material";
@@ -11,6 +10,8 @@ import {
   Divider as MuiDivider,
   useControlled,
 } from "@mui/material";
+
+import styled from "./styled";
 
 const StyledAccordion = styled(MuiAccordion)({
   borderRadius: "4px",
@@ -83,7 +84,7 @@ export const StyledAccordionSummary = styled(AccordionSummaryBase)({
   },
 });
 
-const StyledAccordionGroup = styled.div({
+const StyledAccordionGroup = styled("div")({
   width: "100%",
 
   ".MuiAccordion-root": {

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import {
@@ -14,6 +13,7 @@ import type { SpacingProps as MuiSpacingProps } from "@mui/system";
 import { spacing } from "@mui/system";
 
 import { IconButton } from "./button";
+import styled from "./styled";
 import { Typography, TypographyProps } from "./typography";
 
 // TODO: seperate out the different card parts into various files
@@ -29,7 +29,7 @@ export interface CardProps {
 
 const Card = ({ children, ...props }: CardProps) => <StyledCard {...props}>{children}</StyledCard>;
 
-const StyledCardHeaderContainer = styled.div({
+const StyledCardHeaderContainer = styled("div")({
   background: "#EBEDFB",
 });
 
@@ -41,7 +41,7 @@ const StyledCardHeader = styled(Grid)({
   },
 });
 
-const StyledCardHeaderAvatarContainer = styled.div({
+const StyledCardHeaderAvatarContainer = styled("div")({
   padding: "8px",
   height: "32px",
   width: "32px",
@@ -50,7 +50,7 @@ const StyledCardHeaderAvatarContainer = styled.div({
 });
 
 // TODO: use material ui avatar component and implement figma design
-const StyledCardHeaderAvatar = styled.div({
+const StyledCardHeaderAvatar = styled("div")({
   width: "24px",
   height: "24px",
   fontSize: "18px",
@@ -116,11 +116,11 @@ const CardHeader = ({ actions, avatar, children, title, summary = [] }: CardHead
 // We can add more to this list as use cases arise
 interface SpacingProps extends Pick<MuiSpacingProps, "padding" | "p"> {}
 
-const BaseCardContent = styled.div<SpacingProps>`
+const BaseCardContent = styled("div")<SpacingProps>`
   ${spacing}
 `;
 
-const StyledCardContentContainer = styled.div((props: { maxHeight: number | "none" }) => ({
+const StyledCardContentContainer = styled("div")((props: { maxHeight: number | "none" }) => ({
   "> .MuiPaper-root": {
     border: "0",
     borderRadius: "0",

--- a/frontend/packages/core/src/confirmation.tsx
+++ b/frontend/packages/core/src/confirmation.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import styled from "@emotion/styled";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import { Grid } from "@mui/material";
+
+import styled from "./styled";
 
 const IconContainer = styled(Grid)({
   paddingTop: "4px",
@@ -31,7 +32,7 @@ const CheckmarkIcon = styled(CheckCircleIcon)({
   marginRight: "8px",
 });
 
-const SubtitleContainer = styled.div({
+const SubtitleContainer = styled("div")({
   color: "rgba(13, 16, 48, 0.6)",
   fontSize: "12px",
 });

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import CloseIcon from "@mui/icons-material/Close";
 import type { DialogProps as MuiDialogProps } from "@mui/material";
 import {
@@ -10,6 +9,8 @@ import {
   IconButton as MuiIconButton,
   Paper,
 } from "@mui/material";
+
+import styled from "./styled";
 
 const DialogPaper = styled(Paper)({
   border: "1px solid rgba(13, 16, 48, 0.1)",
@@ -29,7 +30,7 @@ const DialogTitle = styled(MuiDialogTitle)({
   color: "#0D1030",
 });
 
-const DialogTitleText = styled.div({
+const DialogTitleText = styled("div")({
   padding: "14px 0 0 0",
 });
 

--- a/frontend/packages/core/src/horizontal-rule.tsx
+++ b/frontend/packages/core/src/horizontal-rule.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import styled from "@emotion/styled";
+
+import styled from "./styled";
 
 const HorizontalRuleBase = ({ children, ...props }: HorizontalRuleProps) => (
   <div {...props}>

--- a/frontend/packages/core/src/icon.tsx
+++ b/frontend/packages/core/src/icon.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import styled from "@emotion/styled";
 import FiberManualRecordTwoToneIcon from "@mui/icons-material/FiberManualRecordTwoTone";
 import { Grid } from "@mui/material";
 
 import type { GridJustification } from "./grid";
+import styled from "./styled";
 
 const StyledStatusIcon = styled(FiberManualRecordTwoToneIcon)`
   ${({ ...props }) => `
@@ -11,7 +11,7 @@ const StyledStatusIcon = styled(FiberManualRecordTwoToneIcon)`
   `}
 `;
 
-export const AvatarIcon = styled.img({
+export const AvatarIcon = styled("img")({
   borderRadius: "50%",
   maxHeight: "100%",
   maxWidth: "initial",

--- a/frontend/packages/core/src/landing.tsx
+++ b/frontend/packages/core/src/landing.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
 import Typography from "@mui/material/Typography";
 
@@ -9,8 +8,9 @@ import { MonsterGraphic } from "./Assets/Graphics";
 import { LandingCard } from "./card";
 import { useAppContext } from "./Contexts";
 import { useNavigate } from "./navigation";
+import styled from "./styled";
 
-const StyledLanding = styled.div({
+const StyledLanding = styled("div")({
   backgroundColor: "#f9f9fe",
   display: "flex",
   flexDirection: "column",

--- a/frontend/packages/core/src/loading.tsx
+++ b/frontend/packages/core/src/loading.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import styled from "@emotion/styled";
 import { CircularProgress, Grid, Paper } from "@mui/material";
+
+import styled from "./styled";
 
 const LoadingSpinner = styled(CircularProgress)`
   color: #3548d4;
@@ -11,7 +12,7 @@ const ContentContainer = styled(Grid)`
   position: relative;
 `;
 
-const ChildrenContainer = styled.div({
+const ChildrenContainer = styled("div")({
   width: "100%",
 });
 

--- a/frontend/packages/core/src/not-found.tsx
+++ b/frontend/packages/core/src/not-found.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import styled from "@emotion/styled";
 import ThumbDownIcon from "@mui/icons-material/ThumbDown";
 import { Grid, Typography } from "@mui/material";
 
-const Container = styled(Grid)`
-  minheight: 80vh;
-`;
+import styled from "./styled";
+
+const Container = styled(Grid)({
+  minHeight: "80vh",
+});
 
 const IconContainer = styled(Grid)({
   color: "#02acbe",
@@ -13,13 +14,7 @@ const IconContainer = styled(Grid)({
 });
 
 const NotFound: React.FC<{}> = () => (
-  <Container
-    container
-    direction="column"
-    justifyContent="center"
-    alignItems="center"
-    style={{ minHeight: "80vh" }}
-  >
+  <Container container direction="column" justifyContent="center" alignItems="center">
     <IconContainer item>
       <ThumbDownIcon fontSize="inherit" />
     </IconContainer>

--- a/frontend/packages/core/src/panel.tsx
+++ b/frontend/packages/core/src/panel.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "@emotion/styled";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   Accordion as MuiExpansionPanel,
@@ -7,6 +6,8 @@ import {
   AccordionSummary,
   Typography,
 } from "@mui/material";
+
+import styled from "./styled";
 
 const FullWidthExpansionPanel = styled(MuiExpansionPanel)`
   width: 100%;

--- a/frontend/packages/core/src/paper.tsx
+++ b/frontend/packages/core/src/paper.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import type { PaperProps as MuiPaperProps } from "@mui/material";
 import { Paper as MuiPaper } from "@mui/material";
+
+import styled from "./styled";
 
 export interface PaperProps extends Pick<MuiPaperProps, "children"> {}
 

--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import type {
   ClickAwayListenerProps,
   ListItemProps,
@@ -14,6 +13,8 @@ import {
   Paper as MuiPaper,
   Popper as MuiPopper,
 } from "@mui/material";
+
+import styled from "./styled";
 
 const StyledPopper = styled(MuiPopper)({
   zIndex: 1201,
@@ -54,7 +55,7 @@ const ListItem = styled(MuiListItem)({
   padding: "0",
 });
 
-const PopperItemIcon = styled.div({
+const PopperItemIcon = styled("div")({
   margin: "12px 5px 12px 12px",
   height: "24px",
   width: "24px",

--- a/frontend/packages/core/src/stepper.tsx
+++ b/frontend/packages/core/src/stepper.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import MuiCheckIcon from "@mui/icons-material/Check";
 import PriorityHighIcon from "@mui/icons-material/PriorityHigh";
 import {
@@ -9,7 +8,9 @@ import {
   Stepper as MuiStepper,
 } from "@mui/material";
 
-const StepContainer = styled.div({
+import styled from "./styled";
+
+const StepContainer = styled("div")({
   margin: "0px 2px 30px 2px",
   ".MuiStepLabel-label": {
     fontWeight: 500,
@@ -80,7 +81,7 @@ const StepContainer = styled.div({
   },
 });
 
-const Circle = styled.div((props: { background: string; border: string }) => ({
+const Circle = styled("div")((props: { background: string; border: string }) => ({
   backgroundColor: props.background,
   border: props.border,
   boxSizing: "border-box",
@@ -90,7 +91,7 @@ const Circle = styled.div((props: { background: string; border: string }) => ({
   top: "24px",
 }));
 
-const DefaultIcon = styled.div((props: { font: string }) => ({
+const DefaultIcon = styled("div")((props: { font: string }) => ({
   height: "100%",
   width: "100%",
   color: props.font,

--- a/frontend/packages/core/src/stories/linearTimeline.stories.tsx
+++ b/frontend/packages/core/src/stories/linearTimeline.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import type { Meta } from "@storybook/react";
 
 import LinearTimeline from "../Charts/linearTimeline";
 import type { LinearTimelineData } from "../Charts/types";
+import styled from "../styled";
 
 export default {
   title: "Core/Charts/LinearTimeline",

--- a/frontend/packages/core/src/stories/stepper.stories.tsx
+++ b/frontend/packages/core/src/stories/stepper.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import type { Meta } from "@storybook/react";
 
 import { Button, ButtonGroup } from "../button";
 import type { StepperProps } from "../stepper";
 import { Step, Stepper } from "../stepper";
+import styled from "../styled";
 
-const Text = styled.div({
+const Text = styled("div")({
   textAlign: "center",
 });
 

--- a/frontend/packages/core/src/stories/timeseries.stories.tsx
+++ b/frontend/packages/core/src/stories/timeseries.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import type { Meta } from "@storybook/react";
 
 import { dateTimeFormatter, isoTimeFormatter } from "../Charts/helpers";
 import TimeseriesChart from "../Charts/timeseries";
 import type { TimeseriesReferenceLineProps } from "../Charts/types";
+import styled from "../styled";
 
 export default {
   title: "Core/Charts/TimeseriesChart",

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import { TabContext, TabList, TabPanel as MuiTabPanel } from "@mui/lab";
 import type { TabProps as MuiTabProps, TabsProps as MuiTabsProps } from "@mui/material";
 import { Tab as MuiTab } from "@mui/material";
+
+import styled from "./styled";
 
 const StyledTab = styled(MuiTab)({
   minWidth: "111px",

--- a/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
@@ -10,23 +10,28 @@ exports[`Not Found component renders correctly 1`] = `
             <CssBaseline>
               <GlobalStyles styles={[Function: styles]}>
                 <GlobalStyles styles={[Function: styles]} defaultTheme={{...}}>
-                  <ForwardRef styles={[Function (anonymous)]} />
+                  <EmotionGlobal styles={[Function (anonymous)]} />
                 </GlobalStyles>
               </GlobalStyles>
             </CssBaseline>
             <StylesProvider>
               <NotFound>
                 <Styled(Component) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\">
+                  <Insertion cache={{...}} serialized={{...}} isStringTag={false} />
                   <ForwardRef(Grid) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\" className=\\"css-9hh926\\">
                     <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-9hh926\\" as=\\"div\\" sx={{...}}>
+                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                       <div className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-cv76y0-MuiGrid-root\\">
                         <Styled(Component) item={true}>
+                          <Insertion cache={{...}} serialized={{...}} isStringTag={false} />
                           <ForwardRef(Grid) item={true} className=\\"css-sm4uoy\\">
                             <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item css-sm4uoy\\" as=\\"div\\" sx={{...}}>
+                              <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                               <div className=\\"MuiGrid-root MuiGrid-item css-15yh1qb-MuiGrid-root\\">
                                 <ForwardRef(ThumbDownIcon) fontSize=\\"inherit\\">
                                   <ForwardRef(SvgIcon) data-testid=\\"ThumbDownIcon\\" fontSize=\\"inherit\\">
                                     <MuiSvgIconRoot as=\\"svg\\" className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" ownerState={{...}} focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
+                                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                       <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1yk9s9q-MuiSvgIcon-root\\" focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
                                         <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
                                       </svg>
@@ -39,12 +44,15 @@ exports[`Not Found component renders correctly 1`] = `
                         </Styled(Component)>
                         <ForwardRef(Grid) item={true}>
                           <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
+                            <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                             <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
                                 <MuiTypographyRoot as=\\"h3\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter\\" sx={{...}}>
+                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter css-x6fgw-MuiTypography-root\\">
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
+                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Whoops...
                                         </div>
@@ -52,6 +60,7 @@ exports[`Not Found component renders correctly 1`] = `
                                     </ForwardRef(Grid)>
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
+                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Looks like you took a wrong turn
                                         </div>
@@ -62,6 +71,7 @@ exports[`Not Found component renders correctly 1`] = `
                               </ForwardRef(Typography)>
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
                                 <MuiTypographyRoot as=\\"h6\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter\\" sx={{...}}>
+                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter css-1n1umxm-MuiTypography-root\\">
                                     &lt; 404 Not Found &gt;
                                   </h6>

--- a/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
@@ -19,17 +19,14 @@ exports[`Not Found component renders correctly 1`] = `
                 <Styled(Component) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\">
                   <ForwardRef(Grid) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\" className=\\"css-9hh926\\">
                     <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-9hh926\\" as=\\"div\\" sx={{...}}>
-                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                       <div className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-cv76y0-MuiGrid-root\\">
                         <Styled(Component) item={true}>
                           <ForwardRef(Grid) item={true} className=\\"css-sm4uoy\\">
                             <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item css-sm4uoy\\" as=\\"div\\" sx={{...}}>
-                              <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                               <div className=\\"MuiGrid-root MuiGrid-item css-15yh1qb-MuiGrid-root\\">
                                 <ForwardRef(ThumbDownIcon) fontSize=\\"inherit\\">
                                   <ForwardRef(SvgIcon) data-testid=\\"ThumbDownIcon\\" fontSize=\\"inherit\\">
                                     <MuiSvgIconRoot as=\\"svg\\" className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" ownerState={{...}} focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
-                                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                       <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1yk9s9q-MuiSvgIcon-root\\" focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
                                         <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
                                       </svg>
@@ -42,15 +39,12 @@ exports[`Not Found component renders correctly 1`] = `
                         </Styled(Component)>
                         <ForwardRef(Grid) item={true}>
                           <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
-                            <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                             <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
                                 <MuiTypographyRoot as=\\"h3\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter\\" sx={{...}}>
-                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter css-x6fgw-MuiTypography-root\\">
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
-                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Whoops...
                                         </div>
@@ -58,7 +52,6 @@ exports[`Not Found component renders correctly 1`] = `
                                     </ForwardRef(Grid)>
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
-                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Looks like you took a wrong turn
                                         </div>
@@ -69,7 +62,6 @@ exports[`Not Found component renders correctly 1`] = `
                               </ForwardRef(Typography)>
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
                                 <MuiTypographyRoot as=\\"h6\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter\\" sx={{...}}>
-                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter css-1n1umxm-MuiTypography-root\\">
                                     &lt; 404 Not Found &gt;
                                   </h6>

--- a/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
@@ -16,17 +16,20 @@ exports[`Not Found component renders correctly 1`] = `
             </CssBaseline>
             <StylesProvider>
               <NotFound>
-                <Styled(Component) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\" style={{...}}>
-                  <ForwardRef(Grid) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\" style={{...}} className=\\"css-1rc10fs\\">
-                    <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1rc10fs\\" as=\\"div\\" style={{...}} sx={{...}}>
-                      <div className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-zxxfrz-MuiGrid-root\\" style={{...}}>
+                <Styled(Component) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\">
+                  <ForwardRef(Grid) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\" className=\\"css-9hh926\\">
+                    <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-9hh926\\" as=\\"div\\" sx={{...}}>
+                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
+                      <div className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-cv76y0-MuiGrid-root\\">
                         <Styled(Component) item={true}>
                           <ForwardRef(Grid) item={true} className=\\"css-sm4uoy\\">
                             <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item css-sm4uoy\\" as=\\"div\\" sx={{...}}>
+                              <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                               <div className=\\"MuiGrid-root MuiGrid-item css-15yh1qb-MuiGrid-root\\">
                                 <ForwardRef(ThumbDownIcon) fontSize=\\"inherit\\">
                                   <ForwardRef(SvgIcon) data-testid=\\"ThumbDownIcon\\" fontSize=\\"inherit\\">
                                     <MuiSvgIconRoot as=\\"svg\\" className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" ownerState={{...}} focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
+                                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                       <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1yk9s9q-MuiSvgIcon-root\\" focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
                                         <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
                                       </svg>
@@ -39,12 +42,15 @@ exports[`Not Found component renders correctly 1`] = `
                         </Styled(Component)>
                         <ForwardRef(Grid) item={true}>
                           <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
+                            <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                             <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
                                 <MuiTypographyRoot as=\\"h3\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter\\" sx={{...}}>
+                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter css-x6fgw-MuiTypography-root\\">
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
+                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Whoops...
                                         </div>
@@ -52,6 +58,7 @@ exports[`Not Found component renders correctly 1`] = `
                                     </ForwardRef(Grid)>
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
+                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Looks like you took a wrong turn
                                         </div>
@@ -62,6 +69,7 @@ exports[`Not Found component renders correctly 1`] = `
                               </ForwardRef(Typography)>
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
                                 <MuiTypographyRoot as=\\"h6\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter\\" sx={{...}}>
+                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter css-1n1umxm-MuiTypography-root\\">
                                     &lt; 404 Not Found &gt;
                                   </h6>

--- a/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/not-found.test.tsx.snap
@@ -10,28 +10,23 @@ exports[`Not Found component renders correctly 1`] = `
             <CssBaseline>
               <GlobalStyles styles={[Function: styles]}>
                 <GlobalStyles styles={[Function: styles]} defaultTheme={{...}}>
-                  <EmotionGlobal styles={[Function (anonymous)]} />
+                  <ForwardRef styles={[Function (anonymous)]} />
                 </GlobalStyles>
               </GlobalStyles>
             </CssBaseline>
             <StylesProvider>
               <NotFound>
                 <Styled(Component) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\">
-                  <Insertion cache={{...}} serialized={{...}} isStringTag={false} />
                   <ForwardRef(Grid) container={true} direction=\\"column\\" justifyContent=\\"center\\" alignItems=\\"center\\" className=\\"css-9hh926\\">
                     <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-9hh926\\" as=\\"div\\" sx={{...}}>
-                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                       <div className=\\"MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-cv76y0-MuiGrid-root\\">
                         <Styled(Component) item={true}>
-                          <Insertion cache={{...}} serialized={{...}} isStringTag={false} />
                           <ForwardRef(Grid) item={true} className=\\"css-sm4uoy\\">
                             <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item css-sm4uoy\\" as=\\"div\\" sx={{...}}>
-                              <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                               <div className=\\"MuiGrid-root MuiGrid-item css-15yh1qb-MuiGrid-root\\">
                                 <ForwardRef(ThumbDownIcon) fontSize=\\"inherit\\">
                                   <ForwardRef(SvgIcon) data-testid=\\"ThumbDownIcon\\" fontSize=\\"inherit\\">
                                     <MuiSvgIconRoot as=\\"svg\\" className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit\\" ownerState={{...}} focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
-                                      <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                       <svg className=\\"MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1yk9s9q-MuiSvgIcon-root\\" focusable=\\"false\\" color={[undefined]} aria-hidden={true} role={[undefined]} viewBox=\\"0 0 24 24\\" data-testid=\\"ThumbDownIcon\\">
                                         <path d=\\"M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z\\" />
                                       </svg>
@@ -44,15 +39,12 @@ exports[`Not Found component renders correctly 1`] = `
                         </Styled(Component)>
                         <ForwardRef(Grid) item={true}>
                           <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
-                            <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                             <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h3\\">
                                 <MuiTypographyRoot as=\\"h3\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter\\" sx={{...}}>
-                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h3 className=\\"MuiTypography-root MuiTypography-h3 MuiTypography-alignCenter css-x6fgw-MuiTypography-root\\">
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
-                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Whoops...
                                         </div>
@@ -60,7 +52,6 @@ exports[`Not Found component renders correctly 1`] = `
                                     </ForwardRef(Grid)>
                                     <ForwardRef(Grid) item={true}>
                                       <MuiGridRoot ownerState={{...}} className=\\"MuiGrid-root MuiGrid-item\\" as=\\"div\\" sx={{...}}>
-                                        <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                         <div className=\\"MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root\\">
                                           Looks like you took a wrong turn
                                         </div>
@@ -71,7 +62,6 @@ exports[`Not Found component renders correctly 1`] = `
                               </ForwardRef(Typography)>
                               <ForwardRef(Typography) align=\\"center\\" color=\\"textPrimary\\" variant=\\"h6\\">
                                 <MuiTypographyRoot as=\\"h6\\" ownerState={{...}} className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter\\" sx={{...}}>
-                                  <Insertion cache={{...}} serialized={{...}} isStringTag={true} />
                                   <h6 className=\\"MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter css-1n1umxm-MuiTypography-root\\">
                                     &lt; 404 Not Found &gt;
                                   </h6>

--- a/frontend/packages/core/src/text.tsx
+++ b/frontend/packages/core/src/text.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import { Fab, Grid } from "@mui/material";
 
 import { ClipboardButton } from "./button";
+import styled from "./styled";
 
 const CopyButtonContainer = styled(Grid)({
   marginLeft: "7px",
@@ -13,7 +13,7 @@ const ContentContainer = styled(Grid)({
   flex: 1,
 });
 
-const Pre = styled.pre({
+const Pre = styled("pre")({
   border: "1px solid rgba(13, 16, 48, 0.38)",
   backgroundColor: "rgba(13,16,48,0.12)",
   borderRadius: "4px",

--- a/frontend/workflows/dynamodb/package.json
+++ b/frontend/workflows/dynamodb/package.json
@@ -25,7 +25,6 @@
     "@clutch-sh/core": "^2.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
-    "@emotion/styled": "^11.1.5",
     "@mui/material": "^5.8.5",
     "lodash": "4.17.21",
     "react": "^17.0.2",

--- a/frontend/workflows/experimentation/package.json
+++ b/frontend/workflows/experimentation/package.json
@@ -22,7 +22,6 @@
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^2.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@emotion/styled": "^11.0.0",
     "@mui/material": "^5.8.5",
     "@mui/styles": "^5.8.4",
     "history": "^5.0.0",

--- a/frontend/workflows/experimentation/src/core/page-layout.tsx
+++ b/frontend/workflows/experimentation/src/core/page-layout.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import type { ClutchError } from "@clutch-sh/core";
-import { Error } from "@clutch-sh/core";
-import styled from "@emotion/styled";
+import { Error, styled } from "@clutch-sh/core";
 import { Container, Grid, Typography } from "@mui/material";
 
-const PageContainer = styled.div({
+const PageContainer = styled("div")({
   display: "flex",
   flex: "1 auto",
   margin: "30px",

--- a/frontend/workflows/experimentation/src/list-view.tsx
+++ b/frontend/workflows/experimentation/src/list-view.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import styled from "@emotion/styled";
+import { styled } from "@clutch-sh/core";
 import {
   Paper,
   Table,

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -26,7 +26,6 @@
     "@clutch-sh/core": "^2.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
-    "@emotion/styled": "^11.1.5",
     "@hookform/resolvers": "2.8.8",
     "@mui/icons-material": "^5.8.4",
     "lodash": "4.17.21",

--- a/frontend/workflows/k8s/src/crons-table.tsx
+++ b/frontend/workflows/k8s/src/crons-table.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Table, TableRow } from "@clutch-sh/core";
+import { styled, Table, TableRow } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
-import styled from "@emotion/styled";
 import _ from "lodash";
 
-const CronsContainer = styled.div({
+const CronsContainer = styled("div")({
   display: "flex",
   maxHeight: "50vh",
 });

--- a/frontend/workflows/k8s/src/deployments-table.tsx
+++ b/frontend/workflows/k8s/src/deployments-table.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 import TimeAgo from "react-timeago";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Table, TableRow } from "@clutch-sh/core";
+import { styled, Table, TableRow } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
-import styled from "@emotion/styled";
 import _ from "lodash";
 
 import { convertTime, timeFormatter } from "./pods-table";
 
-const DeploymentsContainer = styled.div({
+const DeploymentsContainer = styled("div")({
   display: "flex",
   maxHeight: "50vh",
 });

--- a/frontend/workflows/k8s/src/k8s-dash-header.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-header.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import styled from "@emotion/styled";
+import { styled } from "@clutch-sh/core";
 
-const Category = styled.div({
+const Category = styled("div")({
   fontWeight: 700,
   fontSize: "12px",
   lineHeight: "16px",
@@ -10,7 +10,7 @@ const Category = styled.div({
   paddingBottom: "8px",
 });
 
-const HeaderText = styled.div({
+const HeaderText = styled("div")({
   fontWeight: 700,
   fontSize: "26px",
   lineHeight: "32px",

--- a/frontend/workflows/k8s/src/k8s-dash-search.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-search.tsx
@@ -8,15 +8,15 @@ import {
   FormRow,
   IconButton,
   Paper,
+  styled,
   TextField,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
-import styled from "@emotion/styled";
 import { yupResolver } from "@hookform/resolvers/yup";
 import SearchIcon from "@mui/icons-material/Search";
 import * as yup from "yup";
 
-const Container = styled.div({
+const Container = styled("div")({
   margin: "32px 0",
 });
 
@@ -25,7 +25,7 @@ const schema = yup.object().shape({
   clientset: yup.string().required("Clientset is required"),
 });
 
-const Content = styled.div({
+const Content = styled("div")({
   margin: "32px 0",
 });
 

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { client, ClutchError, Error, Paper, Tab, Tabs } from "@clutch-sh/core";
+import { client, ClutchError, Error, Paper, styled, Tab, Tabs } from "@clutch-sh/core";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
-import styled from "@emotion/styled";
 import AppsIcon from "@mui/icons-material/Apps";
 import CropFreeIcon from "@mui/icons-material/CropFree";
 import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined";
@@ -16,7 +15,7 @@ import K8sDashSearch from "./k8s-dash-search";
 import PodTable from "./pods-table";
 import StatefulSetTable from "./stateful-sets-table";
 
-const Container = styled.div({
+const Container = styled("div")({
   flex: 1,
   margin: "32px",
   display: "flex",
@@ -26,11 +25,11 @@ const Container = styled.div({
   },
 });
 
-const Content = styled.div({
+const Content = styled("div")({
   margin: "32px 0",
 });
 
-const PlaceholderTitle = styled.div({
+const PlaceholderTitle = styled("div")({
   paddingBottom: "16px",
   fontWeight: 700,
   fontSize: "22px",
@@ -38,7 +37,7 @@ const PlaceholderTitle = styled.div({
   color: "0D1030",
 });
 
-const PlaceholderText = styled.div({
+const PlaceholderText = styled("div")({
   fontWeight: 400,
   fontSize: "16px",
   lineHeight: "22px",

--- a/frontend/workflows/k8s/src/pods-table.tsx
+++ b/frontend/workflows/k8s/src/pods-table.tsx
@@ -3,6 +3,7 @@ import TimeAgo from "react-timeago";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import {
   Chip,
+  styled,
   Table,
   TableRow,
   TableRowAction,
@@ -10,11 +11,10 @@ import {
   useNavigate,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
-import styled from "@emotion/styled";
 import DeleteIcon from "@mui/icons-material/Delete";
 import _ from "lodash";
 
-const PodsContainer = styled.div({
+const PodsContainer = styled("div")({
   display: "flex",
   maxHeight: "50vh",
 });

--- a/frontend/workflows/k8s/src/stateful-sets-table.tsx
+++ b/frontend/workflows/k8s/src/stateful-sets-table.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Table, TableRow } from "@clutch-sh/core";
+import { styled, Table, TableRow } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
-import styled from "@emotion/styled";
 import _ from "lodash";
 
-const StatefulSetsContainer = styled.div({
+const StatefulSetsContainer = styled("div")({
   display: "flex",
   maxHeight: "50vh",
 });

--- a/frontend/workflows/kinesis/package.json
+++ b/frontend/workflows/kinesis/package.json
@@ -26,7 +26,6 @@
     "@clutch-sh/core": "^2.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
-    "@emotion/styled": "^11.0.0",
     "@mui/material": "^5.8.5",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -10,19 +10,19 @@ import {
   NotePanel,
   Resolver,
   Select,
+  styled,
   TextField,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
-import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
 import _ from "lodash";
 
 import type { ResolverChild, WorkflowProps } from "./index";
 
-const Form = styled.form({
+const Form = styled("form")({
   alignItems: "center",
   display: "flex",
   flexDirection: "column",

--- a/frontend/workflows/projectCatalog/package.json
+++ b/frontend/workflows/projectCatalog/package.json
@@ -26,7 +26,6 @@
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/project-selector": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
-    "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -5,12 +5,12 @@ import {
   Grid,
   IconButton,
   Paper,
+  styled,
   TextField,
   Tooltip,
   Typography,
   useNavigate,
 } from "@clutch-sh/core";
-import styled from "@emotion/styled";
 import RestoreIcon from "@mui/icons-material/Restore";
 import SearchIcon from "@mui/icons-material/Search";
 import { Box, CircularProgress } from "@mui/material";
@@ -55,7 +55,7 @@ const autoComplete = async (search: string): Promise<any> => {
   return { results: response?.data?.results || [] };
 };
 
-const Form = styled.form({});
+const Form = styled("form")({});
 
 const Catalog: React.FC<WorkflowProps> = () => {
   const navigate = useNavigate();

--- a/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Card, Grid, IconButton, Typography } from "@clutch-sh/core";
-import styled from "@emotion/styled";
+import { Card, Grid, IconButton, styled, Typography } from "@clutch-sh/core";
 import CloseIcon from "@mui/icons-material/Close";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 

--- a/frontend/workflows/projectSelector/package.json
+++ b/frontend/workflows/projectSelector/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@clutch-sh/core": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
-    "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",
     "lodash": "^4.17.21",

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -7,13 +7,13 @@ import {
   Error,
   Grid,
   IconButton,
+  styled,
 } from "@clutch-sh/core";
-import styled from "@emotion/styled";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { LinearProgress } from "@mui/material";
 
-const StyledProgressContainer = styled.div({
+const StyledProgressContainer = styled("div")({
   height: "4px",
   ".MuiLinearProgress-root": {
     backgroundColor: "rgb(194, 200, 242)",

--- a/frontend/workflows/projectSelector/src/dash.tsx
+++ b/frontend/workflows/projectSelector/src/dash.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { google as IGoogle } from "@clutch-sh/api";
-import styled from "@emotion/styled";
+import { styled } from "@clutch-sh/core";
 import { Box } from "@mui/material";
 import _ from "lodash";
 
@@ -63,7 +63,7 @@ const initialTimeRangeState: TimeRangeState = {
   endTimeMs: Date.now(),
 };
 
-const CardContainer = styled.div({
+const CardContainer = styled("div")({
   display: "flex",
   flex: 1,
   maxHeight: "100%",

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { Checkbox, Switch } from "@clutch-sh/core";
-import styled from "@emotion/styled";
+import { Checkbox, styled, Switch } from "@clutch-sh/core";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ClearIcon from "@mui/icons-material/Clear";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -10,19 +9,19 @@ import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
 import ProjectLinks from "./project-links";
 import type { Group } from "./types";
 
-const StyledGroup = styled.div({
+const StyledGroup = styled("div")({
   fontWeight: 500,
   marginLeft: "4px",
   marginTop: "9px",
   display: "block",
 });
 
-const StyledGroupTitle = styled.span({
+const StyledGroupTitle = styled("span")({
   marginRight: "4px",
   display: "inline-block",
 });
 
-const StyledCount = styled.span({
+const StyledCount = styled("span")({
   color: "rgba(13, 16, 48, 0.6)",
   backgroundColor: "rgba(13, 16, 48, 0.03)",
   fontVariantNumeric: "tabular-nums",
@@ -38,7 +37,7 @@ const StyledCount = styled.span({
 
 // This div used to have `padding: "0 25px 0 8px"` but that made it look weird when we implemented quicklinks
 // because the "only" and "x" buttons are hidden when the popper is expanded and mouse is no longer hovering.
-const StyledMenuItem = styled.div({
+const StyledMenuItem = styled("div")({
   height: "48px",
   display: "flex",
   alignItems: "center",
@@ -50,7 +49,7 @@ const StyledMenuItem = styled.div({
   },
 });
 
-const StyledProjectHeader = styled.div({
+const StyledProjectHeader = styled("div")({
   display: "flex",
   maxWidth: "100%",
   alignItems: "flex-start",
@@ -59,25 +58,25 @@ const StyledProjectHeader = styled.div({
   padding: "0 12px",
 });
 
-const StyledHeaderColumn = styled.div((props: { grow?: boolean }) => ({
+const StyledHeaderColumn = styled("div")((props: { grow?: boolean }) => ({
   display: "flex",
   minHeight: "38px",
   alignItems: "center",
   flexGrow: props.grow ? 1 : 0,
 }));
 
-const StyledNoProjectsText = styled.div({
+const StyledNoProjectsText = styled("div")({
   color: "rgba(13, 16, 48, 0.38)",
   textAlign: "center",
   fontSize: "12px",
   marginBottom: "16px",
 });
 
-const StyledAllText = styled.div({
+const StyledAllText = styled("div")({
   color: "rgba(13, 16, 48, 0.38)",
 });
 
-const StyledMenuItemName = styled.span({
+const StyledMenuItemName = styled("span")({
   flexGrow: 1,
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
@@ -88,7 +87,7 @@ const StyledMenuItemName = styled.span({
   maxWidth: "160px",
 });
 
-const StyledClearIcon = styled.span({
+const StyledClearIcon = styled("span")({
   ".MuiIconButton-root": {
     padding: "6px",
     color: "rgba(13, 16, 48, 0.38)",
@@ -101,7 +100,7 @@ const StyledClearIcon = styled.span({
   },
 });
 
-const StyledOnlyButton = styled.button({
+const StyledOnlyButton = styled("button")({
   border: "none",
   cursor: "pointer",
   borderRadius: "4px",
@@ -119,7 +118,7 @@ const StyledOnlyButton = styled.button({
   },
 });
 
-const StyledHoverOptions = styled.div({
+const StyledHoverOptions = styled("div")({
   alignItems: "center",
 });
 

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Link, Popper, Typography } from "@clutch-sh/core";
-import styled from "@emotion/styled";
+import { Link, Popper, styled, Typography } from "@clutch-sh/core";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IconButton from "@mui/material/IconButton";
 
@@ -20,18 +19,18 @@ const itemHoverStyle = {
   },
 };
 
-const StyledMenuItem = styled.div({
+const StyledMenuItem = styled("div")({
   ...itemHoverStyle,
 });
 
-const StyledSubLink = styled.div({
+const StyledSubLink = styled("div")({
   ...itemHoverStyle,
   paddingBottom: "8px",
   paddingTop: "8px",
   paddingLeft: "40px",
 });
 
-const StyledMoreVertIcon = styled.span({
+const StyledMoreVertIcon = styled("span")({
   ".MuiIconButton-root": {
     padding: "6px",
     color: "rgba(13, 16, 48, 0.38)",
@@ -44,31 +43,31 @@ const StyledMoreVertIcon = styled.span({
   },
 });
 
-const StyledLinkTitle = styled.span({
+const StyledLinkTitle = styled("span")({
   fontWeight: "bold",
   padding: "7px 0px",
 });
 
-const StyledMultiLinkTitle = styled.span({
+const StyledMultiLinkTitle = styled("span")({
   fontWeight: "bold",
 });
 
-const StyledLinkBox = styled.div({
+const StyledLinkBox = styled("div")({
   borderRadius: "4px",
   width: "160px",
 });
 
-const StyledMultilinkImage = styled.div({
+const StyledMultilinkImage = styled("div")({
   display: "flex",
   padding: "8px",
 });
 
-const StyledMultilinkHeader = styled.div({
+const StyledMultilinkHeader = styled("div")({
   display: "flex",
   alignItems: "center",
 });
 
-const StyledCenterImgSpan = styled.span({
+const StyledCenterImgSpan = styled("span")({
   display: "flex",
   alignItems: "center",
   padding: "8px",
@@ -153,7 +152,7 @@ const ExpandedLinks = ({ linkGroups }: ExpandedLinksProps) => (
   </StyledLinkBox>
 );
 
-const StyledFlexEnd = styled.div({
+const StyledFlexEnd = styled("div")({
   justifyContent: "right",
 });
 

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -6,6 +6,7 @@ import {
   ClutchError,
   FeatureOn,
   SimpleFeatureFlag,
+  styled,
   TextField,
   Tooltip,
   TooltipContainer,
@@ -13,7 +14,6 @@ import {
   userId,
   useWorkflowStorageContext,
 } from "@clutch-sh/core";
-import styled from "@emotion/styled";
 import AddIcon from "@mui/icons-material/Add";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import UpdateIcon from "@mui/icons-material/Update";
@@ -63,7 +63,7 @@ const initialState: State = {
   error: undefined,
 };
 
-const StyledSelectorContainer = styled.div({
+const StyledSelectorContainer = styled("div")({
   backgroundColor: "#F9FAFE",
   borderRight: "1px solid rgba(13, 16, 48, 0.1)",
   boxShadow: "0px 4px 6px rgba(53, 72, 212, 0.2)",
@@ -73,7 +73,7 @@ const StyledSelectorContainer = styled.div({
   maxHeight: "100%",
 });
 
-const StyledWorkflowHeader = styled.div({
+const StyledWorkflowHeader = styled("div")({
   margin: "16px 16px 12px 16px",
   display: "flex",
   alignItems: "center",
@@ -81,7 +81,7 @@ const StyledWorkflowHeader = styled.div({
   height: "24px",
 });
 
-const StyledWorkflowTitle = styled.span({
+const StyledWorkflowTitle = styled("span")({
   fontWeight: "bold",
   fontSize: "20px",
   lineHeight: "24px",
@@ -92,7 +92,7 @@ const StyledProjectTextField = styled(TextField)({
   padding: "16px 16px 8px 16px",
 });
 
-const StyledProgressContainer = styled.div({
+const StyledProgressContainer = styled("div")({
   height: "4px",
   ".MuiLinearProgress-root": {
     backgroundColor: "rgb(194, 200, 242)",
@@ -103,7 +103,7 @@ const StyledProgressContainer = styled.div({
 });
 
 // TODO(smonero): decide on styling for this
-const FlexCenterAlignContainer = styled.div({
+const FlexCenterAlignContainer = styled("div")({
   display: "flex",
   alignItems: "center",
 });
@@ -209,7 +209,7 @@ const autoComplete = async (search: string): Promise<any> => {
   return { results: response?.data?.results || [] };
 };
 
-const Form = styled.form({});
+const Form = styled("form")({});
 
 const ProjectSelector = ({ onError }: ProjectSelectorProps) => {
   // On load, we'll request a list of owned projects and their upstreams and downstreams from the API.

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -23,7 +23,6 @@
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/experimentation": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
-    "@emotion/styled": "^11.0.0",
     "@hookform/resolvers": "2.8.8",
     "@mui/material": "^5.8.5",
     "react": "^17.0.2",

--- a/frontend/workflows/sourcecontrol/package.json
+++ b/frontend/workflows/sourcecontrol/package.json
@@ -25,7 +25,6 @@
     "@clutch-sh/core": "^2.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
-    "@emotion/styled": "^11.0.0",
     "@hookform/resolvers": "2.8.8",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",

--- a/frontend/workflows/sourcecontrol/src/create-repository.tsx
+++ b/frontend/workflows/sourcecontrol/src/create-repository.tsx
@@ -10,13 +10,13 @@ import {
   Form,
   Link,
   Select,
+  styled,
   TextField,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
-import styled from "@emotion/styled";
 import { yupResolver } from "@hookform/resolvers/yup";
 import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
@@ -24,7 +24,7 @@ import * as yup from "yup";
 
 import type { WorkflowProps } from ".";
 
-const ConfirmationMessage = styled.div({
+const ConfirmationMessage = styled("div")({
   display: "flex",
   alignItems: "center",
   fontSize: "14px",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -662,6 +662,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-module-imports@^7.7.0":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+  dependencies:
+    "@babel/types" "^7.12.5"
+
 "@babel/helper-module-transforms@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
@@ -1595,7 +1602,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@7.12.1":
+"@babel/plugin-syntax-jsx@7.12.1", "@babel/plugin-syntax-jsx@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz#9d9d357cc818aa7ae7935917c1257f67677a0926"
   integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
@@ -2715,13 +2722,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.18.3":
-  version "7.20.7"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
-  integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@babel/runtime@^7.18.9", "@babel/runtime@^7.19.0":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
@@ -3187,23 +3187,23 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@emotion/babel-plugin@^11.10.5":
-  version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
-  integrity sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==
+"@emotion/babel-plugin@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.0.0.tgz#e6f40fa81ef52775773a53d50220c597ebc5c2ef"
+  integrity sha512-w3YP0jlqrNwBBaSI6W+r80fOKF6l9QmsPfLNx5YWSHwrxjVZhM+L50gY7YCVAvlfr1/qdD1vsFN+PDZmLvt42Q==
   dependencies:
-    "@babel/helper-module-imports" "^7.16.7"
-    "@babel/plugin-syntax-jsx" "^7.17.12"
-    "@babel/runtime" "^7.18.3"
-    "@emotion/hash" "^0.9.0"
-    "@emotion/memoize" "^0.8.0"
-    "@emotion/serialize" "^1.1.1"
-    babel-plugin-macros "^3.1.0"
+    "@babel/helper-module-imports" "^7.7.0"
+    "@babel/plugin-syntax-jsx" "^7.12.1"
+    "@babel/runtime" "^7.7.2"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/serialize" "^1.0.0"
+    babel-plugin-macros "^2.6.1"
     convert-source-map "^1.5.0"
     escape-string-regexp "^4.0.0"
     find-root "^1.1.0"
     source-map "^0.5.7"
-    stylis "4.1.3"
+    stylis "^4.0.3"
 
 "@emotion/babel-plugin@^11.3.0":
   version "11.3.0"
@@ -3241,16 +3241,16 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^11.10.5":
-  version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
-  integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
+"@emotion/cache@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.0.0.tgz#473adcaf9e04c6a0e30fb1421e79a209a96818f8"
+  integrity sha512-NStfcnLkL5vj3mBILvkR2m/5vFxo3G0QEreYKDGHNHm9IMYoT/t3j6xwjx6lMI/S1LUJfVHQqn0m9wSINttTTQ==
   dependencies:
-    "@emotion/memoize" "^0.8.0"
-    "@emotion/sheet" "^1.2.1"
-    "@emotion/utils" "^1.2.0"
-    "@emotion/weak-memoize" "^0.3.0"
-    stylis "4.1.3"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
 
 "@emotion/cache@^11.7.1":
   version "11.7.1"
@@ -3263,23 +3263,25 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
 
-"@emotion/css-prettifier@^1.1.1":
-  version "1.1.1"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/css-prettifier/-/css-prettifier-1.1.1.tgz#87f3104c057a55674ff464f9c4fdf7326847f0ea"
-  integrity sha512-dtiZLNN3dWP0mo/+VTPkzNrjp1wL6VRHOOSMn3XpQM4D/7xOVHEIQR6lT5Yj5Omun1REog5NFZ+5hxj+LtTIyQ==
+"@emotion/css-prettifier@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.0.0.tgz#3ed4240d93c9798c001cedf27dd0aa960bdddd1a"
+  integrity sha512-efxSrRTiTqHTQVKW15Gz5H4pNAw8OqcG8NaiwkJIkqIdNXTD4Qr1zC1Ou6r2acd1oJJ2s56nb1ClnXMiWoj6gQ==
   dependencies:
-    "@emotion/memoize" "^0.8.0"
-    stylis "4.1.3"
+    "@emotion/memoize" "^0.7.4"
+    stylis "^4.0.3"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/hash@^0.9.0":
-  version "0.9.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
-  integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
+"@emotion/is-prop-valid@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.0.0.tgz#1dbe82e52a12c065d416a702e2d106e552cde5be"
+  integrity sha512-G5X0t7eR9pkhUvAY32QS3lToP9JyNF8It5CcmMvbWjmC9/Yq7IhevaKqxl+me2BKR93iTPiL/h3En1ZX/1G3PQ==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
 
 "@emotion/is-prop-valid@^1.1.0":
   version "1.1.0"
@@ -3295,23 +3297,16 @@
   dependencies:
     "@emotion/memoize" "^0.7.4"
 
-"@emotion/is-prop-valid@^1.2.0":
-  version "1.2.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
-  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
+"@emotion/jest@^11.0.0":
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.6.0.tgz#e6d63375930b1ce5388907b1e76e22d2466ab4f6"
+  integrity sha512-HJrnA6ARrRlYYi0AzSvFG3eAupar0cmegnG1OkXfKdBvqfbuTDLAHVovbsg5EecFjq0wTCHDvbBllGz8RpadCg==
   dependencies:
-    "@emotion/memoize" "^0.8.0"
-
-"@emotion/jest@^11.5.0":
-  version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/jest/-/jest-11.10.5.tgz#6aea1aec38e1c59e675702fa877644a6b1c18d05"
-  integrity sha512-LagosxybgisPlxfBGas9kGcNB5xTTX125WbjEVZiE3MEbb+dI4UYn0XIzrsilR8nUaQ5lH6yKUFrMmz7kB34vg==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@emotion/css-prettifier" "^1.1.1"
+    "@babel/runtime" "^7.13.10"
+    "@emotion/css-prettifier" "^1.0.0"
     chalk "^4.1.0"
     specificity "^0.4.1"
-    stylis "4.1.3"
+    stylis "^4.0.10"
 
 "@emotion/memoize@^0.7.4":
   version "0.7.4"
@@ -3323,10 +3318,18 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
-"@emotion/memoize@^0.8.0":
-  version "0.8.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
-  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
+"@emotion/react@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.0.0.tgz#6b39b5bb5e2d48d720a420ff885a95ff268dae0d"
+  integrity sha512-mMQOuJcCVHUHUKZMamCbNnuUEgEff1W1JL3/1jGXFN52Ik5R/2ccVb3FherYFkSJkkjkPC3dUfFSeisXVh9Spg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@emotion/cache" "^11.0.0"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
 
 "@emotion/react@^11.1.5":
   version "11.7.1"
@@ -3341,19 +3344,16 @@
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/react@^11.9.0":
-  version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
-  integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
+"@emotion/serialize@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0.tgz#1a61f4f037cf39995c97fc80ebe99abc7b191ca9"
+  integrity sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==
   dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.10.5"
-    "@emotion/cache" "^11.10.5"
-    "@emotion/serialize" "^1.1.1"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@emotion/utils" "^1.2.0"
-    "@emotion/weak-memoize" "^0.3.0"
-    hoist-non-react-statics "^3.3.1"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
 
 "@emotion/serialize@^1.0.2":
   version "1.0.2"
@@ -3366,26 +3366,15 @@
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
 
-"@emotion/serialize@^1.1.1":
-  version "1.1.1"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
-  integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
-  dependencies:
-    "@emotion/hash" "^0.9.0"
-    "@emotion/memoize" "^0.8.0"
-    "@emotion/unitless" "^0.8.0"
-    "@emotion/utils" "^1.2.0"
-    csstype "^3.0.2"
+"@emotion/sheet@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.0.tgz#a0ef06080f339477ad4ba7f56e1c931f7ba50822"
+  integrity sha512-cdCHfZtf/0rahPDCZ9zyq+36EqfD/6c0WUqTFZ/hv9xadTUv2lGE5QK7/Z6Dnx2oRxC0usfVM2/BYn9q9B9wZA==
 
 "@emotion/sheet@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
-
-"@emotion/sheet@^1.2.1":
-  version "1.2.1"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
-  integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
 
 "@emotion/styled@11.8.1":
   version "11.8.1"
@@ -3398,6 +3387,17 @@
     "@emotion/serialize" "^1.0.2"
     "@emotion/utils" "^1.1.0"
 
+"@emotion/styled@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.0.0.tgz#698196c2822746360a8644a73a5d842b2d1a78a5"
+  integrity sha512-498laccxJlBiJqrr2r/fx9q+Pr55D0URP2UyOkoSGLjevb8LLAFWueqthsQ5XijE66iGo7y3rzzEYdA7CHmZEQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@emotion/babel-plugin" "^11.0.0"
+    "@emotion/is-prop-valid" "^1.0.0"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+
 "@emotion/styled@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
@@ -3409,32 +3409,10 @@
     "@emotion/serialize" "^1.0.2"
     "@emotion/utils" "^1.0.0"
 
-"@emotion/styled@^11.8.1":
-  version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
-  integrity sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.10.5"
-    "@emotion/is-prop-valid" "^1.2.0"
-    "@emotion/serialize" "^1.1.1"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@emotion/utils" "^1.2.0"
-
 "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
-
-"@emotion/unitless@^0.8.0":
-  version "0.8.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
-  integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
-
-"@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
-  version "1.0.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
-  integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
 
 "@emotion/utils@^1.0.0":
   version "1.0.0"
@@ -3446,20 +3424,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
   integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
 
-"@emotion/utils@^1.2.0":
-  version "1.2.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
-  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
-
 "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
-
-"@emotion/weak-memoize@^0.3.0":
-  version "0.3.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
-  integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
@@ -21109,10 +21077,10 @@ stylis@4.0.13:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
   integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
-stylis@4.1.3:
-  version "4.1.3"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
-  integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
+stylis@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
 stylis@^4.0.3:
   version "4.0.3"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3398,7 +3398,7 @@
     "@emotion/serialize" "^1.0.0"
     "@emotion/utils" "^1.0.0"
 
-"@emotion/styled@^11.1.5", "@emotion/styled@^11.3.0":
+"@emotion/styled@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
   integrity sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -662,13 +662,6 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-module-imports@^7.7.0":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
-  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
-  dependencies:
-    "@babel/types" "^7.12.5"
-
 "@babel/helper-module-transforms@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
@@ -1602,7 +1595,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@7.12.1", "@babel/plugin-syntax-jsx@^7.12.1":
+"@babel/plugin-syntax-jsx@7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz#9d9d357cc818aa7ae7935917c1257f67677a0926"
   integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
@@ -2722,6 +2715,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.18.3":
+  version "7.20.7"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
+  integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.18.9", "@babel/runtime@^7.19.0":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
@@ -3187,23 +3187,23 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@emotion/babel-plugin@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.0.0.tgz#e6f40fa81ef52775773a53d50220c597ebc5c2ef"
-  integrity sha512-w3YP0jlqrNwBBaSI6W+r80fOKF6l9QmsPfLNx5YWSHwrxjVZhM+L50gY7YCVAvlfr1/qdD1vsFN+PDZmLvt42Q==
+"@emotion/babel-plugin@^11.10.5":
+  version "11.10.5"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
+  integrity sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==
   dependencies:
-    "@babel/helper-module-imports" "^7.7.0"
-    "@babel/plugin-syntax-jsx" "^7.12.1"
-    "@babel/runtime" "^7.7.2"
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/serialize" "^1.0.0"
-    babel-plugin-macros "^2.6.1"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/plugin-syntax-jsx" "^7.17.12"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/serialize" "^1.1.1"
+    babel-plugin-macros "^3.1.0"
     convert-source-map "^1.5.0"
     escape-string-regexp "^4.0.0"
     find-root "^1.1.0"
     source-map "^0.5.7"
-    stylis "^4.0.3"
+    stylis "4.1.3"
 
 "@emotion/babel-plugin@^11.3.0":
   version "11.3.0"
@@ -3241,16 +3241,16 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.0.0.tgz#473adcaf9e04c6a0e30fb1421e79a209a96818f8"
-  integrity sha512-NStfcnLkL5vj3mBILvkR2m/5vFxo3G0QEreYKDGHNHm9IMYoT/t3j6xwjx6lMI/S1LUJfVHQqn0m9wSINttTTQ==
+"@emotion/cache@^11.10.5":
+  version "11.10.5"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
+  integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
   dependencies:
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/sheet" "^1.0.0"
-    "@emotion/utils" "^1.0.0"
-    "@emotion/weak-memoize" "^0.2.5"
-    stylis "^4.0.3"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/sheet" "^1.2.1"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    stylis "4.1.3"
 
 "@emotion/cache@^11.7.1":
   version "11.7.1"
@@ -3263,25 +3263,23 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
 
-"@emotion/css-prettifier@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.0.0.tgz#3ed4240d93c9798c001cedf27dd0aa960bdddd1a"
-  integrity sha512-efxSrRTiTqHTQVKW15Gz5H4pNAw8OqcG8NaiwkJIkqIdNXTD4Qr1zC1Ou6r2acd1oJJ2s56nb1ClnXMiWoj6gQ==
+"@emotion/css-prettifier@^1.1.1":
+  version "1.1.1"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/css-prettifier/-/css-prettifier-1.1.1.tgz#87f3104c057a55674ff464f9c4fdf7326847f0ea"
+  integrity sha512-dtiZLNN3dWP0mo/+VTPkzNrjp1wL6VRHOOSMn3XpQM4D/7xOVHEIQR6lT5Yj5Omun1REog5NFZ+5hxj+LtTIyQ==
   dependencies:
-    "@emotion/memoize" "^0.7.4"
-    stylis "^4.0.3"
+    "@emotion/memoize" "^0.8.0"
+    stylis "4.1.3"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.0.0.tgz#1dbe82e52a12c065d416a702e2d106e552cde5be"
-  integrity sha512-G5X0t7eR9pkhUvAY32QS3lToP9JyNF8It5CcmMvbWjmC9/Yq7IhevaKqxl+me2BKR93iTPiL/h3En1ZX/1G3PQ==
-  dependencies:
-    "@emotion/memoize" "^0.7.4"
+"@emotion/hash@^0.9.0":
+  version "0.9.0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
+  integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
 "@emotion/is-prop-valid@^1.1.0":
   version "1.1.0"
@@ -3297,16 +3295,23 @@
   dependencies:
     "@emotion/memoize" "^0.7.4"
 
-"@emotion/jest@^11.0.0":
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.6.0.tgz#e6d63375930b1ce5388907b1e76e22d2466ab4f6"
-  integrity sha512-HJrnA6ARrRlYYi0AzSvFG3eAupar0cmegnG1OkXfKdBvqfbuTDLAHVovbsg5EecFjq0wTCHDvbBllGz8RpadCg==
+"@emotion/is-prop-valid@^1.2.0":
+  version "1.2.0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
   dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@emotion/css-prettifier" "^1.0.0"
+    "@emotion/memoize" "^0.8.0"
+
+"@emotion/jest@^11.5.0":
+  version "11.10.5"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/jest/-/jest-11.10.5.tgz#6aea1aec38e1c59e675702fa877644a6b1c18d05"
+  integrity sha512-LagosxybgisPlxfBGas9kGcNB5xTTX125WbjEVZiE3MEbb+dI4UYn0XIzrsilR8nUaQ5lH6yKUFrMmz7kB34vg==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/css-prettifier" "^1.1.1"
     chalk "^4.1.0"
     specificity "^0.4.1"
-    stylis "^4.0.10"
+    stylis "4.1.3"
 
 "@emotion/memoize@^0.7.4":
   version "0.7.4"
@@ -3318,18 +3323,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
-"@emotion/react@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.0.0.tgz#6b39b5bb5e2d48d720a420ff885a95ff268dae0d"
-  integrity sha512-mMQOuJcCVHUHUKZMamCbNnuUEgEff1W1JL3/1jGXFN52Ik5R/2ccVb3FherYFkSJkkjkPC3dUfFSeisXVh9Spg==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    "@emotion/cache" "^11.0.0"
-    "@emotion/serialize" "^1.0.0"
-    "@emotion/sheet" "^1.0.0"
-    "@emotion/utils" "^1.0.0"
-    "@emotion/weak-memoize" "^0.2.5"
-    hoist-non-react-statics "^3.3.1"
+"@emotion/memoize@^0.8.0":
+  version "0.8.0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
 "@emotion/react@^11.1.5":
   version "11.7.1"
@@ -3344,16 +3341,19 @@
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0.tgz#1a61f4f037cf39995c97fc80ebe99abc7b191ca9"
-  integrity sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==
+"@emotion/react@^11.9.0":
+  version "11.10.5"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
+  integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
   dependencies:
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/unitless" "^0.7.5"
-    "@emotion/utils" "^1.0.0"
-    csstype "^3.0.2"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.5"
+    "@emotion/cache" "^11.10.5"
+    "@emotion/serialize" "^1.1.1"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    hoist-non-react-statics "^3.3.1"
 
 "@emotion/serialize@^1.0.2":
   version "1.0.2"
@@ -3366,15 +3366,26 @@
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
 
-"@emotion/sheet@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.0.tgz#a0ef06080f339477ad4ba7f56e1c931f7ba50822"
-  integrity sha512-cdCHfZtf/0rahPDCZ9zyq+36EqfD/6c0WUqTFZ/hv9xadTUv2lGE5QK7/Z6Dnx2oRxC0usfVM2/BYn9q9B9wZA==
+"@emotion/serialize@^1.1.1":
+  version "1.1.1"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
+  integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
+  dependencies:
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/unitless" "^0.8.0"
+    "@emotion/utils" "^1.2.0"
+    csstype "^3.0.2"
 
 "@emotion/sheet@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
+
+"@emotion/sheet@^1.2.1":
+  version "1.2.1"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
+  integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
 
 "@emotion/styled@11.8.1":
   version "11.8.1"
@@ -3387,17 +3398,6 @@
     "@emotion/serialize" "^1.0.2"
     "@emotion/utils" "^1.1.0"
 
-"@emotion/styled@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.0.0.tgz#698196c2822746360a8644a73a5d842b2d1a78a5"
-  integrity sha512-498laccxJlBiJqrr2r/fx9q+Pr55D0URP2UyOkoSGLjevb8LLAFWueqthsQ5XijE66iGo7y3rzzEYdA7CHmZEQ==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    "@emotion/babel-plugin" "^11.0.0"
-    "@emotion/is-prop-valid" "^1.0.0"
-    "@emotion/serialize" "^1.0.0"
-    "@emotion/utils" "^1.0.0"
-
 "@emotion/styled@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
@@ -3409,10 +3409,32 @@
     "@emotion/serialize" "^1.0.2"
     "@emotion/utils" "^1.0.0"
 
+"@emotion/styled@^11.8.1":
+  version "11.10.5"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
+  integrity sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.5"
+    "@emotion/is-prop-valid" "^1.2.0"
+    "@emotion/serialize" "^1.1.1"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@emotion/utils" "^1.2.0"
+
 "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/unitless@^0.8.0":
+  version "0.8.0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
+  integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
+  version "1.0.0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
+  integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
 
 "@emotion/utils@^1.0.0":
   version "1.0.0"
@@ -3424,10 +3446,20 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
   integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
 
+"@emotion/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
+
 "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+
+"@emotion/weak-memoize@^0.3.0":
+  version "0.3.0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
+  integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
@@ -21077,10 +21109,10 @@ stylis@4.0.13:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
   integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
-stylis@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
-  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
+stylis@4.1.3:
+  version "4.1.3"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
 
 stylis@^4.0.3:
   version "4.0.3"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2717,7 +2717,7 @@
 
 "@babel/runtime@^7.18.3":
   version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
   dependencies:
     regenerator-runtime "^0.13.11"
@@ -3189,7 +3189,7 @@
 
 "@emotion/babel-plugin@^11.10.5":
   version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
   integrity sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
@@ -3243,7 +3243,7 @@
 
 "@emotion/cache@^11.10.5":
   version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
   integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
   dependencies:
     "@emotion/memoize" "^0.8.0"
@@ -3265,7 +3265,7 @@
 
 "@emotion/css-prettifier@^1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.1.1.tgz#87f3104c057a55674ff464f9c4fdf7326847f0ea"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/css-prettifier/-/css-prettifier-1.1.1.tgz#87f3104c057a55674ff464f9c4fdf7326847f0ea"
   integrity sha512-dtiZLNN3dWP0mo/+VTPkzNrjp1wL6VRHOOSMn3XpQM4D/7xOVHEIQR6lT5Yj5Omun1REog5NFZ+5hxj+LtTIyQ==
   dependencies:
     "@emotion/memoize" "^0.8.0"
@@ -3278,7 +3278,7 @@
 
 "@emotion/hash@^0.9.0":
   version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
 "@emotion/is-prop-valid@^1.1.0":
@@ -3297,14 +3297,14 @@
 
 "@emotion/is-prop-valid@^1.2.0":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
   integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
   dependencies:
     "@emotion/memoize" "^0.8.0"
 
 "@emotion/jest@^11.5.0":
   version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.10.5.tgz#6aea1aec38e1c59e675702fa877644a6b1c18d05"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/jest/-/jest-11.10.5.tgz#6aea1aec38e1c59e675702fa877644a6b1c18d05"
   integrity sha512-LagosxybgisPlxfBGas9kGcNB5xTTX125WbjEVZiE3MEbb+dI4UYn0XIzrsilR8nUaQ5lH6yKUFrMmz7kB34vg==
   dependencies:
     "@babel/runtime" "^7.18.3"
@@ -3325,7 +3325,7 @@
 
 "@emotion/memoize@^0.8.0":
   version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
 "@emotion/react@^11.1.5":
@@ -3343,7 +3343,7 @@
 
 "@emotion/react@^11.9.0":
   version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
   integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
   dependencies:
     "@babel/runtime" "^7.18.3"
@@ -3368,7 +3368,7 @@
 
 "@emotion/serialize@^1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
   integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
   dependencies:
     "@emotion/hash" "^0.9.0"
@@ -3384,7 +3384,7 @@
 
 "@emotion/sheet@^1.2.1":
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
   integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
 
 "@emotion/styled@11.8.1":
@@ -3411,7 +3411,7 @@
 
 "@emotion/styled@^11.8.1":
   version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
   integrity sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==
   dependencies:
     "@babel/runtime" "^7.18.3"
@@ -3428,12 +3428,12 @@
 
 "@emotion/unitless@^0.8.0":
   version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
   integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
 
 "@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
   integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
 
 "@emotion/utils@^1.0.0":
@@ -3448,7 +3448,7 @@
 
 "@emotion/utils@^1.2.0":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
   integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
 
 "@emotion/weak-memoize@^0.2.5":
@@ -3458,7 +3458,7 @@
 
 "@emotion/weak-memoize@^0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
   integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@eslint/eslintrc@^1.3.0":
@@ -21111,7 +21111,7 @@ stylis@4.0.13:
 
 stylis@4.1.3:
   version "4.1.3"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
   integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
 
 stylis@^4.0.3:

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2717,7 +2717,7 @@
 
 "@babel/runtime@^7.18.3":
   version "7.20.7"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
   dependencies:
     regenerator-runtime "^0.13.11"
@@ -3189,7 +3189,7 @@
 
 "@emotion/babel-plugin@^11.10.5":
   version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
   integrity sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
@@ -3243,7 +3243,7 @@
 
 "@emotion/cache@^11.10.5":
   version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
   integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
   dependencies:
     "@emotion/memoize" "^0.8.0"
@@ -3265,7 +3265,7 @@
 
 "@emotion/css-prettifier@^1.1.1":
   version "1.1.1"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/css-prettifier/-/css-prettifier-1.1.1.tgz#87f3104c057a55674ff464f9c4fdf7326847f0ea"
+  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.1.1.tgz#87f3104c057a55674ff464f9c4fdf7326847f0ea"
   integrity sha512-dtiZLNN3dWP0mo/+VTPkzNrjp1wL6VRHOOSMn3XpQM4D/7xOVHEIQR6lT5Yj5Omun1REog5NFZ+5hxj+LtTIyQ==
   dependencies:
     "@emotion/memoize" "^0.8.0"
@@ -3278,7 +3278,7 @@
 
 "@emotion/hash@^0.9.0":
   version "0.9.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
 "@emotion/is-prop-valid@^1.1.0":
@@ -3297,14 +3297,14 @@
 
 "@emotion/is-prop-valid@^1.2.0":
   version "1.2.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
   integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
   dependencies:
     "@emotion/memoize" "^0.8.0"
 
 "@emotion/jest@^11.5.0":
   version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/jest/-/jest-11.10.5.tgz#6aea1aec38e1c59e675702fa877644a6b1c18d05"
+  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.10.5.tgz#6aea1aec38e1c59e675702fa877644a6b1c18d05"
   integrity sha512-LagosxybgisPlxfBGas9kGcNB5xTTX125WbjEVZiE3MEbb+dI4UYn0XIzrsilR8nUaQ5lH6yKUFrMmz7kB34vg==
   dependencies:
     "@babel/runtime" "^7.18.3"
@@ -3325,7 +3325,7 @@
 
 "@emotion/memoize@^0.8.0":
   version "0.8.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
 "@emotion/react@^11.1.5":
@@ -3343,7 +3343,7 @@
 
 "@emotion/react@^11.9.0":
   version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
   integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
   dependencies:
     "@babel/runtime" "^7.18.3"
@@ -3368,7 +3368,7 @@
 
 "@emotion/serialize@^1.1.1":
   version "1.1.1"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
   integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
   dependencies:
     "@emotion/hash" "^0.9.0"
@@ -3384,7 +3384,7 @@
 
 "@emotion/sheet@^1.2.1":
   version "1.2.1"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
   integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
 
 "@emotion/styled@11.8.1":
@@ -3411,7 +3411,7 @@
 
 "@emotion/styled@^11.8.1":
   version "11.10.5"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
   integrity sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==
   dependencies:
     "@babel/runtime" "^7.18.3"
@@ -3428,12 +3428,12 @@
 
 "@emotion/unitless@^0.8.0":
   version "0.8.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
   integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
 
 "@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
   version "1.0.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
   integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
 
 "@emotion/utils@^1.0.0":
@@ -3448,7 +3448,7 @@
 
 "@emotion/utils@^1.2.0":
   version "1.2.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
   integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
 
 "@emotion/weak-memoize@^0.2.5":
@@ -3458,7 +3458,7 @@
 
 "@emotion/weak-memoize@^0.3.0":
   version "0.3.0"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
   integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@eslint/eslintrc@^1.3.0":
@@ -21111,7 +21111,7 @@ stylis@4.0.13:
 
 stylis@4.1.3:
   version "4.1.3"
-  resolved "https://artifactory.lyft.net/artifactory/api/npm/virtual-npm-lyft/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
   integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
 
 stylis@^4.0.3:


### PR DESCRIPTION
### Description
This was originally reverted here: https://github.com/lyft/clutch/pull/2520 due to some issues with unit testing the module. Biggest difference here is the removal of material-table and updating the snapshot test as well as modifying the frontend github workflow to use the makefile which defaults to `--frozen-lockfile`.

Original Description:
Since we have an internal wrapper for @emotion/styled, converting all instances of @emotion/styled to use the wrapper component and removing any references to imports for @emotion/styled. This should allow for easier upgrades as time goes on.

### Testing Performed
manual
