### PR TITLE
frontend: Typography - Fixing noWrap error message

### DIFF
--- a/frontend/packages/core/src/typography.tsx
+++ b/frontend/packages/core/src/typography.tsx
@@ -140,14 +140,14 @@ type TextVariant =
 const StyledTypography = styled("div")<{
   $variant: TypographyProps["variant"];
   $color: TypographyProps["color"];
-  noWrap: TypographyProps["noWrap"];
+  $noWrap: TypographyProps["noWrap"];
 }>(props => ({
   color: props.$color,
   fontSize: `${STYLE_MAP[props.$variant].size}px`,
   fontWeight: STYLE_MAP[props.$variant].weight,
   lineHeight: `${STYLE_MAP[props.$variant].lineHeight}px`,
   ...(STYLE_MAP[props.$variant]?.props || {}),
-  ...(props.noWrap
+  ...(props.$noWrap
     ? {
         whiteSpace: "nowrap",
         textOverflow: "ellipsis",
@@ -169,9 +169,16 @@ const Typography = ({
   children,
   color = "#0D1030",
   textTransform,
+  noWrap,
   ...props
 }: TypographyProps) => (
-  <StyledTypography $variant={variant} $color={color} $textTransform={textTransform} {...props}>
+  <StyledTypography
+    $variant={variant}
+    $color={color}
+    $textTransform={textTransform}
+    $noWrap={noWrap}
+    {...props}
+  >
     {children}
   </StyledTypography>
 );


### PR DESCRIPTION
### Description
Seeing a lot of these error messages due to using `noWrap` on the Typography component. Limiting this to not pass into the dom.

#### Error
![Screenshot 2023-03-21 at 9 18 56 AM](https://user-images.githubusercontent.com/8338893/226673568-3dcd527b-ae12-4e79-bf6e-cdcee39efc28.png)


### Testing Performed
manual
