### PR TITLE
frontend: audit workflow fix state bug

### DIFF
--- a/frontend/workflows/audit/src/logs/event-row.tsx
+++ b/frontend/workflows/audit/src/logs/event-row.tsx
@@ -171,16 +171,17 @@ const EventRows = ({
 
   const containerRef = React.useRef(null);
 
-  const fetch = () => {
-    if (pageToken === "" || isLoading) {
+  const fetch = (page?: number) => {
+    if ((page === undefined && pageToken === "") || isLoading) {
       return;
     }
+    const tkn = page || pageToken;
     onFetch();
     setIsLoading(true);
     const data = {
       range: { startTime, endTime },
       limit: 10,
-      pageToken,
+      pageToken: tkn,
     } as IClutch.audit.v1.IGetEventsRequest;
     client
       .post(ENDPOINT, data)
@@ -227,7 +228,10 @@ const EventRows = ({
   React.useEffect(() => {
     setPageToken("0");
     setEvents([]);
-    fetch();
+    // n.b. we explicitly pass in 0 here in addition to the setPageToken
+    // call above since react won't pick up the state updates when
+    // fetch is invoked.
+    fetch(0);
   }, [rangeKey]);
 
   return (

--- a/frontend/workflows/audit/src/logs/event-row.tsx
+++ b/frontend/workflows/audit/src/logs/event-row.tsx
@@ -172,7 +172,7 @@ const EventRows = ({
   const containerRef = React.useRef(null);
 
   const fetch = (page?: string) => {
-    if ((page === undefined && page === "" && pageToken === "") || isLoading) {
+    if (((page === undefined || page === "") && pageToken === "") || isLoading) {
       return;
     }
     const tkn = page || pageToken;

--- a/frontend/workflows/audit/src/logs/event-row.tsx
+++ b/frontend/workflows/audit/src/logs/event-row.tsx
@@ -171,8 +171,8 @@ const EventRows = ({
 
   const containerRef = React.useRef(null);
 
-  const fetch = (page?: number) => {
-    if ((page === undefined && pageToken === "") || isLoading) {
+  const fetch = (page?: string) => {
+    if ((page === undefined && page === "" && pageToken === "") || isLoading) {
       return;
     }
     const tkn = page || pageToken;
@@ -231,7 +231,7 @@ const EventRows = ({
     // n.b. we explicitly pass in 0 here in addition to the setPageToken
     // call above since react won't pick up the state updates when
     // fetch is invoked.
-    fetch(0);
+    fetch("0");
   }, [rangeKey]);
 
   return (

--- a/frontend/workflows/audit/src/logs/index.tsx
+++ b/frontend/workflows/audit/src/logs/index.tsx
@@ -70,6 +70,7 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
   const theme = useTheme();
   const shrink = useMediaQuery(theme.breakpoints.down("md"));
 
+  const genTimeRangeKey = () => `${startTime}-${endTime}-${new Date().toString()}`;
   return (
     <RootContainer spacing={2} direction="column">
       <Typography variant="h2">{heading}</Typography>
@@ -97,17 +98,17 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
             onQuickSelect={(start, end) => {
               setStartTime(start);
               setEndTime(end);
-              setTimeRangeKey(`${startTime}-${endTime}-${new Date().toString()}`);
+              setTimeRangeKey(genTimeRangeKey());
             }}
           />
           {shrink ? (
             <Button
               text="Search"
-              onClick={() => setTimeRangeKey(`${startTime}-${endTime}-${new Date().toString()}`)}
+              onClick={() => setTimeRangeKey(genTimeRangeKey())}
             />
           ) : (
             <IconButton
-              onClick={() => setTimeRangeKey(`${startTime}-${endTime}-${new Date().toString()}`)}
+              onClick={() => setTimeRangeKey(genTimeRangeKey())}
             >
               <SearchIcon />
             </IconButton>

--- a/frontend/workflows/audit/src/logs/index.tsx
+++ b/frontend/workflows/audit/src/logs/index.tsx
@@ -97,13 +97,18 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
             onQuickSelect={(start, end) => {
               setStartTime(start);
               setEndTime(end);
-              setTimeRangeKey(`${startTime}-${endTime}`);
+              setTimeRangeKey(`${startTime}-${endTime}-${new Date().toString()}`);
             }}
           />
           {shrink ? (
-            <Button text="Search" onClick={() => setTimeRangeKey(`${startTime}-${endTime}`)} />
+            <Button
+              text="Search"
+              onClick={() => setTimeRangeKey(`${startTime}-${endTime}-${new Date().toString()}`)}
+            />
           ) : (
-            <IconButton onClick={() => setTimeRangeKey(`${startTime}-${endTime}`)}>
+            <IconButton
+              onClick={() => setTimeRangeKey(`${startTime}-${endTime}-${new Date().toString()}`)}
+            >
               <SearchIcon />
             </IconButton>
           )}

--- a/frontend/workflows/audit/src/logs/index.tsx
+++ b/frontend/workflows/audit/src/logs/index.tsx
@@ -102,14 +102,9 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
             }}
           />
           {shrink ? (
-            <Button
-              text="Search"
-              onClick={() => setTimeRangeKey(genTimeRangeKey())}
-            />
+            <Button text="Search" onClick={() => setTimeRangeKey(genTimeRangeKey())} />
           ) : (
-            <IconButton
-              onClick={() => setTimeRangeKey(genTimeRangeKey())}
-            >
+            <IconButton onClick={() => setTimeRangeKey(genTimeRangeKey())}>
               <SearchIcon />
             </IconButton>
           )}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Fixes two issues with the audit workflow:
- allows users to resubmit queries even after selecting and submitting a time range (the only limitation is users cannot query within a second)
- If the server sends back a response with the next page token empty it's stored in state and when a subsequent query is submitted we attempt to reset the page token but this doesn't happen before `fetch` is invoked which triggers the quick return since it believes there is no next page token to fetch. This is fixed by explicitly calling fetch with a zero page token.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
manual
