### PR TITLE
backend: fix authn error test assertions

### DIFF
--- a/backend/module/authn/authn_test.go
+++ b/backend/module/authn/authn_test.go
@@ -104,7 +104,8 @@ func TestAPICallback(t *testing.T) {
 		ErrorDescription: "description",
 	})
 	assert.Nil(t, response)
-	assert.Error(t, err, "error: description")
+	assert.Error(t, err)
+	assert.Equal(t, errors.New("error: description"), err)
 
 	transportStream := &grpcmock.MockServerTransportStream{}
 	ctx := grpc.NewContextWithServerTransportStream(context.Background(), transportStream)
@@ -130,7 +131,8 @@ func TestAPICallbackWithRefresh(t *testing.T) {
 		ErrorDescription: "description",
 	})
 	assert.Nil(t, response)
-	assert.Error(t, err, "error: description")
+	assert.Error(t, err)
+	assert.Equal(t, errors.New("error: description"), err)
 
 	transportStream := &grpcmock.MockServerTransportStream{}
 	ctx := grpc.NewContextWithServerTransportStream(context.Background(), transportStream)


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
currently this asserts `err` is an error and prints the text `"error: description"` when this fails. The test should be asserting that the error's message is `"error: description"` instead.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
CI