### PR TITLE
ci: use node-version for cache key

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
+        id: setup-node
         with:
           node-version: '16.x'
           check-latest: true
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
+        id: setup-node
         with:
           node-version: '16.x'
           check-latest: true
@@ -83,7 +85,9 @@ jobs:
         id: setup-go
         with:
           go-version: 1.19.x
-      - uses: actions/setup-node@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        id: setup-node
         with:
           node-version: '16.x'
           check-latest: true
@@ -142,6 +146,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
+        id: setup-node
         with:
           node-version: '16.x'
           check-latest: true
@@ -169,6 +174,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
+        id: setup-node
         with:
           node-version: '16.x'
           check-latest: true


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
node-version not used for cache key.

### Testing Performed

CI