### PR TITLE
frontend: set color for single project links

### DIFF
--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -47,6 +47,7 @@ const StyledMoreVertIcon = styled.span({
 const StyledLinkTitle = styled.span({
   fontWeight: "bold",
   padding: "7px 0px",
+  color: "#2D3F50",
 });
 
 const StyledMultiLinkTitle = styled.span({


### PR DESCRIPTION
### Description
The top level single elements in the ProjectLinks dropdown have a different color from the entries with children. This PR adds the same color to those elements to unify them.
Suggested by @smonero 🙌 

Before:
<img width="164" alt="image" src="https://user-images.githubusercontent.com/5430603/220423064-b517a5e5-5df9-4820-84d5-6ebdc9264e91.png">

After:
<img width="163" alt="image" src="https://user-images.githubusercontent.com/5430603/220422001-ab654438-a31d-4007-9782-7bd61d63f40d.png">

Hover:
<img width="164" alt="image" src="https://user-images.githubusercontent.com/5430603/220422124-9feaa9ba-468f-4280-90b2-5b17945b6d1c.png">

### Testing Performed
manual