### PR TITLE
frontend: K8s scale resources workflow

### DIFF
--- a/frontend/packages/app/src/clutch.config.js
+++ b/frontend/packages/app/src/clutch.config.js
@@ -60,6 +60,12 @@ module.exports = {
     kubeDashboard: {
       trending: true,
     },
+    scaleResources: {
+      trending: true,
+      componentProps: {
+        resolverType: "clutch.k8s.v1.Deployment",
+      },
+    },
     cordonNode: {
       trending: true,
       componentProps: {

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -5,6 +5,7 @@ import CordonNode from "./cordon-node";
 import DeletePod from "./delete-pod";
 import KubeDashboard from "./k8s-dashboard";
 import ResizeHPA from "./resize-hpa";
+import ScaleResources from "./scale-resources";
 
 interface ResolverConfigProps {
   resolverType: string;
@@ -42,6 +43,13 @@ const register = (): WorkflowConfiguration => {
         displayName: "Resize HPA",
         description: "Resize a horizontal autoscaler.",
         component: ResizeHPA,
+        requiredConfigProps: ["resolverType"],
+      },
+      scaleResources: {
+        path: "scale/resources",
+        displayName: "Scale Resources",
+        description: "Scale CPU and memory requests and limits.",
+        component: ScaleResources,
         requiredConfigProps: ["resolverType"],
       },
       kubeDashboard: {

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -46,7 +46,7 @@ const register = (): WorkflowConfiguration => {
         requiredConfigProps: ["resolverType"],
       },
       scaleResources: {
-        path: "scale/resources",
+        path: "resources/scale",
         displayName: "Scale Resources",
         description: "Scale CPU and memory requests and limits.",
         component: ScaleResources,

--- a/frontend/workflows/k8s/src/scale-resources.tsx
+++ b/frontend/workflows/k8s/src/scale-resources.tsx
@@ -1,0 +1,286 @@
+import React from "react";
+import type { clutch as IClutch } from "@clutch-sh/api";
+import {
+  Button,
+  ButtonGroup,
+  client,
+  Confirmation,
+  MetadataTable,
+  Resolver,
+  Select,
+  useWizardContext,
+} from "@clutch-sh/core";
+import { useDataLayout } from "@clutch-sh/data-layout";
+import type { WizardChild } from "@clutch-sh/wizard";
+import { Wizard, WizardStep } from "@clutch-sh/wizard";
+import { string } from "yup";
+
+import type { ConfirmChild, ResolverChild, WorkflowProps } from ".";
+
+const QUANTITY_REGEX = /^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$/;
+
+const DeploymentIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
+  const { onSubmit } = useWizardContext();
+  const deploymentData = useDataLayout("deploymentData");
+  const inputData = useDataLayout("inputData");
+
+  const onResolve = ({ results, input }) => {
+    // Decide how to process results.
+    deploymentData.assign(results[0]);
+    inputData.assign(input);
+    onSubmit();
+  };
+
+  return <Resolver type={resolverType} searchLimit={1} onResolve={onResolve} />;
+};
+
+const DeploymentDetails: React.FC<WizardChild> = () => {
+  const { onSubmit, onBack } = useWizardContext();
+  const deploymentData = useDataLayout("deploymentData");
+  const deployment = deploymentData.displayValue() as IClutch.k8s.v1.Deployment;
+  const update = (key: string, value: boolean) => {
+    deploymentData.updateData(key, value);
+  };
+
+  const currentDeploymentData = useDataLayout("currentDeploymentData");
+
+  const [containerName, setContainerName] = React.useState(
+    deployment.deploymentSpec.template.spec.containers[0].name
+  );
+
+  const [containerIndex, setContainerIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    // save the original values of deployment spec
+    if (deployment) {
+      currentDeploymentData.assign(deployment);
+    }
+  }, []);
+
+  return (
+    <WizardStep error={deploymentData.error} isLoading={deploymentData.isLoading}>
+      <strong>Deployment Details</strong>
+      <MetadataTable
+        onUpdate={update}
+        data={[
+          { name: "Name", value: deployment.name },
+          { name: "Namespace", value: deployment.namespace },
+          {
+            name: "Container Name",
+            value: (
+              <Select
+                label="Container Name"
+                name="containerName"
+                onChange={value => {
+                  setContainerName(value);
+                  setContainerIndex(
+                    deployment.deploymentSpec.template.spec.containers.findIndex(
+                      container => container.name === value
+                    )
+                  );
+                  deploymentData.updateData("containerName", value);
+                }}
+                options={deployment.deploymentSpec.template.spec.containers.map(container => {
+                  return { label: container.name };
+                })}
+              />
+            ),
+          },
+          {
+            name: "CPU Limit",
+            value: deployment.deploymentSpec.template.spec.containers.find(
+              container => container.name === containerName
+            ).resources.limits.cpu,
+            textFieldLabels: {
+              disabledField: "Current Limit",
+              updatedField: "New limit",
+            },
+            input: {
+              type: "string",
+              key: `deploymentSpec.template.spec.containers[${containerIndex}].resources.limits.cpu`,
+              validation: string().matches(QUANTITY_REGEX),
+            },
+          },
+          {
+            name: "CPU Request",
+            value: deployment.deploymentSpec.template.spec.containers.find(
+              container => container.name === containerName
+            ).resources.requests.cpu,
+            textFieldLabels: {
+              disabledField: "Current Request",
+              updatedField: "New Request",
+            },
+            input: {
+              type: "string",
+              key: `deploymentSpec.template.spec.containers[${containerIndex}].resources.requests.cpu`,
+              validation: string().matches(QUANTITY_REGEX),
+            },
+          },
+          {
+            name: "Memory Limit",
+            value: deployment.deploymentSpec.template.spec.containers.find(
+              container => container.name === containerName
+            ).resources.limits.memory,
+            textFieldLabels: {
+              disabledField: "Current Limit",
+              updatedField: "New limit",
+            },
+            input: {
+              type: "string",
+              key: `deploymentSpec.template.spec.containers[${containerIndex}].resources.limits.memory`,
+              validation: string().matches(QUANTITY_REGEX),
+            },
+          },
+          {
+            name: "Memory Request",
+            value: deployment.deploymentSpec.template.spec.containers.find(
+              container => container.name === containerName
+            ).resources.requests.memory,
+            textFieldLabels: {
+              disabledField: "Current Request",
+              updatedField: "New Request",
+            },
+            input: {
+              type: "string",
+              key: `deploymentSpec.template.spec.containers[${containerIndex}].resources.requests.memory`,
+              validation: string().matches(QUANTITY_REGEX),
+            },
+          },
+        ]}
+      />
+      <ButtonGroup>
+        <Button text="Back" variant="neutral" onClick={() => onBack()} />
+        <Button text="Update" variant="destructive" onClick={onSubmit} />
+      </ButtonGroup>
+    </WizardStep>
+  );
+};
+
+function fortmatResourceString(resourceName: string, resourceRequirement: string): string {
+  // Capitalize the first letter of resourceName
+  const capitalizedResourceName = resourceName.charAt(0).toUpperCase() + resourceName.slice(1);
+
+  // Capitalize and remove the s at the end of resourceRequirement
+  const modifiedResourceRequirement =
+    resourceRequirement.charAt(0).toUpperCase() + resourceRequirement.slice(1, -1);
+
+  // Return the modified strings
+  return `${capitalizedResourceName} ${modifiedResourceRequirement}`;
+}
+
+const Confirm: React.FC<ConfirmChild> = () => {
+  const deployment = useDataLayout("deploymentData").displayValue() as IClutch.k8s.v1.Deployment;
+  const updateData = useDataLayout("updateData");
+  const currentDeploymentData = useDataLayout(
+    "currentDeploymentData"
+  ).displayValue() as IClutch.k8s.v1.Deployment;
+
+  const updateRows: any[] = [];
+
+  let updatedContainer = false;
+  deployment.deploymentSpec.template.spec.containers.forEach(container => {
+    Object.keys(container.resources).forEach(resourceRequirement => {
+      Object.keys(container.resources[resourceRequirement]).forEach(resourceName => {
+        const newValue = container.resources[resourceRequirement][resourceName];
+        const oldValue = currentDeploymentData.deploymentSpec.template.spec.containers.find(
+          oldContainer => oldContainer.name === container.name
+        ).resources[resourceRequirement][resourceName];
+        if (newValue !== oldValue) {
+          if (!updatedContainer) {
+            updateRows.push({ name: "Container Name", value: container.name });
+            updatedContainer = true;
+          }
+          updateRows.push({
+            name: `Old ${fortmatResourceString(resourceName, resourceRequirement)}`,
+            value: oldValue,
+          });
+          updateRows.push({
+            name: `New ${fortmatResourceString(resourceName, resourceRequirement)}`,
+            value: newValue,
+          });
+        }
+      });
+    });
+  });
+
+  return (
+    <WizardStep error={updateData.error} isLoading={updateData.isLoading}>
+      <Confirmation action="Update" />
+      <MetadataTable
+        data={[
+          { name: "Name", value: deployment.name },
+          { name: "Namespace", value: deployment.namespace },
+          { name: "Cluster", value: deployment.cluster },
+          ...updateRows,
+        ]}
+      />
+    </WizardStep>
+  );
+};
+
+const ScaleResources: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
+  const dataLayout = {
+    inputData: {},
+    deploymentData: {},
+    currentDeploymentData: {},
+    updateData: {
+      deps: ["deploymentData", "inputData", "currentDeploymentData"],
+      hydrator: (
+        deploymentData: {
+          cluster: string;
+          containerName: string;
+          deploymentSpec: IClutch.k8s.v1.Deployment.DeploymentSpec;
+          name: string;
+          namespace: string;
+        },
+        inputData: { clientset: string },
+        currentDeploymentData: IClutch.k8s.v1.Deployment
+      ) => {
+        const clientset = inputData.clientset ?? "undefined";
+        const limits: { [key: string]: string } = {
+          cpu: deploymentData.deploymentSpec.template.spec.containers.find(
+            container => container.name === deploymentData.containerName
+          ).resources.limits.cpu,
+          memory: deploymentData.deploymentSpec.template.spec.containers.find(
+            container => container.name === deploymentData.containerName
+          ).resources.limits.memory,
+        };
+        const requests: { [key: string]: string } = {
+          cpu: deploymentData.deploymentSpec.template.spec.containers.find(
+            container => container.name === deploymentData.containerName
+          ).resources.requests.cpu,
+          memory: deploymentData.deploymentSpec.template.spec.containers.find(
+            container => container.name === deploymentData.containerName
+          ).resources.requests.memory,
+        };
+        return client.post("/v1/k8s/updateDeployment", {
+          clientset,
+          cluster: deploymentData.cluster,
+          namespace: deploymentData.namespace,
+          name: deploymentData.name,
+          fields: {
+            containerResources: [
+              {
+                containerName: deploymentData.containerName,
+                resources: {
+                  limits,
+                  requests,
+                },
+              },
+            ],
+          },
+        } as IClutch.k8s.v1.UpdateDeploymentRequest);
+      },
+    },
+  };
+
+  return (
+    <Wizard dataLayout={dataLayout} heading={heading}>
+      <DeploymentIdentifier name="Lookup" resolverType={resolverType} />
+      <DeploymentDetails name="Modify" />
+      <Confirm name="Confirmation" />
+    </Wizard>
+  );
+};
+
+export default ScaleResources;

--- a/frontend/workflows/k8s/src/scale-resources.tsx
+++ b/frontend/workflows/k8s/src/scale-resources.tsx
@@ -243,13 +243,14 @@ const ScaleResources: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
         currentDeploymentData: IClutch.k8s.v1.Deployment
       ) => {
         const clientset = inputData.clientset ?? "undefined";
+        const container = findContainer({ ...deploymentData });
         const limits: { [key: string]: string } = {
-          cpu: findContainer({ ...deploymentData }).resources.limits.cpu,
-          memory: findContainer({ ...deploymentData }).resources.limits.memory,
+          cpu: container.resources.limits.cpu,
+          memory: container.resources.limits.memory,
         };
         const requests: { [key: string]: string } = {
-          cpu: findContainer({ ...deploymentData }).resources.requests.cpu,
-          memory: findContainer({ ...deploymentData }).resources.requests.memory,
+          cpu: container.resources.requests.cpu,
+          memory: container.resources.requests.memory,
         };
         return client.post("/v1/k8s/updateDeployment", {
           clientset,

--- a/frontend/workflows/k8s/src/scale-resources.tsx
+++ b/frontend/workflows/k8s/src/scale-resources.tsx
@@ -54,9 +54,9 @@ const DeploymentDetails: React.FC<WizardChild> = () => {
 
   const currentDeploymentData = useDataLayout("currentDeploymentData");
 
-  const [containerName, setContainerName] = React.useState(
-    deployment.deploymentSpec.template.spec.containers[0].name
-  );
+  const { containers } = deployment.deploymentSpec.template.spec;
+
+  const [containerName, setContainerName] = React.useState(containers[0].name);
 
   const [containerIndex, setContainerIndex] = React.useState(0);
 
@@ -90,14 +90,10 @@ const DeploymentDetails: React.FC<WizardChild> = () => {
                 name="containerName"
                 onChange={value => {
                   setContainerName(value);
-                  setContainerIndex(
-                    deployment.deploymentSpec.template.spec.containers.findIndex(
-                      container => container.name === value
-                    )
-                  );
+                  setContainerIndex(containers.findIndex(container => container.name === value));
                   deploymentData.updateData("containerName", value);
                 }}
-                options={deployment.deploymentSpec.template.spec.containers.map(container => {
+                options={containers.map(container => {
                   return { label: container.name };
                 })}
               />

--- a/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthLg css-qvkihn-MuiContainer-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-g39oug-MuiGrid-root"
+      style="display: inline;"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+      >
+        <div
+          class="css-7an8u1"
+        >
+          <div
+            class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
+          >
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel css-n7tliy-MuiStep-root"
+            >
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal MuiStepLabel-alternativeLabel css-ascpo7-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="css-pu8aqe"
+                  >
+                    <div
+                      class="css-h5bkmw"
+                    >
+                      1
+                    </div>
+                  </div>
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer css-16ubnlw-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-active MuiStepLabel-alternativeLabel css-qivjh0-MuiStepLabel-label"
+                  >
+                    Lookup
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel css-n7tliy-MuiStep-root"
+            >
+              <div
+                class="MuiStepConnector-root MuiStepConnector-horizontal MuiStepConnector-alternativeLabel Mui-disabled css-zpcwqm-MuiStepConnector-root"
+              >
+                <span
+                  class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-z7uhs0-MuiStepConnector-line"
+                />
+              </div>
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal Mui-disabled MuiStepLabel-alternativeLabel css-ascpo7-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="css-1od1op4"
+                  >
+                    <div
+                      class="css-1c0nvhn"
+                    >
+                      2
+                    </div>
+                  </div>
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer css-16ubnlw-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-disabled MuiStepLabel-alternativeLabel css-qivjh0-MuiStepLabel-label"
+                  >
+                    Modify
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel css-n7tliy-MuiStep-root"
+            >
+              <div
+                class="MuiStepConnector-root MuiStepConnector-horizontal MuiStepConnector-alternativeLabel Mui-disabled css-zpcwqm-MuiStepConnector-root"
+              >
+                <span
+                  class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-z7uhs0-MuiStepConnector-line"
+                />
+              </div>
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal Mui-disabled MuiStepLabel-alternativeLabel css-ascpo7-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="css-1od1op4"
+                  >
+                    <div
+                      class="css-1c0nvhn"
+                    >
+                      3
+                    </div>
+                  </div>
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer css-16ubnlw-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-disabled MuiStepLabel-alternativeLabel css-qivjh0-MuiStepLabel-label"
+                  >
+                    Confirmation
+                  </span>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1w31snl-MuiPaper-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"
+          >
+            <span
+              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-jc2eav-MuiCircularProgress-root"
+              role="progressbar"
+              style="width: 40px; height: 40px;"
+            >
+              <svg
+                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                viewBox="22 22 44 44"
+              >
+                <circle
+                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                  cx="44"
+                  cy="44"
+                  fill="none"
+                  r="20.2"
+                  stroke-width="3.6"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container css-1lym95h-MuiGrid-root"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/workflows/k8s/src/tests/scale-resources.test.tsx
+++ b/frontend/workflows/k8s/src/tests/scale-resources.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import { render } from "@testing-library/react";
+
+import "@testing-library/jest-dom";
+
+import ScaleResources from "../scale-resources";
+
+test("renders correctly", () => {
+  const { asFragment } = render(
+    <BrowserRouter>
+      <ScaleResources resolverType="clutch.k8s.v1.Deployment" />
+    </BrowserRouter>
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Adding a workflow to scale CPU and memory requests and limits in Kubernetes. 

<!-- Reference previous related pull requests below. -->

Follow to:
https://github.com/lyft/clutch/pull/2589
https://github.com/lyft/clutch/pull/2604

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

<img width="876" alt="Screenshot 2023-03-10 at 5 01 47 PM" src="https://user-images.githubusercontent.com/19522571/224455862-1ceb465e-8b45-4da8-b100-c9951eea97b1.png">

<img width="844" alt="Screenshot 2023-03-10 at 5 02 16 PM" src="https://user-images.githubusercontent.com/19522571/224455868-df09a521-e4f1-4f62-ac75-ceddb400ec41.png">

<img width="822" alt="Screenshot 2023-03-10 at 5 02 30 PM" src="https://user-images.githubusercontent.com/19522571/224455875-bbd3b106-fffe-46b7-9f4b-cfbe9f8b056e.png">




### Testing Performed
<!-- Describe how you tested this change below. -->
* Scaled each type of resource on my cluster
* Tried with different containers on the same deployment
* Tested validation by putting in bogus inputs
* Included Jest Snapshot
