### PR TITLE
frontend: Modifying filtered workflows to be handled at the component level

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -15,7 +15,7 @@ import { useAppContext } from "../Contexts";
 import type { PopperItemProps } from "../popper";
 import { Popper, PopperItem } from "../popper";
 
-import { routesByGrouping, sortedGroupings, workflowByRoute } from "./utils";
+import { filterHiddenRoutes, routesByGrouping, sortedGroupings, workflowByRoute } from "./utils";
 
 // sidebar
 const DrawerPanel = styled(MuiDrawer)({
@@ -157,6 +157,7 @@ const Link: React.FC<LinkProps> = ({ to, text }) => {
 
 const Drawer: React.FC = () => {
   const { workflows } = useAppContext();
+  const filteredWorkflows = filterHiddenRoutes(workflows);
   const [activeWorkflow, setActiveWorkflow] = React.useState<Workflow>(null);
   const [openGroup, setOpenGroup] = React.useState("");
   const location = useLocation();
@@ -166,18 +167,18 @@ const Drawer: React.FC = () => {
   };
 
   React.useEffect(() => {
-    setActiveWorkflow(workflowByRoute(workflows, location.pathname));
+    setActiveWorkflow(workflowByRoute(filteredWorkflows, location.pathname));
   }, [location]);
 
   // Will hide the drawer if there are no visible workflows
-  if (!workflows.length) {
+  if (!filteredWorkflows.length) {
     return null;
   }
 
   return (
     <DrawerPanel data-qa="drawer" variant="permanent">
-      {sortedGroupings(workflows).map(grouping => {
-        const value = routesByGrouping(workflows)[grouping];
+      {sortedGroupings(filteredWorkflows).map(grouping => {
+        const value = routesByGrouping(filteredWorkflows)[grouping];
         const sortedWorkflows = _.sortBy(value.workflows, w => w.displayName);
 
         return (

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -21,7 +21,7 @@ import { useAppContext } from "../Contexts";
 import { useNavigate } from "../navigation";
 
 import type { SearchIndex } from "./utils";
-import { searchIndexes } from "./utils";
+import { filterHiddenRoutes, searchIndexes } from "./utils";
 
 const hotKey = "/";
 
@@ -197,7 +197,7 @@ const filterResults = (searchOptions: SearchIndex[], state: FilterOptionsState<S
 const SearchField: React.FC = () => {
   const { workflows } = useAppContext();
   const navigate = useNavigate();
-  const options = searchIndexes(workflows);
+  const options = searchIndexes(filterHiddenRoutes(workflows));
   const [inputValue, setInputValue] = React.useState("");
   const [showOptions, setShowOptions] = React.useState(false);
   const [open, setOpen] = React.useState(false);

--- a/frontend/packages/core/src/AppLayout/utils.tsx
+++ b/frontend/packages/core/src/AppLayout/utils.tsx
@@ -127,8 +127,8 @@ const searchIndexes = (workflows: Workflow[]): SearchIndex[] => {
 };
 
 /** Filter out all of the workflows that are configured to be `hideNav: true`.
- * This prevents the workflows from being discoverable by the user from the UI,
- * both search and drawer navigation.
+ * This prevents the workflows from being discoverable by the user from the UI where used.
+ * Some example usages are in the search and drawer navigation components.
  *
  * The routes for all configured workflows will still be reachable
  * by manually providing the full path in the URI.

--- a/frontend/packages/core/src/AppLayout/utils.tsx
+++ b/frontend/packages/core/src/AppLayout/utils.tsx
@@ -1,4 +1,5 @@
 import type { Route, Workflow } from "../AppProvider/workflow";
+import * as _ from "lodash";
 
 interface GroupedRoutes {
   [category: string]: {
@@ -124,4 +125,27 @@ const searchIndexes = (workflows: Workflow[]): SearchIndex[] => {
   return indexOptions;
 };
 
-export { routesByGrouping, searchIndexes, sortedGroupings, workflowByRoute, workflowsByTrending };
+/** Filter out all of the workflows that are configured to be `hideNav: true`.
+ * This prevents the workflows from being discoverable by the user from the UI,
+ * both search and drawer navigation.
+ *
+ * The routes for all configured workflows will still be reachable
+ * by manually providing the full path in the URI.
+ */
+const filterHiddenRoutes = (workflows: Workflow[]): Workflow[] =>
+  _.cloneDeep(workflows).filter(workflow => {
+    const publicRoutes = workflow.routes.filter(route => {
+      return !(route?.hideNav !== undefined ? route.hideNav : false);
+    });
+    workflow.routes = publicRoutes; /* eslint-disable-line no-param-reassign */
+    return publicRoutes.length !== 0;
+  });
+
+export {
+  filterHiddenRoutes,
+  routesByGrouping,
+  searchIndexes,
+  sortedGroupings,
+  workflowByRoute,
+  workflowsByTrending,
+};

--- a/frontend/packages/core/src/AppLayout/utils.tsx
+++ b/frontend/packages/core/src/AppLayout/utils.tsx
@@ -1,5 +1,6 @@
-import type { Route, Workflow } from "../AppProvider/workflow";
 import * as _ from "lodash";
+
+import type { Route, Workflow } from "../AppProvider/workflow";
 
 interface GroupedRoutes {
   [category: string]: {

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -92,25 +92,12 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
 
   const [discoverableWorkflows, setDiscoverableWorkflows] = React.useState([]);
   React.useEffect(() => {
-    /** Filter out all of the workflows that are configured to be `hideNav: true`.
-     * This prevents the workflows from being discoverable by the user from the UI,
-     * both search and drawer navigation.
-     *
-     * The routes for all configured workflows will still be reachable
-     * by manually providing the full path in the URI.
-     */
-    const pw = _.cloneDeep(workflows).filter(workflow => {
+    const filteredWorkflows = workflows.filter(workflow => workflow.path === "");
+    if (filteredWorkflows.length > 0) {
       /** Used to control a custom landing page */
-      if (workflow.path === "") {
-        setHasCustomLanding(true);
-      }
-      const publicRoutes = workflow.routes.filter(route => {
-        return !(route?.hideNav !== undefined ? route.hideNav : false);
-      });
-      workflow.routes = publicRoutes; /* eslint-disable-line no-param-reassign */
-      return publicRoutes.length !== 0;
-    });
-    setDiscoverableWorkflows(pw);
+      setHasCustomLanding(true);
+    }
+    setDiscoverableWorkflows(workflows);
   }, [workflows]);
 
   const shortLinkProviderProps: ShortLinkContextProps = React.useMemo(

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -92,7 +92,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
   const [discoverableWorkflows, setDiscoverableWorkflows] = React.useState([]);
   React.useEffect(() => {
     const landingWorkflows = workflows.filter(workflow => workflow.path === "");
-    if (filteredWorkflows.length > 0) {
+    if (landingWorkflows.length > 0) {
       /** Used to control a custom landing page */
       setHasCustomLanding(true);
     }

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -91,7 +91,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
 
   const [discoverableWorkflows, setDiscoverableWorkflows] = React.useState([]);
   React.useEffect(() => {
-    const filteredWorkflows = workflows.filter(workflow => workflow.path === "");
+    const landingWorkflows = workflows.filter(workflow => workflow.path === "");
     if (filteredWorkflows.length > 0) {
       /** Used to control a custom landing page */
       setHasCustomLanding(true);

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { BrowserRouter as Router, Outlet, Route, Routes } from "react-router-dom";
-import _ from "lodash";
 
 import AppLayout from "../AppLayout";
 import { ApplicationContext, ShortLinkContext } from "../Contexts";

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -76,6 +76,8 @@ export interface Route {
   requiredConfigProps?: string[];
   /** Is the workflow discoverable via search and drawer navigation. This defaults to false. */
   hideNav?: boolean;
+  /** Is the workflow shown in the NPS header. This defaults to false. Only active if hideNav is true. */
+  showInNPS?: boolean;
   /**
    * The feature flag used to determine if the route should be registered.
    *

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -76,8 +76,6 @@ export interface Route {
   requiredConfigProps?: string[];
   /** Is the workflow discoverable via search and drawer navigation. This defaults to false. */
   hideNav?: boolean;
-  /** Is the workflow shown in the NPS header. This defaults to false. Only active if hideNav is true. */
-  showInNPS?: boolean;
   /**
    * The feature flag used to determine if the route should be registered.
    *

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -59,20 +59,20 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
     const { group, path, routes, displayName } = workflow;
 
     routes.forEach(route => {
-      if (
-        route.hideNav === undefined ||
-        route.hideNav === false ||
-        (route.hideNav === true && route.showInNPS === true)
-      ) {
+      const additionalNPS = get(route, "componentProps.additionalNPS", []);
+
+      if (route.hideNav === undefined || route.hideNav === false || additionalNPS) {
         if (!typeMap[group]) {
           typeMap[group] = [];
         }
 
-        typeMap[group].push({
-          label: route.displayName || displayName,
-          value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
-        });
-        const additionalNPS = get(route, "componentProps.additionalNPS", []);
+        if (route.hideNav === undefined || route.hideNav === false) {
+          typeMap[group].push({
+            label: route.displayName || displayName,
+            value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
+          });
+        }
+
         if (additionalNPS) {
           typeMap[group].push(...additionalNPS);
         }

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -61,12 +61,13 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
     routes.forEach(route => {
       const additionalNPS = get(route, "componentProps.additionalNPS", []);
 
-      if (route.hideNav === undefined || route.hideNav === false || additionalNPS.length > 0) {
+      const showRoute = route.hideNav === undefined || route.hideNav === false;
+      if (showRoute || additionalNPS.length > 0) {
         if (!typeMap[group]) {
           typeMap[group] = [];
         }
 
-        if (route.hideNav === undefined || route.hideNav === false) {
+        if (showRoute) {
           typeMap[group].push({
             label: route.displayName || displayName,
             value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -61,7 +61,7 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
     routes.forEach(route => {
       const additionalNPS = get(route, "componentProps.additionalNPS", []);
 
-      if (route.hideNav === undefined || route.hideNav === false || additionalNPS) {
+      if (route.hideNav === undefined || route.hideNav === false || additionalNPS.length > 0) {
         if (!typeMap[group]) {
           typeMap[group] = [];
         }

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -58,16 +58,16 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
   workflows.forEach(workflow => {
     const { group, path, routes, displayName } = workflow;
 
-    if (!typeMap[group]) {
-      typeMap[group] = [];
-    }
-
     routes.forEach(route => {
       if (
         route.hideNav === undefined ||
         route.hideNav === false ||
         (route.hideNav === true && route.showInNPS === true)
       ) {
+        if (!typeMap[group]) {
+          typeMap[group] = [];
+        }
+
         typeMap[group].push({
           label: route.displayName || displayName,
           value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -63,14 +63,19 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
     }
 
     routes.forEach(route => {
-      typeMap[group].push({
-        label: route.displayName || displayName,
-        value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
-      });
-
-      const additionalNPS = get(route, "componentProps.additionalNPS", []);
-      if (additionalNPS) {
-        typeMap[group].push(...additionalNPS);
+      if (
+        route.hideNav === undefined ||
+        route.hideNav === false ||
+        (route.hideNav === true && route.showInNPS === true)
+      ) {
+        typeMap[group].push({
+          label: route.displayName || displayName,
+          value: `/${path}/${route.path}`.replace(/\/\/+/g, "/"),
+        });
+        const additionalNPS = get(route, "componentProps.additionalNPS", []);
+        if (additionalNPS) {
+          typeMap[group].push(...additionalNPS);
+        }
       }
     });
   });

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -73,7 +73,7 @@ export const generateFeedbackTypes = (workflows: Workflow[]): SelectOption[] => 
           });
         }
 
-        if (additionalNPS) {
+        if (additionalNPS.length > 0) {
           typeMap[group].push(...additionalNPS);
         }
       }


### PR DESCRIPTION
### Description
Noticed we were having some issues if `hideNav: true` was set in our configuration then it would not show up in the NPS Header, however this was a necessary step to remove the item from the drawers and eventually hide them.

So this PR does a few things:

- Adds a new filterHiddenRoutes to our utils file in AppLayout, this function has the same functionality as the old one in AppProvider
- Removed the filtering in AppProvider and left the landing page check
- Modified the Search Component to use the new filterHiddenRoutes function
- Modified the Drawers Component to use the new filterHiddenRoutes function
- Modified the NPS Header Component to add to the dropdown if either `hideNav: false` or `additionalNPS` is set

### Testing Performed
manual