### PR TITLE
slack sink: trim leading/trailing whitespace in custom slack audit messages

### DIFF
--- a/backend/service/auditsink/slack/slack.go
+++ b/backend/service/auditsink/slack/slack.go
@@ -148,10 +148,9 @@ func FormatCustomText(message string, event *auditv1.RequestEvent) (string, erro
 	}
 
 	// When a value is nil, the Go Template sets the value as "<no value>".
-	// Ex of when we hit this scenario: https://github.com/lyft/clutch/blob/main/api/k8s/v1/k8s.proto#L860
 	sanitized := strings.ReplaceAll(buf.String(), "<no value>", defaultNone)
 
-	return sanitized, nil
+	return strings.TrimSpace(sanitized), nil
 }
 
 func (s *svc) auditEventToMessage(username string, event *auditv1.RequestEvent) string {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Custom slack audit message templates might have text that is conditionally rendered if the info in available in the API request/response, which creates leading/trailing whitespace in the messages when the info isn't present. PR trims out the whitespace.

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
