### PR TITLE
frontend: NPS Header fixing close behavior

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -115,9 +115,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
         // Will set the open status and spread any additional data onto the property named after the item
         setTriggeredHeaderData({
           ...triggeredHeaderData,
-          [item]: {
-            ...(data as any),
-          },
+          [item]: data as any,
         }),
       triggeredHeaderData,
     }),

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -7,7 +7,7 @@ import {
   Paper as MuiPaper,
   Popper as MuiPopper,
 } from "@mui/material";
-import { get, sortBy } from "lodash";
+import { get, isEmpty, sortBy } from "lodash";
 
 import type { Workflow } from "../AppProvider/workflow";
 import { IconButton } from "../button";
@@ -104,8 +104,14 @@ const HeaderFeedback = () => {
     setOpen(!open);
   };
 
+  const timedClose = () => {
+    setTimeout(() => {
+      setOpen(false);
+    }, 1500);
+  };
+
   React.useEffect(() => {
-    if (triggeredHeaderData && triggeredHeaderData.NPS) {
+    if (triggeredHeaderData && !isEmpty(triggeredHeaderData.NPS)) {
       setDefaultFeedbackOption((triggeredHeaderData.NPS.defaultFeedbackOption as string) ?? "");
       setOpen(true);
     }
@@ -153,6 +159,7 @@ const HeaderFeedback = () => {
                     origin="HEADER"
                     feedbackTypes={generateFeedbackTypes(workflows)}
                     defaultFeedbackOption={defaultFeedbackOption}
+                    onSubmit={timedClose}
                   />
                 </MenuList>
               </ClickAwayListener>

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -7,7 +7,7 @@ import {
   Paper as MuiPaper,
   Popper as MuiPopper,
 } from "@mui/material";
-import { get, isEmpty, sortBy } from "lodash";
+import { get, sortBy } from "lodash";
 
 import type { Workflow } from "../AppProvider/workflow";
 import { IconButton } from "../button";

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -99,13 +99,14 @@ const HeaderFeedback = () => {
   const anchorRef = React.useRef(null);
   const { workflows, triggerHeaderItem, triggeredHeaderData } = useAppContext();
   const [defaultFeedbackOption, setDefaultFeedbackOption] = React.useState<string>();
+  const timer = React.useRef(null);
 
   const handleToggle = () => {
     setOpen(!open);
   };
 
   const timedClose = () => {
-    setTimeout(() => {
+    timer.current = setTimeout(() => {
       setOpen(false);
     }, 1500);
   };
@@ -129,6 +130,7 @@ const HeaderFeedback = () => {
     if (event.target.id !== "nps-banner-button") {
       triggerHeaderItem && triggerHeaderItem("NPS", {});
       setOpen(false);
+      clearTimeout(timer.current);
     }
   };
 

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -112,7 +112,7 @@ const HeaderFeedback = () => {
   };
 
   React.useEffect(() => {
-    if (triggeredHeaderData && !isEmpty(triggeredHeaderData.NPS)) {
+    if (triggeredHeaderData && triggeredHeaderData.NPS) {
       setDefaultFeedbackOption((triggeredHeaderData.NPS.defaultFeedbackOption as string) ?? "");
       setOpen(true);
     }
@@ -128,7 +128,7 @@ const HeaderFeedback = () => {
     }
     // handler for the NPS Banner button so that it doesn't reset the headerLink
     if (event.target.id !== "nps-banner-button") {
-      triggerHeaderItem && triggerHeaderItem("NPS", {});
+      triggerHeaderItem && triggerHeaderItem("NPS", undefined);
       setOpen(false);
       clearTimeout(timer.current);
     }


### PR DESCRIPTION
### Description
Was found that the NPS header was not closing when clicking outside of the container after submission. This was due to the new NPS Feedback Banner open behavior which was being retriggered and keeping it open. Also decided to put in a timeout to auto-close the feedback submission.

### Testing Performed
manual
