### PR TITLE
frontend: fix audit workflow quick time selection

### DIFF
--- a/frontend/workflows/audit/src/logs/event-row.tsx
+++ b/frontend/workflows/audit/src/logs/event-row.tsx
@@ -148,7 +148,7 @@ const EventRow = ({ event, detailsPathPrefix, downloadPrefix }: EventRowProps) =
 interface EventRowsProps extends Pick<EventRowProps, "detailsPathPrefix" | "downloadPrefix"> {
   startTime: Date;
   endTime: Date;
-  key: string;
+  rangeKey: string;
   onFetch: () => void;
   onSuccess: () => void;
   onError: (e: ClutchError) => void;
@@ -159,7 +159,7 @@ const EventRows = ({
   downloadPrefix,
   startTime,
   endTime,
-  key,
+  rangeKey,
   onFetch,
   onSuccess,
   onError,
@@ -223,11 +223,12 @@ const EventRows = ({
       }
     };
   }, [containerRef, options]);
+
   React.useEffect(() => {
     setPageToken("0");
     setEvents([]);
     fetch();
-  }, [key]);
+  }, [rangeKey]);
 
   return (
     <>

--- a/frontend/workflows/audit/src/logs/index.tsx
+++ b/frontend/workflows/audit/src/logs/index.tsx
@@ -122,7 +122,7 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
             downloadPrefix={downloadPrefix}
             startTime={startTime}
             endTime={endTime}
-            key={timeRangeKey}
+            rangeKey={timeRangeKey}
             onFetch={() => setIsLoading(true)}
             onSuccess={() => {
               setIsLoading(false);


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes the audit logs workflow view to trigger an event request when the quick time range is selected.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual