### PR TITLE
frontend: migrate charts tests to rtl

### DIFF
--- a/frontend/packages/core/src/Charts/tests/timeseries.test.tsx
+++ b/frontend/packages/core/src/Charts/tests/timeseries.test.tsx
@@ -1,100 +1,179 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { render, waitFor } from "@testing-library/react";
+
+import "@testing-library/jest-dom";
 
 import { TimeseriesChart } from "..";
 
-describe("<TimeseriesChart />", () => {
-  describe("basic rendering", () => {
-    const mockDataSingleLine = [
-      {
-        lineName: "line1",
-        timestamp: 1546300800000,
-        value: 5,
-      },
-      {
-        lineName: "line1",
-        timestamp: 1546300900000,
-        value: 20,
-      },
-      {
-        lineName: "line1",
-        timestamp: 1546301000000,
-        value: 30,
-      },
-      {
-        lineName: "line1",
-        timestamp: 1546300700000,
-        value: 5,
-      },
-      {
-        lineName: "line1",
-        timestamp: 1546300600000,
-        value: 20,
-      },
-      {
-        lineName: "line1",
-        timestamp: 1546301800000,
-        value: 30,
-      },
-    ];
+jest.mock("recharts", () => {
+  const OriginalModule = jest.requireActual("recharts");
+  return {
+    ...OriginalModule,
+    ResponsiveContainer: ({ children }) => (
+      <OriginalModule.ResponsiveContainer width={400} height={200}>
+        {children}
+      </OriginalModule.ResponsiveContainer>
+    ),
+  };
+});
 
-    const mockLines = [
-      {
-        dataKey: "value",
-        color: "red",
-        animationDuration: 0,
-      },
-    ];
+const mockDataSingleLine = [
+  {
+    lineName: "line1",
+    timestamp: 1546300800000,
+    value: 5,
+  },
+  {
+    lineName: "line1",
+    timestamp: 1546300900000,
+    value: 20,
+  },
+  {
+    lineName: "line1",
+    timestamp: 1546301000000,
+    value: 30,
+  },
+  {
+    lineName: "line1",
+    timestamp: 1546300700000,
+    value: 5,
+  },
+  {
+    lineName: "line1",
+    timestamp: 1546300600000,
+    value: 20,
+  },
+  {
+    lineName: "line1",
+    timestamp: 1546301800000,
+    value: 30,
+  },
+];
 
-    let timeseriesChart;
-    beforeEach(() => {
-      timeseriesChart = shallow(
-        <TimeseriesChart
-          data={mockDataSingleLine}
-          xAxisDataKey="timestamp"
-          yAxisDataKey="value"
-          lines={mockLines}
-          xDomainSpread={0.3}
-          yDomainSpread={0.3}
-          regularIntervalTicks
-        />
-      );
-    });
+const mockLines = [
+  {
+    dataKey: "value",
+    color: "red",
+    animationDuration: 0,
+  },
+];
 
-    it("renders", () => {
-      expect(timeseriesChart.find(TimeseriesChart)).toBeDefined();
-    });
+const setup = () =>
+  render(
+    <TimeseriesChart
+      data={mockDataSingleLine}
+      xAxisDataKey="timestamp"
+      yAxisDataKey="value"
+      lines={mockLines}
+      xDomainSpread={0.3}
+      yDomainSpread={0.3}
+      regularIntervalTicks
+    />
+  );
 
-    it("renders XAxis with type number property", () => {
-      expect(timeseriesChart.find("XAxis").props().type).toBe("number");
-    });
+test("renders correctly", () => {
+  const { container } = setup();
 
-    it("renders YAxis with type number property", () => {
-      expect(timeseriesChart.find("YAxis").props().type).toBe("number");
-    });
+  expect(container.querySelector(".recharts-responsive-container")).toBeVisible();
+});
 
-    it("renders a Cartesian Grid", () => {
-      expect(timeseriesChart.find("CartesianGrid")).toBeDefined();
-    });
+test("renders a Cartesian Grid", async () => {
+  const { container } = setup();
 
-    it("renders a line with line type linear", () => {
-      expect(timeseriesChart.find("Line").prop("type")).toBe("linear");
-    });
-
-    it("renders a line with red stroke", () => {
-      expect(timeseriesChart.find("Line").prop("stroke")).toBe("red");
-    });
-
-    it("renders the x axis with 5 ticks", () => {
-      expect(timeseriesChart.find("XAxis").prop("tickCount")).toBe(5);
-    });
-
-    it("renders the y axis with 5 ticks", () => {
-      expect(timeseriesChart.find("YAxis").prop("tickCount")).toBe(5);
-    });
-
-    it("renders one line", () => {
-      expect(timeseriesChart.find("Line")).toHaveLength(1);
-    });
+  await waitFor(() => {
+    expect(container.querySelector(".recharts-cartesian-grid")).toBeDefined();
   });
+});
+
+test("renders a horizontal Cartesian Grid", async () => {
+  const { container } = setup();
+
+  await waitFor(() => {
+    expect(container.querySelector(".recharts-cartesian-grid-horizontal")).toBeDefined();
+    expect(
+      container.querySelectorAll(".recharts-cartesian-grid-horizontal line").length
+    ).toBeGreaterThan(0);
+  });
+});
+
+test("renders a vertical Cartesian Grid", async () => {
+  const { container } = setup();
+
+  await waitFor(() => {
+    expect(container.querySelector(".recharts-cartesian-grid-vertical")).toBeDefined();
+    expect(
+      container.querySelectorAll(".recharts-cartesian-grid-vertical line").length
+    ).toBeGreaterThan(0);
+  });
+});
+
+test("renders xAxis with type number property", async () => {
+  const { container } = setup();
+
+  await waitFor(() => {
+    expect(
+      container.querySelector(".recharts-xAxis .recharts-cartesian-axis-line")
+    ).toHaveAttribute("type", "number");
+  });
+});
+
+test("renders yAxis with type number property", async () => {
+  const { container } = setup();
+
+  await waitFor(() => {
+    expect(
+      container.querySelector(".recharts-yAxis .recharts-cartesian-axis-line")
+    ).toHaveAttribute("type", "number");
+  });
+});
+
+test("renders the x axis with 5 ticks", async () => {
+  const { container } = setup();
+
+  await waitFor(() => {
+    expect(
+      container.querySelector(".recharts-xAxis .recharts-cartesian-axis-ticks")?.childElementCount
+    ).toBe(5);
+  });
+});
+
+test("renders the y axis with 5 ticks", async () => {
+  const { container } = setup();
+
+  await waitFor(() => {
+    expect(
+      container.querySelector(".recharts-yAxis .recharts-cartesian-axis-ticks")?.childElementCount
+    ).toBe(5);
+  });
+});
+
+test("renders one line", async () => {
+  const { container } = setup();
+
+  await waitFor(() => {
+    const chartLines = container.querySelectorAll(".recharts-line-curve");
+    expect(chartLines).toHaveLength(1);
+  });
+});
+
+test("renders a line with line type linear", async () => {
+  const { container } = setup();
+
+  let chartLine;
+  await waitFor(() => {
+    [chartLine] = container.querySelectorAll(".recharts-line-curve");
+  });
+
+  expect(chartLine).toHaveAttribute("type", "linear");
+});
+
+test("renders a line with red stroke", async () => {
+  const { container } = setup();
+
+  let chartLine;
+  await waitFor(() => {
+    [chartLine] = container.querySelectorAll(".recharts-line-curve");
+  });
+
+  expect(chartLine).toHaveAttribute("stroke", "red");
 });


### PR DESCRIPTION
### Description
As part of the ongoing migration away from enzyme and into RTL, this PR updates the tests for the TimeseriesChart component.

As an alternative to checking for components and their prop values, I'm relying in querySelectors to target classes assigned by recharts and attributes in the generated elements.

<img width="373" alt="image" src="https://user-images.githubusercontent.com/5430603/218158109-bde7005c-b45c-478d-8788-432d732c69fa.png">

### Testing Performed
manual