### PR TITLE
frontend: add children prop to error component

### DIFF
--- a/frontend/packages/core/src/Feedback/error/index.tsx
+++ b/frontend/packages/core/src/Feedback/error/index.tsx
@@ -47,9 +47,10 @@ const OpenInNewIcon = styled(MuiOpenInNewIcon)({
 export interface ErrorProps {
   subject: ClutchError;
   onRetry?: () => void;
+  children?: React.ReactChild | React.ReactChildren;
 }
 
-const Error = ({ subject: error, onRetry }: ErrorProps) => {
+const Error = ({ subject: error, onRetry, children }: ErrorProps) => {
   const action =
     onRetry !== undefined ? (
       <IconButton aria-label="retry" color="inherit" size="small" onClick={() => onRetry()}>
@@ -61,6 +62,7 @@ const Error = ({ subject: error, onRetry }: ErrorProps) => {
     return (
       <Alert severity="error" title={error.status?.text} action={action}>
         {error.message}
+        {children}
       </Alert>
     );
   }

--- a/frontend/packages/core/src/Feedback/error/index.tsx
+++ b/frontend/packages/core/src/Feedback/error/index.tsx
@@ -62,7 +62,7 @@ const Error = ({ subject: error, onRetry, children }: ErrorProps) => {
     return (
       <Alert severity="error" title={error.status?.text} action={action}>
         {error.message}
-        {children}
+        {children && children}
       </Alert>
     );
   }

--- a/frontend/packages/core/src/Feedback/error/stories/error.stories.tsx
+++ b/frontend/packages/core/src/Feedback/error/stories/error.stories.tsx
@@ -164,3 +164,15 @@ WithWrappedDetails.args = {
   },
   onRetry: action("retry-click"),
 };
+
+export const WithChildren = Template.bind({});
+WithChildren.args = {
+  subject: {
+    status: {
+      code: 500,
+      text: "Client Error",
+    },
+    message: "Request exceeded timed out of 1 ms",
+  },
+  children: <h4>This message is complimentary to the error</h4>,
+};

--- a/frontend/packages/core/src/Feedback/error/stories/error.stories.tsx
+++ b/frontend/packages/core/src/Feedback/error/stories/error.stories.tsx
@@ -172,7 +172,7 @@ WithChildren.args = {
       code: 500,
       text: "Client Error",
     },
-    message: "Request exceeded timed out of 1 ms",
+    message: "Request exceeded timeout of 1 ms",
   },
   children: <h4>This message is complimentary to the error</h4>,
 };


### PR DESCRIPTION
### Description
In order to allow additional content to complement an error message, this prop allows to pass children to the Error component.

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/5430603/216691360-59456865-9ada-481d-bf8e-6c60df2cd47b.png">

### Testing Performed
manual