### PR TITLE
housekeeping: Locking renovate version to 34.x.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh
       - name: Install renovate-config-validator
-        run: yarn add renovate
+        run: yarn add renovate@^34.0.0
         working-directory: build
       - name: Validate renovate.json
         run: yarn renovate-config-validator ../.github/renovate.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,10 @@ name: ci
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
-    paths:
-    - .github/renovate.json
+      - main
 jobs:
   renovate-config:
     runs-on: ubuntu-latest
@@ -16,7 +14,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: "16.x"
           check-latest: true
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,12 @@ name: ci
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
     branches:
-      - main
+    - main
+    paths:
+    - .github/renovate.json
 jobs:
   renovate-config:
     runs-on: ubuntu-latest
@@ -14,7 +16,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: '16.x'
           check-latest: true
       - name: Enforce consistent Yarn version
         run: ./tools/install-yarn.sh


### PR DESCRIPTION
### Description
Renovate recently upgraded and locked node behind a min version of 18.x. Since we're still running 16.x, installing renovate to a specific version.

Commit where renovate was upgraded: https://github.com/renovatebot/renovate/commit/2102b706073676ae949692a6595cc590770b7803

Failures from trying to install current renovate:
https://github.com/lyft/clutch/actions/runs/4481493781/jobs/7883978530

Successful run with change:
https://github.com/lyft/clutch/actions/runs/4484340241/jobs/7884734580?pr=2621

### Testing Performed
manual
