### PR TITLE
housekeeping: Updating renovate config to remove postUpgradeTask

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,9 +24,6 @@
     {
       "groupName": "eslint",
       "matchPackagePatterns": ["^eslint"],
-      "postUpgradeTasks": {
-        "commands": ["make frontend-lint-fix"]
-      },
       "schedule": ["every 2 week on monday"],
       "stabilityDays": 14
     },
@@ -56,6 +53,5 @@
     }
   ],
   "postUpdateOptions": ["gomodTidy"],
-  "allowedPostUpgradeCommands": ["^make frontend-lint-fix$"],
   "ignoreDeps": ["@date-io/core", "babel-jest"]
 }


### PR DESCRIPTION
### Description
Realized that postUpgradeTasks only work for self-hosted solutions of renovate, since we're using a hosted version this will never work. So removing to reduce the unnecessary error messages. 

#### Listed under self-hosted
https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands

#### Error Message
https://github.com/lyft/clutch/pull/2676#issuecomment-1577428689
