### PR TITLE
frontend: Add AppConfiguration for drawers

### DIFF
--- a/frontend/packages/core/src/AppLayout/index.tsx
+++ b/frontend/packages/core/src/AppLayout/index.tsx
@@ -25,7 +25,10 @@ interface AppLayoutProps {
   configuration?: AppConfiguration;
 }
 
-const AppLayout: React.FC<AppLayoutProps> = ({ isLoading = false, configuration = {} }) => {
+const AppLayout: React.FC<AppLayoutProps> = ({
+  isLoading = false,
+  configuration = { hideDrawers: false },
+}) => {
   return (
     <AppGrid container direction="column">
       <Header {...configuration} />
@@ -34,7 +37,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ isLoading = false, configuration 
           <Loadable isLoading={isLoading} variant="overlay" />
         ) : (
           <>
-            <Drawer />
+            {!configuration?.hideDrawers && <Drawer />}
             <MainContent>
               <Outlet />
             </MainContent>

--- a/frontend/packages/core/src/AppLayout/tests/__snapshots__/layout.test.tsx.snap
+++ b/frontend/packages/core/src/AppLayout/tests/__snapshots__/layout.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`AppLayout component renders correctly 1`] = `
 "<Styled(Component) container={true} direction=\\"column\\">
-  <Header />
+  <Header hideDrawers={false} />
   <Styled(Component) container={true} wrap=\\"nowrap\\">
     <Drawer />
     <Styled(div)>

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -31,6 +31,11 @@ export interface AppConfiguration {
   title?: string;
   /** Supports a react node or a string representing a public assets path */
   logo?: React.ReactNode | string;
+  /**
+   * Will hide the drawers
+   * @defaultValue disabled
+   */
+  hideDrawers?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Description
Modifies the AppConfiguration to take a `hideDrawers` boolean which can be used to hide the drawers.

Context: Currently the only way to hide the side drawers is by marking all workflows as hidden. This breaks some features such as NPS Feedback which require knowledge about visible workflows. For those that still want the drawers hidden we can add a customizable input prop that is disabled by default and allow users to choose if they want them displayed or not.

### Testing Performed
manual