### PR TITLE
frontend: Drawer Icons Patch

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -37,36 +37,40 @@ const GroupList = styled(List)({
   padding: "0px",
 });
 
-const GroupListItem = styled(ListItemButton)({
-  flexDirection: "column",
-  minHeight: "82px",
-  padding: "16px 8px 16px 8px",
-  height: "fit-content",
-  "&:hover": {
-    backgroundColor: "#F5F6FD",
-  },
-  "&:active": {
-    backgroundColor: "#D7DAF6",
-  },
-  // avatar and label
-  "&:hover, &:active, &.Mui-selected": {
-    ".MuiAvatar-root": {
-      backgroundColor: "#3548D4",
-    },
-    ".MuiTypography-root": {
-      color: "#3548D4",
-    },
-  },
-  "&.Mui-selected": {
-    backgroundColor: "#EBEDFB",
+const GroupListItem = styled(ListItemButton)<{ icon: boolean }>(
+  {
+    flexDirection: "column",
+    minHeight: "82px",
+    padding: "16px 8px 16px 8px",
+    height: "fit-content",
     "&:hover": {
       backgroundColor: "#F5F6FD",
     },
     "&:active": {
       backgroundColor: "#D7DAF6",
     },
+    "&.Mui-selected": {
+      backgroundColor: "#EBEDFB",
+      "&:hover": {
+        backgroundColor: "#F5F6FD",
+      },
+      "&:active": {
+        backgroundColor: "#D7DAF6",
+      },
+    },
   },
-});
+  props => ({
+    // avatar and label
+    "&:hover, &:active, &.Mui-selected": {
+      ".MuiAvatar-root": {
+        backgroundColor: props.icon ? "unset" : "#3548D4",
+      },
+      ".MuiTypography-root": {
+        color: "#3548D4",
+      },
+    },
+  })
+);
 
 const GroupHeading = styled(Typography)({
   color: "rgba(13, 16, 48, 0.6)",
@@ -80,10 +84,13 @@ const GroupHeading = styled(Typography)({
   overflow: "hidden",
 });
 
-const Avatar = styled(MuiAvatar)({
-  background: "rgba(13, 16, 48, 0.6)",
+const IconAvatar = styled(MuiAvatar)({
   height: "24px",
   width: "24px",
+});
+
+const Avatar = styled(IconAvatar)({
+  background: "rgba(13, 16, 48, 0.6)",
   color: "#FFFFFF",
   fontSize: "14px",
   borderRadius: "4px",
@@ -125,12 +132,13 @@ const Group = ({
         ref={anchorRef}
         aria-controls={open ? "workflow-options" : undefined}
         aria-haspopup="true"
+        icon={icon.path && icon.path.length > 0}
         onClick={() => {
           updateOpenGroup(heading);
         }}
       >
         {icon.path && icon.path.length > 0 ? (
-          <Avatar src={icon.path} />
+          <IconAvatar src={icon.path} />
         ) : (
           <Avatar>{heading.charAt(0)}</Avatar>
         )}

--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -116,6 +116,7 @@ const Group = ({
   children,
 }: GroupProps) => {
   const anchorRef = React.useRef(null);
+  const validIcon = icon.path && icon.path.length > 0;
 
   // n.b. if a Workflow Grouping has no workflows in it don't display it even if
   // it's not explicitly marked as hidden.
@@ -132,16 +133,12 @@ const Group = ({
         ref={anchorRef}
         aria-controls={open ? "workflow-options" : undefined}
         aria-haspopup="true"
-        icon={icon.path && icon.path.length > 0}
+        icon={validIcon}
         onClick={() => {
           updateOpenGroup(heading);
         }}
       >
-        {icon.path && icon.path.length > 0 ? (
-          <IconAvatar src={icon.path} />
-        ) : (
-          <Avatar>{heading.charAt(0)}</Avatar>
-        )}
+        {validIcon ? <IconAvatar src={icon.path} /> : <Avatar>{heading.charAt(0)}</Avatar>}
         <GroupHeading align="center">{heading}</GroupHeading>
         <Popper open={open} onClickAway={closeGroup} anchorRef={anchorRef} id="workflow-options">
           {children}

--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -138,7 +138,11 @@ const Group = ({
           updateOpenGroup(heading);
         }}
       >
-        {validIcon ? <IconAvatar src={icon.path} /> : <Avatar>{heading.charAt(0)}</Avatar>}
+        {validIcon ? (
+          <IconAvatar src={icon.path}>{heading.charAt(0)}</IconAvatar>
+        ) : (
+          <Avatar>{heading.charAt(0)}</Avatar>
+        )}
         <GroupHeading align="center">{heading}</GroupHeading>
         <Popper open={open} onClickAway={closeGroup} anchorRef={anchorRef} id="workflow-options">
           {children}


### PR DESCRIPTION
### Description
Some small modifications for displaying icons on drawers.

- Removed hover color if its an icon type as this was causing some outline weirdness
- Modified to use a direct style from MuiAvatar as the current one was forcing the icon into a square

#### Hover Issue
![Screenshot 2023-06-07 at 1 18 59 PM](https://github.com/lyft/clutch/assets/8338893/1480555f-2460-4833-8840-7df881943772)

#### Square Issue
![Screenshot 2023-06-07 at 1 18 38 PM](https://github.com/lyft/clutch/assets/8338893/e7758d3d-6e1d-40fe-992f-68219264cdc1)

#### After
![Screenshot 2023-06-07 at 1 18 21 PM](https://github.com/lyft/clutch/assets/8338893/bc08a538-6179-4397-a2c6-3d7fc9caa286)

### Testing Performed
manual
