### PR TITLE
frontend: frontend convert tests nps

### DIFF
--- a/frontend/packages/core/src/NPS/feedback.tsx
+++ b/frontend/packages/core/src/NPS/feedback.tsx
@@ -203,12 +203,13 @@ const NPSFeedback = ({
   }
 
   return (
-    <form onSubmit={submitFeedback}>
+    <form onSubmit={submitFeedback} data-testid="feedback-component">
       <MuiGrid
         container
         direction="row"
         alignItems="center"
         style={{ padding: wizardOrigin ? "16px" : "24px" }}
+        data-testid="feedback-items-container"
       >
         <MuiGrid item xs>
           <Typography variant={wizardOrigin ? "subtitle3" : "subtitle2"}>

--- a/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
@@ -50,13 +50,12 @@ test("all emojis have an initial opacity of 0.5 when not selected", () => {
   });
 });
 
-test("emojis will update opacity to 1 on hover", async () => {
+test("emojis will have a tooltip show on hover", async () => {
   const user = userEvent.setup();
   render(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
 
   await user.hover(screen.getByLabelText(/Great/i));
   expect(await screen.findByText("Great")).toHaveClass("MuiTooltip-tooltip");
-  // expect(await screen.findByLabelText(/Great/i)).toHaveStyle("opacity: 1");
   await user.unhover(screen.getByLabelText(/Great/i));
   await waitForElementToBeRemoved(() => screen.queryByText("Great"));
 });

--- a/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
@@ -54,8 +54,9 @@ test("emojis will update opacity to 1 on hover", async () => {
   const user = userEvent.setup();
   render(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
 
-  await user.click(screen.getByLabelText(/Great/i)); // .hover not working
-  expect(screen.getByLabelText(/Great/i)).toHaveStyle("opacity: 1");
+  await user.hover(screen.getByLabelText(/Great/i));
+  expect(await screen.findByText("Great")).toHaveClass("MuiTooltip-tooltip");
+  expect(await screen.findByLabelText(/Great/i)).toHaveStyle("opacity: 1");
 });
 
 test("emojis will update opacity to 1 on selection", async () => {

--- a/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
@@ -1,114 +1,87 @@
 import React from "react";
-import renderer, { act } from "react-test-renderer";
-import { clutch as IClutch } from "@clutch-sh/api";
-import { matchers } from "@emotion/jest";
-import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { capitalize } from "lodash";
+
+import "@testing-library/jest-dom";
 
 import EmojiRatings from "../emojiRatings";
 
-// Add the custom matchers provided by '@emotion/jest'
-expect.extend(matchers);
+const stringExample = [
+  {
+    emoji: 1,
+    label: "bad",
+  },
+  {
+    emoji: 2,
+    label: "ok",
+  },
+  {
+    emoji: 3,
+    label: "great",
+  },
+];
 
-describe("<EmojiRatings />", () => {
-  const stringExample = [
-    {
-      emoji: 1,
-      label: "bad",
-    },
-    {
-      emoji: 2,
-      label: "ok",
-    },
-    {
-      emoji: 3,
-      label: "great",
-    },
-  ];
+const emojiMap = {
+  1: "SAD",
+  2: "NEUTRAL",
+  3: "HAPPY",
+};
 
-  const emojiMap = {
-    1: "SAD",
-    2: "NEUTRAL",
-    3: "HAPPY",
-  };
+test("will display a given list of emojis and their capitalized labels", () => {
+  render(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
 
-  it("will display a given list of emojis and their capitalized labels", () => {
-    const wrapper = shallow(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
-    wrapper.children().forEach((node, i) => {
-      expect(node.find("Tooltip").prop("title")).toEqual(capitalize(stringExample[i].label));
-      expect(node.find("Emoji").prop("type")).toEqual(emojiMap[stringExample[i].emoji]);
-    });
+  const elements = screen.getAllByRole("button");
+
+  expect(elements).toHaveLength(stringExample.length);
+
+  elements.forEach((element, i) => {
+    expect(element).toHaveAttribute("aria-label", capitalize(stringExample[i].label));
   });
+});
 
-  it("all emojis have an initial opacity of 0.5 when not selected", () => {
-    const component = renderer
-      .create(<EmojiRatings ratings={stringExample} setRating={() => {}} />)
-      .toJSON();
+test("all emojis have an initial opacity of 0.5 when not selected", () => {
+  render(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
 
-    component.forEach(node => {
-      expect(node).toHaveStyleRule("opacity", "0.5");
-    });
+  const elements = screen.getAllByRole("button");
+
+  elements.forEach((element, i) => {
+    expect(element).toHaveStyle("opacity: 0.5");
   });
+});
 
-  it("emojis will update opacity to 1 on hover", () => {
-    const component = renderer
-      .create(<EmojiRatings ratings={stringExample} setRating={() => {}} />)
-      .toJSON();
+test("emojis will update opacity to 1 on hover", async () => {
+  const user = userEvent.setup();
+  render(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
 
-    component.forEach(node => {
-      expect(node).toHaveStyleRule("opacity", "1", { target: ":hover" });
-    });
-  });
+  await user.click(screen.getByLabelText(/Great/i)); // .hover not working
+  expect(screen.getByLabelText(/Great/i)).toHaveStyle("opacity: 1");
+});
 
-  it("emojis wll update opacity to 1 on selection", () => {
-    let component;
+test("emojis will update opacity to 1 on selection", async () => {
+  const user = userEvent.setup();
+  render(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
 
-    act(() => {
-      component = renderer.create(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
-    });
+  await user.click(screen.getByLabelText(/Great/i));
+  expect(screen.getByLabelText(/Great/i)).toHaveStyle("opacity: 1");
+});
 
-    let [firstEmoji] = component.toJSON();
+test("will return a given emoji on select", async () => {
+  const user = userEvent.setup();
+  let selected: any = null;
 
-    expect(firstEmoji).toHaveStyleRule("opacity", "0.5");
+  render(
+    <EmojiRatings
+      ratings={stringExample}
+      setRating={rating => {
+        selected = rating;
+      }}
+    />
+  );
 
-    act(() => {
-      firstEmoji.props.onClick();
-    });
+  expect(selected).toBeNull();
 
-    [firstEmoji] = component.toJSON();
+  await user.click(screen.getByLabelText(/Ok/i));
 
-    expect(firstEmoji).toHaveStyleRule("opacity", "1");
-  });
-
-  it("will fetch emojis based on integers with a given enum", () => {
-    const enums = IClutch.feedback.v1.EmojiRating;
-    const wrapper = shallow(<EmojiRatings ratings={stringExample} setRating={() => {}} />);
-
-    wrapper.children().forEach((node, i) => {
-      expect(enums[node.find("Emoji").prop("type")]).toEqual(stringExample[i].emoji);
-    });
-  });
-
-  it("will return a given emoji on select", () => {
-    let selected = null;
-
-    const wrapper = shallow(
-      <EmojiRatings
-        ratings={stringExample}
-        setRating={rating => {
-          selected = rating;
-        }}
-      />
-    );
-
-    expect(selected).toBeNull();
-
-    const neutralEmoji = wrapper.find("Tooltip").at(1).find("Styled(Component)");
-
-    neutralEmoji.prop("onClick")(null);
-
-    wrapper.update();
-
-    expect(selected.emoji).toEqual(emojiMap[stringExample[1].emoji]);
-  });
+  expect(selected.emoji).toEqual(emojiMap[stringExample[1].emoji]);
 });

--- a/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/emojiRatings.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitForElementToBeRemoved } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { capitalize } from "lodash";
 
@@ -56,7 +56,9 @@ test("emojis will update opacity to 1 on hover", async () => {
 
   await user.hover(screen.getByLabelText(/Great/i));
   expect(await screen.findByText("Great")).toHaveClass("MuiTooltip-tooltip");
-  expect(await screen.findByLabelText(/Great/i)).toHaveStyle("opacity: 1");
+  // expect(await screen.findByLabelText(/Great/i)).toHaveStyle("opacity: 1");
+  await user.unhover(screen.getByLabelText(/Great/i));
+  await waitForElementToBeRemoved(() => screen.queryByText("Great"));
 });
 
 test("emojis will update opacity to 1 on selection", async () => {

--- a/frontend/packages/core/src/NPS/tests/feedback.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/feedback.test.tsx
@@ -1,340 +1,339 @@
 import React from "react";
-import { matchers } from "@emotion/jest";
-import { shallow } from "enzyme";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { capitalize } from "lodash";
+
+import "@testing-library/jest-dom";
 
 import contextValues from "../../Contexts/tests/testContext";
 import { client } from "../../Network";
 import NPSFeedback, { defaults, FEEDBACK_MAX_LENGTH } from "../feedback";
 import { generateFeedbackTypes } from "../header";
 
-// Adds the custom matchers provided by '@emotion/jest'
-expect.extend(matchers);
-
 const feedbackTypes = generateFeedbackTypes(contextValues.workflows);
 
-describe("<NPSFeedback />", () => {
-  const defaultResult = {
-    prompt: "Test Prompt",
-    freeformPrompt: "Test Freeform",
-    ratingLabels: [
-      {
-        emoji: "SAD",
-        label: "bad",
-      },
-      {
-        emoji: "NEUTRAL",
-        label: "ok",
-      },
-      {
-        emoji: "HAPPY",
-        label: "great",
-      },
-    ],
+const defaultResult = {
+  prompt: "Test Prompt",
+  freeformPrompt: "Test Freeform",
+  ratingLabels: [
+    {
+      emoji: "SAD",
+      label: "bad",
+    },
+    {
+      emoji: "NEUTRAL",
+      label: "ok",
+    },
+    {
+      emoji: "HAPPY",
+      label: "great",
+    },
+  ],
+};
+
+describe("api success", () => {
+  let spy;
+  beforeEach(() => {
+    spy = jest.spyOn(client, "post").mockReturnValue(
+      new Promise((resolve, reject) => {
+        resolve({
+          data: {
+            originSurvey: {
+              WIZARD: defaultResult,
+              HEADER: defaultResult,
+            },
+          },
+        });
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders survey text prompt", async () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    expect(await screen.findByText(defaultResult.prompt)).toBeVisible();
+  });
+
+  test("renders emojis to <EmojiRatings />", async () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    const emojiButtons = await screen.findAllByRole("button");
+
+    expect(defaultResult.ratingLabels.map(({ label }) => capitalize(label))).toEqual(
+      emojiButtons.map(element => element.getAttribute("aria-label"))
+    );
+  });
+
+  test("renders text placeholder", async () => {
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="WIZARD" />);
+
+    await user.click(await screen.findByLabelText(/Great/i));
+
+    expect(await screen.findByPlaceholderText(defaultResult.freeformPrompt)).toBeVisible();
+  });
+
+  test("displays a successful submission alert after submit", async () => {
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="WIZARD" />);
+
+    await user.click(await screen.findByLabelText(/Great/i));
+    await user.click(await screen.findByText("Submit"));
+
+    expect(await screen.findByText("Thank you for your feedback!")).toBeVisible();
+  });
+
+  test("sends feedback upon emoji selection change", async () => {
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="WIZARD" />);
+    spy.mockClear();
+    expect(spy).not.toHaveBeenCalled();
+
+    await user.click(await screen.findByLabelText(/Great/i));
+    await user.click(await screen.findByText("Submit"));
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("api failure", () => {
+  beforeEach(() => {
+    jest.spyOn(client, "post").mockReturnValue(
+      new Promise((resolve, reject) => {
+        reject(new Error("Test Error"));
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders default text prompt", async () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    expect(await screen.findByText(defaults.prompt as string)).toBeVisible();
+  });
+
+  test("renders default emojis to <EmojiRatings />", async () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    const emojiButtons = await screen.findAllByRole("button");
+
+    if (!defaults.ratingLabels) {
+      return;
+    }
+
+    expect(defaults.ratingLabels.map(({ label }) => capitalize(label as string))).toEqual(
+      emojiButtons.map(element => element.getAttribute("aria-label"))
+    );
+  });
+
+  test("renders default text placeholder", async () => {
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="WIZARD" />);
+
+    await user.click(await screen.findByLabelText(/Great/i));
+
+    expect(await screen.findByPlaceholderText(defaults.freeformPrompt as string)).toBeVisible();
+  });
+});
+
+describe("basic rendering", () => {
+  const maxLength = FEEDBACK_MAX_LENGTH;
+  const generateRandomString = (length, rs = "") => {
+    let randomString = rs;
+    randomString += Math.random().toString(20).substr(2, length);
+    if (randomString.length > length) return randomString.slice(0, length);
+    return generateRandomString(length, randomString);
   };
 
-  const clickEmoji = wrapper => {
-    wrapper.find("EmojiRatings").dive().find("Styled(Component)").first().prop("onClick")(null);
+  beforeEach(() => {
+    jest.spyOn(client, "post").mockReturnValue(
+      new Promise((resolve, reject) => {
+        resolve({
+          data: {
+            originSurvey: {
+              WIZARD: defaultResult,
+            },
+          },
+        });
+      })
+    );
+  });
 
-    wrapper.update();
-  };
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-  describe("basic functionality", () => {
-    describe("api success", () => {
-      let wrapper;
-      let useEffect;
-      let spy;
-      const mockUseEffect = () => {
-        useEffect.mockImplementationOnce(f => f());
-      };
-      beforeEach(() => {
-        useEffect = jest.spyOn(React, "useEffect");
-        mockUseEffect();
-        spy = jest.spyOn(client, "post").mockReturnValue(
-          new Promise((resolve, reject) => {
-            resolve({
-              data: {
-                originSurvey: {
-                  WIZARD: defaultResult,
-                  HEADER: defaultResult,
-                },
-              },
-            });
-          })
-        );
-        wrapper = shallow(<NPSFeedback origin="WIZARD" />);
-      });
-      afterEach(() => {
-        wrapper.unmount();
-        spy.mockClear();
-      });
-      it("renders survey text prompt", () => {
-        expect(wrapper.find({ item: true }).at(0).find("Typography").childAt(0).text()).toEqual(
-          defaultResult.prompt
-        );
-      });
-      it("renders emojis to <EmojiRatings />", () => {
-        expect(wrapper.find("EmojiRatings").prop("ratings")).toEqual(defaultResult.ratingLabels);
-      });
-      it("renders text placeholder", () => {
-        clickEmoji(wrapper);
-        expect(wrapper.find("Styled(Component)").prop("placeholder")).toEqual(
-          defaultResult.freeformPrompt
-        );
-      });
-      it("displays a successful submission alert after submit", () => {
-        wrapper.find("form").prop("onSubmit")(null);
-        wrapper.update();
-        const alert = wrapper.find("FeedbackAlert");
-        expect(alert).toBeDefined();
-        expect(alert.dive().find("Typography").childAt(0).text()).toBe(
-          "Thank you for your feedback!"
-        );
-      });
-      it("sends feedback upon emoji selection change", () => {
-        mockUseEffect();
-        spy.mockClear();
-        expect(spy).not.toHaveBeenCalled();
-        expect(spy).toHaveBeenCalledTimes(0);
-        clickEmoji(wrapper);
-        expect(spy).toHaveBeenCalled();
-        expect(spy).toHaveBeenCalledTimes(1);
-      });
-    });
-    describe("api failure", () => {
-      let wrapper;
-      let useEffect;
-      const mockUseEffect = () => {
-        useEffect.mockImplementationOnce(f => f());
-      };
-      beforeEach(() => {
-        useEffect = jest.spyOn(React, "useEffect");
-        mockUseEffect();
-        jest.spyOn(client, "post").mockReturnValue(
-          new Promise((resolve, reject) => {
-            reject(new Error("Test Error"));
-          })
-        );
-        wrapper = shallow(<NPSFeedback origin="WIZARD" />);
-      });
-      afterEach(() => {
-        wrapper.unmount();
-      });
-      it("renders default text prompt", () => {
-        expect(wrapper.find({ item: true }).at(0).find("Typography").childAt(0).text()).toEqual(
-          defaults.prompt
-        );
-      });
-      it("renders default emojis to <EmojiRatings />", () => {
-        expect(wrapper.find("EmojiRatings").prop("ratings")).toEqual(defaults.ratingLabels);
-      });
-      it("renders default text placeholder", () => {
-        clickEmoji(wrapper);
-        expect(wrapper.find("Styled(Component)").prop("placeholder")).toEqual(
-          defaults.freeformPrompt
-        );
-      });
+  test("will not display feedback form or submit unless emoji is selected", () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    expect(screen.getByTestId("feedback-items-container").childElementCount).toBe(2);
+  });
+
+  test("will display text prompt at top", async () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    const feedbackItems = await screen.findByTestId("feedback-items-container");
+    expect(feedbackItems.childNodes[0].firstChild).toHaveTextContent(defaultResult.prompt);
+  });
+
+  test("will display <EmojiRatings /> below prompt", async () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    const feedbackItems = await screen.findByTestId("feedback-items-container");
+    feedbackItems.childNodes[1].childNodes.forEach(node => {
+      expect(node).toHaveAttribute("aria-label");
     });
   });
 
-  describe("basic rendering", () => {
-    const maxLength = FEEDBACK_MAX_LENGTH;
-    let wrapper;
-    let useEffect;
+  test("displays a text form and submit buttons after selection of emoji", async () => {
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="WIZARD" />);
+    expect(screen.getByTestId("feedback-items-container").childElementCount).toBe(2);
 
-    const mockUseEffect = () => {
-      useEffect.mockImplementationOnce(f => f());
-    };
+    await user.click(await screen.findByLabelText(/Great/i));
 
-    const generateRandomString = (length, rs = "") => {
-      let randomString = rs;
-      randomString += Math.random().toString(20).substr(2, length);
-      if (randomString.length > length) return randomString.slice(0, length);
-      return generateRandomString(length, randomString);
-    };
-
-    beforeEach(() => {
-      useEffect = jest.spyOn(React, "useEffect");
-      mockUseEffect();
-      jest.spyOn(client, "post").mockReturnValue(
-        new Promise((resolve, reject) => {
-          resolve({
-            data: {
-              originSurvey: {
-                WIZARD: defaultResult,
-              },
-            },
-          });
-        })
-      );
-      wrapper = shallow(<NPSFeedback origin="WIZARD" />);
-    });
-
-    afterEach(() => {
-      wrapper.unmount();
-    });
-
-    it("will not display feedback form or submit unless emoji is selected", () => {
-      expect(wrapper.find({ item: true })).toHaveLength(2);
-      expect(wrapper.find("Button")).toHaveLength(0);
-      expect(wrapper.find("Styled(Component)")).toHaveLength(0);
-    });
-
-    it("will display text prompt at top", () => {
-      expect(wrapper.find({ item: true }).at(0).find("Styled(span)")).toBeDefined();
-    });
-
-    it("will display <EmojiRatings /> below prompt", () => {
-      expect(wrapper.find({ item: true }).at(1).find("EmojiRatings")).toBeDefined();
-    });
-
-    it("displays a text form and submit buttons after selection of emoji", () => {
-      expect(wrapper.find({ item: true })).toHaveLength(2);
-
-      clickEmoji(wrapper);
-
-      expect(wrapper.find({ item: true })).toHaveLength(4);
-      expect(wrapper.find("Styled(Component)")).toBeDefined();
-      expect(wrapper.find("Styled(Button)")).toBeDefined();
-    });
-
-    it("will update the length on feedback if input is given", () => {
-      clickEmoji(wrapper);
-
-      const testValue = "Some Feedback Text";
-
-      let textField = wrapper.find("Styled(Component)");
-
-      expect(textField.prop("helperText")).toBe(`0 / ${maxLength}`);
-
-      textField.prop("onChange")({ target: { value: testValue } });
-
-      wrapper.update();
-
-      textField = wrapper.find("Styled(Component)");
-
-      expect(textField.prop("helperText")).toBe(`${testValue.trim().length} / ${maxLength}`);
-      expect(textField.prop("value")).toEqual(testValue);
-    });
-
-    it("will display an error on feedback if more input is given than maxLength", () => {
-      clickEmoji(wrapper);
-
-      const testValue = generateRandomString(FEEDBACK_MAX_LENGTH * 2);
-
-      let textField = wrapper.find("Styled(Component)");
-
-      expect(textField.prop("helperText")).toBe(`0 / ${maxLength}`);
-
-      textField.prop("onChange")({ target: { value: testValue } });
-
-      wrapper.update();
-
-      textField = wrapper.find("Styled(Component)");
-
-      expect(textField.prop("helperText")).toBe(`${testValue.trim().length} / ${maxLength}`);
-      expect(textField.prop("value")).toEqual(testValue);
-      expect(textField.prop("error")).toBeTruthy();
-    });
-
-    it("will disable the submit button upon error", () => {
-      clickEmoji(wrapper);
-
-      let submitButton = wrapper.find("Styled(Button)");
-
-      expect(submitButton.prop("disabled")).toBeFalsy();
-
-      wrapper.find("Styled(Component)").prop("onChange")({
-        target: { value: generateRandomString(FEEDBACK_MAX_LENGTH + 1) },
-      });
-
-      wrapper.update();
-
-      submitButton = wrapper.find("Styled(Button)");
-
-      expect(submitButton.prop("disabled")).toBeTruthy();
-    });
+    expect(await (await screen.findByTestId("feedback-items-container")).childElementCount).toBe(4);
+    expect(await screen.findByRole("textbox")).toBeVisible();
+    expect(
+      await (await screen.findAllByRole("button")).filter(element =>
+        element.hasAttribute("aria-label")
+      )
+    ).toHaveLength(defaultResult.ratingLabels.length);
   });
 
-  // Verifies layout changes for given origins
-  describe("Wizard Origin Rendering", () => {
-    let wrapper;
-    let useEffect;
+  test("will update the length on feedback if input is given", async () => {
+    const testValue = "Some Feedback Text";
+    const user = userEvent.setup();
+    const { container } = render(<NPSFeedback origin="WIZARD" />);
 
-    const mockUseEffect = () => {
-      useEffect.mockImplementationOnce(f => f());
-    };
+    await user.click(await screen.findByLabelText(/Great/i));
 
-    beforeEach(() => {
-      useEffect = jest.spyOn(React, "useEffect");
-      mockUseEffect();
-      jest.spyOn(client, "post").mockReturnValue(
-        new Promise((resolve, reject) => {
-          resolve({
-            data: {
-              originSurvey: {
-                WIZARD: defaultResult,
-              },
-            },
-          });
-        })
-      );
-      wrapper = shallow(<NPSFeedback origin="WIZARD" />);
-    });
+    expect(container.querySelector(".MuiFormHelperText-root")).toHaveTextContent(
+      `0 / ${maxLength}`
+    );
 
-    afterEach(() => {
-      wrapper.unmount();
-    });
+    await user.type(await screen.findByPlaceholderText(defaultResult.freeformPrompt), testValue);
 
-    it("renders", () => {
-      expect(wrapper).toBeDefined();
-    });
-
-    it("styles the submit button correctly", () => {
-      wrapper.find("EmojiRatings").dive().find("Styled(Component)").first().prop("onClick")(null);
-
-      wrapper.update();
-
-      expect(wrapper.find("Styled(Button)").prop("variant")).toBe("secondary");
-    });
+    expect(container.querySelector(".MuiFormHelperText-root")).toHaveTextContent(
+      `${testValue.trim().length} / ${maxLength}`
+    );
+    expect(await screen.findByPlaceholderText(defaultResult.freeformPrompt)).toHaveValue(testValue);
   });
 
-  describe("Header Origin Rendering", () => {
-    let wrapper;
-    let useEffect;
+  jest.setTimeout(30000);
+  test("will display an error on feedback if more input is given than maxLength", async () => {
+    const testValue = generateRandomString(FEEDBACK_MAX_LENGTH + 1);
+    const user = userEvent.setup();
+    const { container } = render(<NPSFeedback origin="WIZARD" />);
 
-    const mockUseEffect = () => {
-      useEffect.mockImplementationOnce(f => f());
-    };
+    user.click(await screen.findByLabelText(/Great/i));
 
-    beforeEach(() => {
-      useEffect = jest.spyOn(React, "useEffect");
-      mockUseEffect();
-      jest.spyOn(client, "post").mockReturnValue(
-        new Promise((resolve, reject) => {
-          resolve({
-            data: {
-              originSurvey: {
-                HEADER: defaultResult,
-              },
-            },
-          });
-        })
+    await waitFor(() => {
+      expect(container.querySelector(".MuiFormHelperText-root")).toHaveTextContent(
+        `0 / ${maxLength}`
       );
-      wrapper = shallow(<NPSFeedback origin="HEADER" feedbackTypes={feedbackTypes} />);
     });
 
-    afterEach(() => {
-      wrapper.unmount();
-    });
+    await user.type(await screen.findByPlaceholderText(defaultResult.freeformPrompt), testValue);
 
-    it("renders", () => {
-      expect(wrapper).toBeDefined();
-    });
+    expect(await screen.findByRole("textbox")).toHaveValue(testValue);
+    expect(container.querySelector(".MuiFormHelperText-root")).toHaveTextContent(
+      `${testValue.trim().length} / ${maxLength}`
+    );
+    expect(await screen.findByPlaceholderText(defaultResult.freeformPrompt)).toHaveValue(testValue);
+  });
 
-    it("styles the submit button correctly", () => {
-      clickEmoji(wrapper);
+  test("will disable the submit button upon error", async () => {
+    const testValue = generateRandomString(FEEDBACK_MAX_LENGTH + 1);
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="WIZARD" />);
 
-      expect(wrapper.find("Styled(Button)").prop("variant")).toBe("primary");
-    });
+    user.click(await screen.findByLabelText(/Great/i));
+
+    expect(await screen.findByText("Submit")).toBeEnabled();
+
+    await user.type(await screen.findByPlaceholderText(defaultResult.freeformPrompt), testValue);
+
+    expect(await screen.findByText("Submit")).toBeDisabled();
+  });
+});
+
+describe("Wizard Origin Rendering", () => {
+  beforeEach(() => {
+    jest.spyOn(client, "post").mockReturnValue(
+      new Promise((resolve, reject) => {
+        resolve({
+          data: {
+            originSurvey: {
+              WIZARD: defaultResult,
+            },
+          },
+        });
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders correctly", () => {
+    render(<NPSFeedback origin="WIZARD" />);
+
+    expect(screen.getByTestId("feedback-component")).toBeVisible();
+  });
+
+  test("styles the submit button correctly", async () => {
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="WIZARD" />);
+
+    user.click(await screen.findByLabelText(/Great/i));
+
+    expect(await screen.findByText("Submit")).toHaveStyle("background-color: transparent");
+  });
+});
+
+describe("Header Origin Rendering", () => {
+  beforeEach(() => {
+    jest.spyOn(client, "post").mockReturnValue(
+      new Promise((resolve, reject) => {
+        resolve({
+          data: {
+            originSurvey: {
+              HEADER: defaultResult,
+            },
+          },
+        });
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders correctly", () => {
+    render(<NPSFeedback origin="HEADER" feedbackTypes={feedbackTypes} />);
+
+    expect(screen.getByTestId("feedback-component")).toBeVisible();
+  });
+
+  test("styles the submit button correctly", async () => {
+    const user = userEvent.setup();
+    render(<NPSFeedback origin="HEADER" feedbackTypes={feedbackTypes} />);
+
+    user.click(await screen.findByLabelText(/Great/i));
+
+    expect(await screen.findByText("Submit")).toHaveStyle("background-color: #3548D4");
   });
 });

--- a/frontend/packages/core/src/NPS/tests/feedback.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/feedback.test.tsx
@@ -222,7 +222,9 @@ describe("basic rendering", () => {
       `0 / ${maxLength}`
     );
 
-    await user.type(await screen.findByPlaceholderText(defaultResult.freeformPrompt), testValue);
+    const textbox = await screen.findByPlaceholderText(defaultResult.freeformPrompt);
+    await user.click(textbox);
+    await user.paste(testValue);
 
     expect(container.querySelector(".MuiFormHelperText-root")).toHaveTextContent(
       `${testValue.trim().length} / ${maxLength}`
@@ -230,7 +232,6 @@ describe("basic rendering", () => {
     expect(await screen.findByPlaceholderText(defaultResult.freeformPrompt)).toHaveValue(testValue);
   });
 
-  jest.setTimeout(30000);
   test("will display an error on feedback if more input is given than maxLength", async () => {
     const testValue = generateRandomString(FEEDBACK_MAX_LENGTH + 1);
     const user = userEvent.setup();
@@ -244,13 +245,15 @@ describe("basic rendering", () => {
       );
     });
 
-    await user.type(await screen.findByPlaceholderText(defaultResult.freeformPrompt), testValue);
+    const textbox = await screen.findByPlaceholderText(defaultResult.freeformPrompt);
+    await user.click(textbox);
+    await user.paste(testValue);
 
     expect(await screen.findByRole("textbox")).toHaveValue(testValue);
     expect(container.querySelector(".MuiFormHelperText-root")).toHaveTextContent(
       `${testValue.trim().length} / ${maxLength}`
     );
-    expect(await screen.findByPlaceholderText(defaultResult.freeformPrompt)).toHaveValue(testValue);
+    expect(container.querySelector(".MuiFormHelperText-root")).toHaveClass("Mui-error");
   });
 
   test("will disable the submit button upon error", async () => {
@@ -262,7 +265,9 @@ describe("basic rendering", () => {
 
     expect(await screen.findByText("Submit")).toBeEnabled();
 
-    await user.type(await screen.findByPlaceholderText(defaultResult.freeformPrompt), testValue);
+    const textbox = await screen.findByPlaceholderText(defaultResult.freeformPrompt);
+    await user.click(textbox);
+    await user.paste(testValue);
 
     expect(await screen.findByText("Submit")).toBeDisabled();
   });

--- a/frontend/packages/core/src/NPS/tests/header.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/header.test.tsx
@@ -1,49 +1,30 @@
 import React from "react";
-import { matchers } from "@emotion/jest";
-import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
-import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import "@testing-library/jest-dom";
 
 import * as ApplicationContext from "../../Contexts/app-context";
 import contextValues from "../../Contexts/tests/testContext";
 import { NPSHeader } from "..";
 
-// Add the custom matchers provided by '@emotion/jest'
-expect.extend(matchers);
+beforeEach(() => {
+  jest.spyOn(ApplicationContext, "useAppContext").mockReturnValue(contextValues);
+  jest.useFakeTimers();
+});
 
-describe("<NPSHeader />", () => {
-  describe("basic rendering", () => {
-    let wrapper;
+test("renders correctly", () => {
+  render(<NPSHeader />);
 
-    beforeEach(() => {
-      jest.spyOn(ApplicationContext, "useAppContext").mockReturnValue(contextValues);
-      jest.useFakeTimers();
-      wrapper = shallow(<NPSHeader />);
-    });
+  expect(screen.getAllByRole("button")).toHaveLength(1);
+  expect(screen.getByRole("button")).toHaveAttribute("id", "headerFeedbackIcon");
+});
 
-    afterEach(() => {
-      wrapper.unmount();
-    });
+test("opens a popper on click of feedback icon", async () => {
+  const user = userEvent.setup({ delay: null });
+  render(<NPSHeader />);
 
-    it("renders", () => {
-      expect(wrapper.find(NPSHeader)).toBeDefined();
-    });
-
-    it("renders clickable feedback icon", () => {
-      const feedbackIcon = wrapper.find("#headerFeedbackIcon");
-      expect(feedbackIcon).toBeTruthy();
-      expect(feedbackIcon.children().contains(<ChatBubbleOutlineIcon />)).toBeTruthy();
-    });
-
-    it("opens a popper on click of feedback icon", () => {
-      const feedbackIcon = wrapper.find("#headerFeedbackIcon");
-
-      expect(wrapper.find("Styled(Component)").at(1).prop("open")).toBeFalsy();
-
-      feedbackIcon.prop("onClick")();
-
-      wrapper.update();
-
-      expect(wrapper.find("Styled(Component)").at(1).prop("open")).toBeTruthy();
-    });
-  });
+  const feedbackButton = await screen.findByRole("button");
+  await user.click(feedbackButton);
+  expect(screen.getByRole("tooltip")).toBeInTheDocument();
 });

--- a/frontend/packages/core/src/NPS/tests/wizard.test.tsx
+++ b/frontend/packages/core/src/NPS/tests/wizard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import "@testing-library/jest-dom";
@@ -61,22 +61,12 @@ test("renders the container with a bluish background", async () => {
 
 test("removes the bluish background", async () => {
   const user = userEvent.setup();
-  const { container } = render(<NPSWizard />);
+  render(<NPSWizard />);
 
-  let emojiButton;
-  await waitFor(() => {
-    emojiButton = container.querySelector('[aria-label="Great"]');
-    expect(emojiButton).toBeVisible();
-  });
-
-  if (!emojiButton) {
-    return;
-  }
-
+  const emojiButton = await screen.findByLabelText(/Great/i);
   await user.click(emojiButton);
 
   const submitButton = await screen.findByText("Submit");
-  expect(submitButton).toBeVisible();
   await user.click(submitButton);
 
   expect(screen.getByTestId("nps-wizard")).toHaveStyle({

--- a/frontend/packages/core/src/NPS/wizard.tsx
+++ b/frontend/packages/core/src/NPS/wizard.tsx
@@ -19,7 +19,7 @@ const NPSWizard = () => {
   const [hasSubmit, setSubmit] = useState<boolean>(false);
 
   return (
-    <NPSContainer $submit={hasSubmit}>
+    <NPSContainer $submit={hasSubmit} data-testid="nps-wizard">
       <NPSFeedback origin="WIZARD" onSubmit={setSubmit} />
     </NPSContainer>
   );


### PR DESCRIPTION
Migrated tests away from enzyme for the NPS related components (NPSWizard, NPSFeedback, NPSHeader and EmojiRatings).

<img width="636" alt="image" src="https://user-images.githubusercontent.com/5430603/214935301-e06a8bed-ef84-4f8a-bf5e-c6240762f35a.png">

### Testing Performed
manual