### PR TITLE
frontend: Adding Icon Support for Drawers

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -10,13 +10,13 @@ import {
 } from "@mui/material";
 import _ from "lodash";
 
+import type { WorkflowIcon } from "../AppProvider";
 import type { Workflow } from "../AppProvider/workflow";
 import { useAppContext } from "../Contexts";
 import type { PopperItemProps } from "../popper";
 import { Popper, PopperItem } from "../popper";
 
 import { filterHiddenRoutes, routesByGrouping, sortedGroupings, workflowByRoute } from "./utils";
-import type { WorkflowIcon } from "../AppProvider";
 
 // sidebar
 const DrawerPanel = styled(MuiDrawer)({

--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -16,6 +16,7 @@ import type { PopperItemProps } from "../popper";
 import { Popper, PopperItem } from "../popper";
 
 import { filterHiddenRoutes, routesByGrouping, sortedGroupings, workflowByRoute } from "./utils";
+import type { WorkflowIcon } from "../AppProvider";
 
 // sidebar
 const DrawerPanel = styled(MuiDrawer)({
@@ -92,6 +93,7 @@ interface GroupProps {
   heading: string;
   open: boolean;
   selected: boolean;
+  icon: WorkflowIcon;
   updateOpenGroup: (heading: string) => void;
   closeGroup: () => void;
   children: React.ReactElement<PopperItemProps> | React.ReactElement<PopperItemProps>[];
@@ -101,6 +103,7 @@ const Group = ({
   heading,
   open = false,
   selected = false,
+  icon,
   updateOpenGroup,
   closeGroup,
   children,
@@ -126,7 +129,11 @@ const Group = ({
           updateOpenGroup(heading);
         }}
       >
-        <Avatar>{heading.charAt(0)}</Avatar>
+        {icon.path && icon.path.length > 0 ? (
+          <Avatar src={icon.path} />
+        ) : (
+          <Avatar>{heading.charAt(0)}</Avatar>
+        )}
         <GroupHeading align="center">{heading}</GroupHeading>
         <Popper open={open} onClickAway={closeGroup} anchorRef={anchorRef} id="workflow-options">
           {children}
@@ -180,13 +187,13 @@ const Drawer: React.FC = () => {
       {sortedGroupings(filteredWorkflows).map(grouping => {
         const value = routesByGrouping(filteredWorkflows)[grouping];
         const sortedWorkflows = _.sortBy(value.workflows, w => w.displayName);
-
         return (
           <Group
             key={grouping}
             heading={grouping}
             open={openGroup === grouping}
             selected={openGroup === grouping || activeWorkflow?.group === grouping}
+            icon={value.icon}
             updateOpenGroup={updateOpenGroup}
             closeGroup={() => setOpenGroup("")}
           >

--- a/frontend/packages/core/src/AppLayout/utils.tsx
+++ b/frontend/packages/core/src/AppLayout/utils.tsx
@@ -1,6 +1,6 @@
 import * as _ from "lodash";
-import type { WorkflowIcon } from "../AppProvider";
 
+import type { WorkflowIcon } from "../AppProvider";
 import type { Route, Workflow } from "../AppProvider/workflow";
 
 interface GroupedRoutes {

--- a/frontend/packages/core/src/AppLayout/utils.tsx
+++ b/frontend/packages/core/src/AppLayout/utils.tsx
@@ -1,9 +1,11 @@
 import * as _ from "lodash";
+import type { WorkflowIcon } from "../AppProvider";
 
 import type { Route, Workflow } from "../AppProvider/workflow";
 
 interface GroupedRoutes {
   [category: string]: {
+    icon?: WorkflowIcon;
     workflows: {
       displayName: string;
       path: string;
@@ -56,7 +58,10 @@ const routesByGrouping = (workflows: Workflow[]): GroupedRoutes => {
   workflows.forEach(workflow => {
     const category = workflow.group;
     if (routes[category] === undefined) {
-      routes[category] = { workflows: [] };
+      routes[category] = {
+        workflows: [],
+        icon: workflow.icon,
+      };
     }
 
     routes[category].workflows = [
@@ -65,7 +70,7 @@ const routesByGrouping = (workflows: Workflow[]): GroupedRoutes => {
         return {
           displayName: getDisplayName(workflow, route, " -"),
           path: `${workflow.path}/${route.path}`,
-          trending: route.trending,
+          trending: route.trending || false,
         };
       }),
     ];

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -19,9 +19,14 @@ import { Theme } from "./themes";
 import type { ConfiguredRoute, Workflow, WorkflowConfiguration } from "./workflow";
 import ErrorBoundary from "./workflow";
 
+export interface WorkflowIcon {
+  path: string;
+}
+
 export interface UserConfiguration {
   [packageName: string]: {
-    [key: string]: ConfiguredRoute;
+    icon: WorkflowIcon;
+    [key: string]: WorkflowIcon | ConfiguredRoute;
   };
 }
 

--- a/frontend/packages/core/src/AppProvider/registrar.tsx
+++ b/frontend/packages/core/src/AppProvider/registrar.tsx
@@ -10,8 +10,11 @@ const workflowRoutes = (
 ): ConfiguredRoute[] => {
   const workflowConfig = configuration?.[workflowId] || {};
   const allRoutes = Object.keys(workflowConfig).map(key => {
-    // if workflow does not contain route with user-specified key return an empty object
-    if (workflow.routes[key] === undefined) {
+    // if workflow contains an icon, return an empty object
+    if (key === "icon") {
+      return {} as ConfiguredRoute;
+      // if workflow does not contain route with user-specified key return an empty object
+    } else if (workflow.routes[key] === undefined) {
       /* eslint-disable-next-line no-console */
       console.warn(
         `[${workflowId}][${key}] Not registered: Invalid config - route does not exist. Valid routes: ${Object.keys(
@@ -64,8 +67,13 @@ const registeredWorkflows = async (
   let validWorkflows = Object.keys(workflows || [])
     .map((workflowId: string) => {
       const workflow = workflows[workflowId]();
+      const icon = configuration?.[workflowId]?.icon || { path: "" };
       try {
-        return { ...workflow, routes: workflowRoutes(workflowId, workflow, configuration) };
+        return {
+          ...workflow,
+          icon,
+          routes: workflowRoutes(workflowId, workflow, configuration),
+        };
       } catch {
         // n.b. if the routes aren't configured properly we drop the workflow
         /* eslint-disable-next-line no-console */

--- a/frontend/packages/core/src/AppProvider/registrar.tsx
+++ b/frontend/packages/core/src/AppProvider/registrar.tsx
@@ -14,7 +14,8 @@ const workflowRoutes = (
     if (key === "icon") {
       return {} as ConfiguredRoute;
       // if workflow does not contain route with user-specified key return an empty object
-    } else if (workflow.routes[key] === undefined) {
+    }
+    if (workflow.routes[key] === undefined) {
       /* eslint-disable-next-line no-console */
       console.warn(
         `[${workflowId}][${key}] Not registered: Invalid config - route does not exist. Valid routes: ${Object.keys(

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -4,6 +4,7 @@ import { Alert, Grid, IconButton } from "@mui/material";
 
 import { Dialog, DialogContent } from "../dialog";
 import Code from "../text";
+import type { WorkflowIcon } from "./index";
 
 export interface BaseWorkflowProps {
   heading: string;
@@ -54,6 +55,7 @@ export interface Workflow extends BaseWorkflowConfiguration, WorkflowShortlinkCo
    * on homepage) and `componentProps` which allow the passing of workflow/route
    * specific props.
    */
+  icon: WorkflowIcon;
   routes: ConfiguredRoute[];
 }
 

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -52,11 +52,16 @@ interface WorkflowShortlinkConfiguration {
 
 export interface Workflow extends BaseWorkflowConfiguration, WorkflowShortlinkConfiguration {
   /**
+   * An optional property that is set via the config and allows for the display of an icon given a path,
+   * this will override the default avatar.
+   * { path: string }
+   */
+  icon: WorkflowIcon;
+  /**
    * Configured routes allow for the optional properties of `trending` (whether to display
    * on homepage) and `componentProps` which allow the passing of workflow/route
    * specific props.
    */
-  icon: WorkflowIcon;
   routes: ConfiguredRoute[];
 }
 

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -4,6 +4,7 @@ import { Alert, Grid, IconButton } from "@mui/material";
 
 import { Dialog, DialogContent } from "../dialog";
 import Code from "../text";
+
 import type { WorkflowIcon } from "./index";
 
 export interface BaseWorkflowProps {


### PR DESCRIPTION
### Description
Adds Icon support for Drawers. This will default to using the given path which can be locally hosted or an external URL. If not present will default to the normal avatar with the first letter.

Configured by modifying the `clutch-config.js` and adding a property `icon: { path: string }`

#### Example
```
  "@clutch-sh/ec2": {
    icon: {
      path: "/example.jpg", OR "http://fake-url.com/image.png"
    },
    terminateInstance: {
      ...
    },
  },
```

#### Screenshot
![Screenshot 2023-06-06 at 8 56 05 AM](https://github.com/lyft/clutch/assets/8338893/df761867-09ca-4fae-b99e-5fa8513f38e3)


### Testing Performed
manual
