### PR TITLE
frontend: Select - support multiple

### DIFF
--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -182,14 +182,13 @@ export interface SelectOption extends BaseSelectOptions {
   group?: BaseSelectOptions[];
 }
 
-export interface SelectProps extends Pick<MuiSelectProps, "disabled" | "error"> {
+export interface SelectProps extends Pick<MuiSelectProps, "disabled" | "error" | "multiple"> {
   defaultOption?: number | string;
   helperText?: string;
   label?: string;
   name: string;
   options: SelectOption[];
   onChange?: (value: string) => void;
-  multiple?: boolean;
 }
 
 export const Select = ({
@@ -231,15 +230,12 @@ export const Select = ({
 
   const [selectedIdxs, setSelectedIdxs] = React.useState(calculateDefaultOption());
 
-  // Returns the list of selected values
-  const selectedValues = () => {
-    return selectedIdxs.map(idx => flatOptions[idx].value || flatOptions[idx].label);
-  };
+  const selectedValues = () =>
+    selectedIdxs.map(idx => flatOptions[idx].value || flatOptions[idx].label);
 
   React.useEffect(() => {
     if (flatOptions.length !== 0) {
-      const onChangeInput: string[] = selectedValues();
-      onChange && onChange(onChangeInput.join(","));
+      onChange && onChange((selectedValues() ?? []).join(","));
     }
   }, []);
 
@@ -249,16 +245,8 @@ export const Select = ({
     if (!value) {
       return;
     }
-
-    if (multiple) {
-      const newSelectedIdxs = value.map(val =>
-        flatOptions.findIndex(opt => opt.value === val || opt.label === val)
-      );
-      setSelectedIdxs(newSelectedIdxs);
-    } else {
-      const index = flatOptions.findIndex(opt => opt.value === value || opt.label === value);
-      setSelectedIdxs([index]);
-    }
+    const findIndex = val => flatOptions.findIndex(opt => opt.value === val || opt.label === val);
+    setSelectedIdxs(multiple ? value.map(val => findIndex(val)) : [findIndex(value)]);
 
     onChange && onChange(selectedIdxs.join(","));
   };

--- a/frontend/packages/core/src/Input/stories/select.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/select.stories.tsx
@@ -74,3 +74,17 @@ WithGrouping.args = {
     },
   ],
 };
+
+export const Multiple = Template.bind({});
+Multiple.args = {
+  ...Default.args,
+  multiple: true,
+  options: [
+    {
+      label: "Option 1",
+    },
+    {
+      label: "Option 2",
+    },
+  ],
+};

--- a/frontend/packages/core/src/Input/stories/select.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/select.stories.tsx
@@ -74,17 +74,3 @@ WithGrouping.args = {
     },
   ],
 };
-
-export const Multiple = Template.bind({});
-Multiple.args = {
-  ...Default.args,
-  multiple: true,
-  options: [
-    {
-      label: "Option 1",
-    },
-    {
-      label: "Option 2",
-    },
-  ],
-};

--- a/frontend/packages/core/src/Input/tests/select.test.tsx
+++ b/frontend/packages/core/src/Input/tests/select.test.tsx
@@ -10,7 +10,7 @@ describe("Select", () => {
         <Select name="foobar" defaultOption={-1} options={[{ label: "foo" }, { label: "bar" }]} />
       );
       expect(component.find("#foobar")).toHaveLength(1);
-      expect(component.find("#foobar-select").props().value).toBe("foo");
+      expect(component.find("#foobar-select").props().value).toStrictEqual(["foo"]);
     });
 
     it("has upper bound", () => {
@@ -18,7 +18,7 @@ describe("Select", () => {
         <Select name="foobar" defaultOption={2} options={[{ label: "foo" }]} />
       );
       expect(component.find("#foobar")).toHaveLength(1);
-      expect(component.find("#foobar-select").props().value).toBe("foo");
+      expect(component.find("#foobar-select").props().value).toStrictEqual(["foo"]);
     });
   });
 });

--- a/frontend/packages/core/src/Input/tests/select.test.tsx
+++ b/frontend/packages/core/src/Input/tests/select.test.tsx
@@ -21,4 +21,20 @@ describe("Select", () => {
       expect(component.find("#foobar-select").props().value).toStrictEqual(["foo"]);
     });
   });
+
+  describe("multiple values", () => {
+    it("allows multiple", () => {
+      const component = shallow(
+        <Select
+          name="foobar"
+          multiple
+          defaultOption={2}
+          options={[{ label: "foo" }, { label: "bar" }]}
+        />
+      );
+      expect(component.find("#foobar")).toHaveLength(1);
+      component.find("#foobar-select").simulate("change", { target: { value: ["foo", "bar"] } });
+      expect(component.find("#foobar-select").props().value).toStrictEqual(["foo", "bar"]);
+    });
+  });
 });


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Modifies Select component to support multiple values. MUI Select uses an array type as the value (https://mui.com/material-ui/react-select/#multiple-select) when multiple is true. This PR changes the internal representation of selected values to an array, even when multiple is False, to support type consistency for the component.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
<img width="1099" alt="Screenshot 2023-01-06 at 16 33 35" src="https://user-images.githubusercontent.com/22361209/211103855-37e422c0-d40e-4b73-b5aa-7ce48ab34977.png">

### Testing Performed
<!-- Describe how you tested this change below. -->
Manual. 
