### PR TITLE
Remove host name from label since only address is supported

### DIFF
--- a/frontend/workflows/envoy/src/remote-triage/index.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/index.tsx
@@ -48,7 +48,7 @@ const TriageIdentifier: React.FC<TriageChild> = ({ host = "" }) => {
   return (
     <>
       <TextField
-        label="IP Address or Hostname"
+        label="IP Address"
         placeholder="127.0.0.1"
         onChange={e => resourceData.updateData("host", e.target.value)}
         onReturn={onSubmit}


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Right now the label implies that you can put in a host name, but that might be confusing.

<img width="672" alt="Screenshot 2023-02-07 at 09 40 31" src="https://user-images.githubusercontent.com/66325812/217323624-55c59ed0-d4bc-4a39-9746-13cc68ecc1f6.png">

![Screenshot 2023-02-07 at 09 41 25](https://user-images.githubusercontent.com/66325812/217323663-9449aae5-807a-4fe6-880c-700a833a37b3.png)


<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
