### PR TITLE
frontend: ProjectSelector - Adjusting Single Quick Link color

### DIFF
--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -44,13 +44,8 @@ const StyledMoreVertIcon = styled.span({
   },
 });
 
-const StyledLinkTitle = styled.span({
-  fontWeight: "bold",
+const StyledLinkTitle = styled(Typography)({
   padding: "7px 0px",
-});
-
-const StyledMultiLinkTitle = styled.span({
-  fontWeight: "bold",
 });
 
 const StyledLinkBox = styled.div({
@@ -103,7 +98,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
             alt={validLinks[0].name ?? `Quick Link to ${validLinks[0].url}`}
           />
         </StyledCenterImgSpan>
-        <StyledLinkTitle>{linkGroupName}</StyledLinkTitle>
+        <StyledLinkTitle variant="h6">{linkGroupName}</StyledLinkTitle>
       </Link>
     </StyledMenuItem>
   ) : (
@@ -112,7 +107,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
         <StyledMultilinkImage>
           <img width={ICON_SIZE} height={ICON_SIZE} src={linkGroupImage} alt={linkGroupName} />
         </StyledMultilinkImage>
-        <StyledMultiLinkTitle>{linkGroupName}</StyledMultiLinkTitle>
+        <Typography variant="h6">{linkGroupName}</Typography>
       </StyledMultilinkHeader>
       <div>
         {validLinks.map(link => {


### PR DESCRIPTION
### Description
We noticed that for the QuickLinks the single links were showing up as a different color than the multi-group links. This modifies both to use an h6 typography variant which fixes the color issue and keeps them aligned with each other.

#### Before
![Screenshot 2023-02-22 at 3 28 03 PM](https://user-images.githubusercontent.com/8338893/220786724-33e717de-0cbf-4cf9-9f7b-5cd4f171327c.png)

#### After
![Screenshot 2023-02-22 at 3 27 50 PM](https://user-images.githubusercontent.com/8338893/220786730-43a4db18-e789-4e29-b236-19f2689dccb6.png)


### Testing Performed
manual
