### PR TITLE
ensure that yarn is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PROJECT_ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 	@grep -E '^\.PHONY: [a-zA-Z_-]+ .*?# .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = "(: |#)"}; {printf "%-30s %s\n", $$2, $$3}'
 
 .PHONY: all # Generate API, Frontend, and backend assets.
-all: preflight-checks api frontend backend-with-assets
+all: install-yarn preflight-checks api frontend backend-with-assets
 
 .PHONY: api # Generate API assets.
 api: yarn-ensure
@@ -197,3 +197,5 @@ preflight-checks:
 util-bump-aws:
 	cd backend && go list -m -f '{{if not .Indirect}}{{.Path}}{{end}}' all | grep aws-sdk-go | tr '\n' ' ' | xargs go get -u
 
+install-yarn:
+	@./tools/install-yarn.sh


### PR DESCRIPTION
### Description
the documentation [here](https://clutch.sh/docs/getting-started/local-build) doesn't seem to include the part where we need to run `tools/install-yarn.sh` to generate the build directory. This update should make new people that just the repo an try to clone easier

### Testing Performed
tested locally make

### GitHub Issue
n/a
