### PR TITLE
FE: Change wording from Confirm to Result

### DIFF
--- a/frontend/workflows/ec2/src/reboot-instance.tsx
+++ b/frontend/workflows/ec2/src/reboot-instance.tsx
@@ -92,7 +92,7 @@ const RebootInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes 
     <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Verify" />
-      <Confirm name="Confirmation" notes={notes} />
+      <Confirm name="Result" notes={notes} />
     </Wizard>
   );
 };

--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -137,7 +137,7 @@ const ResizeAutoscalingGroup: React.FC<WorkflowProps> = ({ heading, resolverType
     <Wizard dataLayout={dataLayout} heading={heading}>
       <GroupIdentifier name="Lookup" resolverType={resolverType} />
       <GroupDetails name="Modify" />
-      <Confirm name="Confirmation" notes={notes} />
+      <Confirm name="Result" notes={notes} />
     </Wizard>
   );
 };

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -111,7 +111,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, not
     <Wizard dataLayout={dataLayout} heading={heading}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Verify" />
-      <Confirm name="Confirmation" notes={notes} />
+      <Confirm name="Result" notes={notes} />
     </Wizard>
   );
 };

--- a/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`Resize Autoscaling Group workflow renders correctly 1`] = `
 "<Wizard dataLayout={{...}} heading={[undefined]}>
   <GroupIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.ec2.v1.AutoscalingGroup\\" />
   <GroupDetails name=\\"Modify\\" />
-  <Confirm name=\\"Confirmation\\" notes={{...}} />
+  <Confirm name=\\"Result\\" notes={{...}} />
 </Wizard>"
 `;

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`Terminate Instance workflow renders correctly 1`] = `
 "<Wizard dataLayout={{...}} heading={[undefined]}>
   <InstanceIdentifier name=\\"Lookup\\" resolverType=\\"clutch.aws.ec2.v1.Instance\\" />
   <InstanceDetails name=\\"Verify\\" />
-  <Confirm name=\\"Confirmation\\" notes={{...}} />
+  <Confirm name=\\"Result\\" notes={{...}} />
 </Wizard>"
 `;

--- a/frontend/workflows/k8s/src/cordon-node.tsx
+++ b/frontend/workflows/k8s/src/cordon-node.tsx
@@ -99,7 +99,7 @@ const CordonNode: React.FC<WorkflowProps> = ({ heading, resolverType, notes = []
     <Wizard dataLayout={dataLayout} heading={heading}>
       <NodeIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
       <NodeDetails name="Verify" />
-      <Confirm name="Confirmation" />
+      <Confirm name="Result" />
     </Wizard>
   );
 };

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -108,7 +108,7 @@ const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
     <Wizard dataLayout={dataLayout} heading={heading}>
       <PodIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
       <PodDetails name="Verify" notes={notes} />
-      <Confirm name="Confirmation" />
+      <Confirm name="Result" />
     </Wizard>
   );
 };

--- a/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`Terminate Instance workflow renders correctly 1`] = `
 "<Wizard dataLayout={{...}} heading={[undefined]}>
   <PodIdentifier name=\\"Lookup\\" resolverType=\\"clutch.k8s.v1.Pod\\" notes={{...}} />
   <PodDetails name=\\"Verify\\" notes={{...}} />
-  <Confirm name=\\"Confirmation\\" />
+  <Confirm name=\\"Result\\" />
 </Wizard>"
 `;

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -155,7 +155,7 @@ const UpdateShardCount: React.FC<WorkflowProps> = ({ heading, resolverType }) =>
     <Wizard dataLayout={dataLayout} heading={heading}>
       <StreamIdentifier name="Lookup" resolverType={resolverType} />
       <StreamDetails name="Modify" />
-      <Confirm name="Confirmation" />
+      <Confirm name="Result" />
     </Wizard>
   );
 };

--- a/frontend/workflows/sourcecontrol/src/create-repository.tsx
+++ b/frontend/workflows/sourcecontrol/src/create-repository.tsx
@@ -141,7 +141,7 @@ const CreateRepository: React.FC<WorkflowProps> = ({ heading }) => {
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <RepositoryDetails name="Repository Details" />
-      <Confirm name="Confirmation" />
+      <Confirm name="Result" />
     </Wizard>
   );
 };


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
A user felt that the word Result was more suited than Confirmation, because at that point things were already confirmed.
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
