### PR TITLE
Add new rpc for namespace events

### DIFF
--- a/api/k8s/v1/k8s.proto
+++ b/api/k8s/v1/k8s.proto
@@ -1222,7 +1222,7 @@ enum ObjectKind {
 }
 
 enum EventType {
-  UNSPECIFIED = 0;
+  TYPE_UNSPECIFIED = 0;
   NORMAL = 1;
   WARNING = 2;
   ERROR = 3;

--- a/api/k8s/v1/k8s.proto
+++ b/api/k8s/v1/k8s.proto
@@ -268,6 +268,33 @@ service K8sAPI {
     };
     option (clutch.api.v1.action).type = UPDATE;
   }
+
+  rpc ListNamespaceEvents(ListNamespaceEventsRequest) returns (ListNamespaceEventsResponse) {
+    option (google.api.http) = {
+      post : "/v1/k8s/listNamespaceEvents"
+      body : "*"
+    };
+    option (clutch.api.v1.action).type = READ;
+  }
+}
+
+message ListNamespaceEventsRequest {
+  option (clutch.api.v1.id).patterns = {
+    type_url : "clutch.k8s.v1.Namespace",
+    // requests for all events associated with a given namespace
+    pattern : "{cluster}/{namespace}"
+  };
+
+  string clientset = 1 [ (validate.rules).string = {min_bytes : 1} ];
+  string cluster = 2 [ (validate.rules).string = {min_bytes : 1} ];
+  string namespace = 3 [ (validate.rules).string = {min_bytes : 1} ];
+  // If no filters, only get errors. If filters are presesnt, allow for multiple types.
+  repeated EventType event_types = 4;
+  // Note object kind is Pod, in the future may support nodes as well
+}
+
+message ListNamespaceEventsResponse {
+  repeated Event events = 1;
 }
 
 message DescribePodRequest {
@@ -1194,6 +1221,13 @@ enum ObjectKind {
   POD = 2;
 }
 
+enum EventType {
+  UNSPECIFIED = 0;
+  NORMAL = 1;
+  WARNING = 2;
+  ERROR = 3;
+}
+
 // this represents a Kubernetes event: https://pkg.go.dev/k8s.io/api/core/v1#Event
 // for a given object
 message Event {
@@ -1215,6 +1249,9 @@ message Event {
   // `lastTimestamp` and `eventTime` fields in the Event object.
   // https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta
   int64 creation_time_millis = 10;
+
+  // type is normal, warning, or error
+  EventType event_type = 11;
 }
 
 message ListEventsRequest {


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
We are going to have a function that lists events in a namespace rather than for a pod or given object. We could also modify the current ListEvents but I feel it is more organized to make another specific function.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
