### PR TITLE
frontend: allow table row to receive extra props

### DIFF
--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -206,8 +206,9 @@ const TableRow = ({
   cellDefault,
   responsive = false,
   colSpan,
+  ...props
 }: TableRowProps) => (
-  <StyledTableRow onClick={onClick} $responsive={responsive}>
+  <StyledTableRow onClick={onClick} $responsive={responsive} {...props}>
     {React.Children.map(children, (value, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <StyledTableCell key={index} $responsive={responsive} colSpan={colSpan}>


### PR DESCRIPTION
### Description
The TableRow component currently can't receive additional props, which can be useful when trying to apply styles at this component's level in a table, such as a grayed out look for a disabled state. This PR adds such behavior.

### Testing Performed
manual