### PR TITLE
Backend update probes

### DIFF
--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -101,12 +101,144 @@ func ProtoForDeploymentSpec(deploymentSpec appsv1.DeploymentSpec) *k8sapiv1.Depl
 			resourceRequests[string(res)] = quantity.String()
 		}
 
+		LivenessProbeObject := &k8sapiv1.Probe{}
+		ReadinessProbeObject := &k8sapiv1.Probe{}
+		if container.LivenessProbe != nil {
+			HandlerObj := &k8sapiv1.Probe{}
+
+			if container.LivenessProbe.ProbeHandler.HTTPGet != nil {
+				LivenessProbeHTTPHeaders := make([]*k8sapiv1.HTTPHeader, 0, len(container.LivenessProbe.ProbeHandler.HTTPGet.HTTPHeaders))
+				for _, value := range container.LivenessProbe.ProbeHandler.HTTPGet.HTTPHeaders {
+					UniqueLivenessHeader := &k8sapiv1.HTTPHeader{
+						Name:  &value.Name,
+						Value: &value.Value,
+					}
+					LivenessProbeHTTPHeaders = append(LivenessProbeHTTPHeaders, UniqueLivenessHeader)
+				}
+
+				LivenessProbeHTTPObject := &k8sapiv1.HTTPGetAction{
+					Path:        container.LivenessProbe.ProbeHandler.HTTPGet.Path,
+					Port:        container.LivenessProbe.ProbeHandler.HTTPGet.Port.IntVal,
+					Host:        container.LivenessProbe.ProbeHandler.HTTPGet.Host,
+					Scheme:      string(container.LivenessProbe.ProbeHandler.HTTPGet.Scheme),
+					HttpHeaders: LivenessProbeHTTPHeaders,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_HttpGet{
+					HttpGet: LivenessProbeHTTPObject,
+				}
+			}
+
+			if container.LivenessProbe.ProbeHandler.Exec != nil {
+				LivenessProbeExec := &k8sapiv1.ExecAction{
+					Command: container.LivenessProbe.ProbeHandler.Exec.Command,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_Exec{
+					Exec: LivenessProbeExec,
+				}
+			}
+
+			if container.LivenessProbe.ProbeHandler.TCPSocket != nil {
+				LivenessProbeTCPSocket := &k8sapiv1.TCPSocketAction{
+					Port: container.LivenessProbe.ProbeHandler.TCPSocket.Port.IntVal,
+					Host: container.LivenessProbe.ProbeHandler.TCPSocket.Host,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_TcpSocket{
+					TcpSocket: LivenessProbeTCPSocket,
+				}
+			}
+
+			if container.LivenessProbe.ProbeHandler.GRPC != nil {
+				LivenessProbeGRPC := &k8sapiv1.GRPCAction{
+					Port:    container.LivenessProbe.ProbeHandler.GRPC.Port,
+					Service: *container.LivenessProbe.ProbeHandler.GRPC.Service,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_Grpc{
+					Grpc: LivenessProbeGRPC,
+				}
+			}
+
+			LivenessProbeObject = &k8sapiv1.Probe{
+				InitialDelaySeconds:           &container.LivenessProbe.InitialDelaySeconds,
+				TimeoutSeconds:                &container.LivenessProbe.TimeoutSeconds,
+				PeriodSeconds:                 &container.LivenessProbe.PeriodSeconds,
+				SuccessThreshold:              &container.LivenessProbe.SuccessThreshold,
+				FailureThreshold:              &container.LivenessProbe.FailureThreshold,
+				TerminationGracePeriodSeconds: container.LivenessProbe.TerminationGracePeriodSeconds,
+				Handler:                       HandlerObj.Handler,
+			}
+		}
+
+		if container.ReadinessProbe != nil {
+			HandlerObj := &k8sapiv1.Probe{}
+			if container.ReadinessProbe.ProbeHandler.HTTPGet != nil {
+				ReadinessProbeHTTPHeaders := make([]*k8sapiv1.HTTPHeader, 0, len(container.ReadinessProbe.ProbeHandler.HTTPGet.HTTPHeaders))
+				for _, value := range container.ReadinessProbe.ProbeHandler.HTTPGet.HTTPHeaders {
+					UniqueReadnessHeader := &k8sapiv1.HTTPHeader{
+						Name:  &value.Name,
+						Value: &value.Value,
+					}
+					ReadinessProbeHTTPHeaders = append(ReadinessProbeHTTPHeaders, UniqueReadnessHeader)
+				}
+				ReadinessProbeHTTPObject := &k8sapiv1.HTTPGetAction{
+					Path:        container.ReadinessProbe.ProbeHandler.HTTPGet.Path,
+					Port:        container.ReadinessProbe.ProbeHandler.HTTPGet.Port.IntVal,
+					Host:        container.ReadinessProbe.ProbeHandler.HTTPGet.Host,
+					Scheme:      string(container.ReadinessProbe.ProbeHandler.HTTPGet.Scheme),
+					HttpHeaders: ReadinessProbeHTTPHeaders,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_HttpGet{
+					HttpGet: ReadinessProbeHTTPObject,
+				}
+			}
+
+			if container.ReadinessProbe.ProbeHandler.Exec != nil {
+				ReadinessProbeExec := &k8sapiv1.ExecAction{
+					Command: container.ReadinessProbe.ProbeHandler.Exec.Command,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_Exec{
+					Exec: ReadinessProbeExec,
+				}
+			}
+
+			if container.ReadinessProbe.ProbeHandler.TCPSocket != nil {
+				ReadinessProbeTCPSocket := &k8sapiv1.TCPSocketAction{
+					Port: container.ReadinessProbe.ProbeHandler.TCPSocket.Port.IntVal,
+					Host: container.ReadinessProbe.ProbeHandler.TCPSocket.Host,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_TcpSocket{
+					TcpSocket: ReadinessProbeTCPSocket,
+				}
+			}
+
+			if container.ReadinessProbe.ProbeHandler.GRPC != nil {
+				ReadinessProbeGRPC := &k8sapiv1.GRPCAction{
+					Port:    container.ReadinessProbe.ProbeHandler.GRPC.Port,
+					Service: *container.ReadinessProbe.ProbeHandler.GRPC.Service,
+				}
+				HandlerObj.Handler = &k8sapiv1.Probe_Grpc{
+					Grpc: ReadinessProbeGRPC,
+				}
+			}
+
+			ReadinessProbeObject = &k8sapiv1.Probe{
+				InitialDelaySeconds:           &container.ReadinessProbe.InitialDelaySeconds,
+				TimeoutSeconds:                &container.ReadinessProbe.TimeoutSeconds,
+				PeriodSeconds:                 &container.ReadinessProbe.PeriodSeconds,
+				SuccessThreshold:              &container.ReadinessProbe.SuccessThreshold,
+				FailureThreshold:              &container.ReadinessProbe.FailureThreshold,
+				TerminationGracePeriodSeconds: container.ReadinessProbe.TerminationGracePeriodSeconds,
+				Handler:                       HandlerObj.Handler,
+			}
+		}
+
 		newContainer := &k8sapiv1.Deployment_DeploymentSpec_PodTemplateSpec_PodSpec_Container{
 			Name: container.Name,
 			Resources: &k8sapiv1.Deployment_DeploymentSpec_PodTemplateSpec_PodSpec_Container_ResourceRequirements{
 				Limits:   resourceLimits,
 				Requests: resourceRequests,
 			},
+			LivenessProbe:  LivenessProbeObject,
+			ReadinessProbe: ReadinessProbeObject,
 		}
 		deploymentContainers = append(deploymentContainers, newContainer)
 	}

--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -87,6 +87,61 @@ func ProtoForDeployment(cluster string, deployment *appsv1.Deployment) *k8sapiv1
 	return k8sDeployment
 }
 
+func ProcessObjProbe(objProbe *v1.Probe) *k8sapiv1.Probe {
+	HandlerObj := &k8sapiv1.Probe{}
+	if objProbe.ProbeHandler.HTTPGet != nil {
+		ObjProbeHTTPHeaders := make([]*k8sapiv1.HTTPHeader, 0, len(objProbe.ProbeHandler.HTTPGet.HTTPHeaders))
+		for _, value := range objProbe.ProbeHandler.HTTPGet.HTTPHeaders {
+			UniqueLivenessHeader := &k8sapiv1.HTTPHeader{
+				Name:  &value.Name,
+				Value: &value.Value,
+			}
+			ObjProbeHTTPHeaders = append(ObjProbeHTTPHeaders, UniqueLivenessHeader)
+		}
+
+		ObjProbeHTTPObject := &k8sapiv1.HTTPGetAction{
+			Path:        objProbe.ProbeHandler.HTTPGet.Path,
+			Port:        objProbe.ProbeHandler.HTTPGet.Port.IntVal,
+			Host:        objProbe.ProbeHandler.HTTPGet.Host,
+			Scheme:      string(objProbe.ProbeHandler.HTTPGet.Scheme),
+			HttpHeaders: ObjProbeHTTPHeaders,
+		}
+		HandlerObj.Handler = &k8sapiv1.Probe_HttpGet{
+			HttpGet: ObjProbeHTTPObject,
+		}
+	}
+
+	if objProbe.ProbeHandler.Exec != nil {
+		ObjProbeExec := &k8sapiv1.ExecAction{
+			Command: objProbe.ProbeHandler.Exec.Command,
+		}
+		HandlerObj.Handler = &k8sapiv1.Probe_Exec{
+			Exec: ObjProbeExec,
+		}
+	}
+
+	if objProbe.ProbeHandler.TCPSocket != nil {
+		ObjProbeTCPSocket := &k8sapiv1.TCPSocketAction{
+			Port: objProbe.ProbeHandler.TCPSocket.Port.IntVal,
+			Host: objProbe.ProbeHandler.TCPSocket.Host,
+		}
+		HandlerObj.Handler = &k8sapiv1.Probe_TcpSocket{
+			TcpSocket: ObjProbeTCPSocket,
+		}
+	}
+
+	if objProbe.ProbeHandler.GRPC != nil {
+		ObjProbeGRPC := &k8sapiv1.GRPCAction{
+			Port:    objProbe.ProbeHandler.GRPC.Port,
+			Service: *objProbe.ProbeHandler.GRPC.Service,
+		}
+		HandlerObj.Handler = &k8sapiv1.Probe_Grpc{
+			Grpc: ObjProbeGRPC,
+		}
+	}
+	return HandlerObj
+}
+
 func ProtoForDeploymentSpec(deploymentSpec appsv1.DeploymentSpec) *k8sapiv1.Deployment_DeploymentSpec {
 	deploymentContainers := make([]*k8sapiv1.Deployment_DeploymentSpec_PodTemplateSpec_PodSpec_Container, 0, len(deploymentSpec.Template.Spec.Containers))
 	for _, container := range deploymentSpec.Template.Spec.Containers {
@@ -104,58 +159,7 @@ func ProtoForDeploymentSpec(deploymentSpec appsv1.DeploymentSpec) *k8sapiv1.Depl
 		LivenessProbeObject := &k8sapiv1.Probe{}
 		ReadinessProbeObject := &k8sapiv1.Probe{}
 		if container.LivenessProbe != nil {
-			HandlerObj := &k8sapiv1.Probe{}
-
-			if container.LivenessProbe.ProbeHandler.HTTPGet != nil {
-				LivenessProbeHTTPHeaders := make([]*k8sapiv1.HTTPHeader, 0, len(container.LivenessProbe.ProbeHandler.HTTPGet.HTTPHeaders))
-				for _, value := range container.LivenessProbe.ProbeHandler.HTTPGet.HTTPHeaders {
-					UniqueLivenessHeader := &k8sapiv1.HTTPHeader{
-						Name:  &value.Name,
-						Value: &value.Value,
-					}
-					LivenessProbeHTTPHeaders = append(LivenessProbeHTTPHeaders, UniqueLivenessHeader)
-				}
-
-				LivenessProbeHTTPObject := &k8sapiv1.HTTPGetAction{
-					Path:        container.LivenessProbe.ProbeHandler.HTTPGet.Path,
-					Port:        container.LivenessProbe.ProbeHandler.HTTPGet.Port.IntVal,
-					Host:        container.LivenessProbe.ProbeHandler.HTTPGet.Host,
-					Scheme:      string(container.LivenessProbe.ProbeHandler.HTTPGet.Scheme),
-					HttpHeaders: LivenessProbeHTTPHeaders,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_HttpGet{
-					HttpGet: LivenessProbeHTTPObject,
-				}
-			}
-
-			if container.LivenessProbe.ProbeHandler.Exec != nil {
-				LivenessProbeExec := &k8sapiv1.ExecAction{
-					Command: container.LivenessProbe.ProbeHandler.Exec.Command,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_Exec{
-					Exec: LivenessProbeExec,
-				}
-			}
-
-			if container.LivenessProbe.ProbeHandler.TCPSocket != nil {
-				LivenessProbeTCPSocket := &k8sapiv1.TCPSocketAction{
-					Port: container.LivenessProbe.ProbeHandler.TCPSocket.Port.IntVal,
-					Host: container.LivenessProbe.ProbeHandler.TCPSocket.Host,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_TcpSocket{
-					TcpSocket: LivenessProbeTCPSocket,
-				}
-			}
-
-			if container.LivenessProbe.ProbeHandler.GRPC != nil {
-				LivenessProbeGRPC := &k8sapiv1.GRPCAction{
-					Port:    container.LivenessProbe.ProbeHandler.GRPC.Port,
-					Service: *container.LivenessProbe.ProbeHandler.GRPC.Service,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_Grpc{
-					Grpc: LivenessProbeGRPC,
-				}
-			}
+			HandlerObj := ProcessObjProbe(container.LivenessProbe)
 
 			LivenessProbeObject = &k8sapiv1.Probe{
 				InitialDelaySeconds:           &container.LivenessProbe.InitialDelaySeconds,
@@ -169,56 +173,7 @@ func ProtoForDeploymentSpec(deploymentSpec appsv1.DeploymentSpec) *k8sapiv1.Depl
 		}
 
 		if container.ReadinessProbe != nil {
-			HandlerObj := &k8sapiv1.Probe{}
-			if container.ReadinessProbe.ProbeHandler.HTTPGet != nil {
-				ReadinessProbeHTTPHeaders := make([]*k8sapiv1.HTTPHeader, 0, len(container.ReadinessProbe.ProbeHandler.HTTPGet.HTTPHeaders))
-				for _, value := range container.ReadinessProbe.ProbeHandler.HTTPGet.HTTPHeaders {
-					UniqueReadnessHeader := &k8sapiv1.HTTPHeader{
-						Name:  &value.Name,
-						Value: &value.Value,
-					}
-					ReadinessProbeHTTPHeaders = append(ReadinessProbeHTTPHeaders, UniqueReadnessHeader)
-				}
-				ReadinessProbeHTTPObject := &k8sapiv1.HTTPGetAction{
-					Path:        container.ReadinessProbe.ProbeHandler.HTTPGet.Path,
-					Port:        container.ReadinessProbe.ProbeHandler.HTTPGet.Port.IntVal,
-					Host:        container.ReadinessProbe.ProbeHandler.HTTPGet.Host,
-					Scheme:      string(container.ReadinessProbe.ProbeHandler.HTTPGet.Scheme),
-					HttpHeaders: ReadinessProbeHTTPHeaders,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_HttpGet{
-					HttpGet: ReadinessProbeHTTPObject,
-				}
-			}
-
-			if container.ReadinessProbe.ProbeHandler.Exec != nil {
-				ReadinessProbeExec := &k8sapiv1.ExecAction{
-					Command: container.ReadinessProbe.ProbeHandler.Exec.Command,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_Exec{
-					Exec: ReadinessProbeExec,
-				}
-			}
-
-			if container.ReadinessProbe.ProbeHandler.TCPSocket != nil {
-				ReadinessProbeTCPSocket := &k8sapiv1.TCPSocketAction{
-					Port: container.ReadinessProbe.ProbeHandler.TCPSocket.Port.IntVal,
-					Host: container.ReadinessProbe.ProbeHandler.TCPSocket.Host,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_TcpSocket{
-					TcpSocket: ReadinessProbeTCPSocket,
-				}
-			}
-
-			if container.ReadinessProbe.ProbeHandler.GRPC != nil {
-				ReadinessProbeGRPC := &k8sapiv1.GRPCAction{
-					Port:    container.ReadinessProbe.ProbeHandler.GRPC.Port,
-					Service: *container.ReadinessProbe.ProbeHandler.GRPC.Service,
-				}
-				HandlerObj.Handler = &k8sapiv1.Probe_Grpc{
-					Grpc: ReadinessProbeGRPC,
-				}
-			}
+			HandlerObj := ProcessObjProbe(container.LivenessProbe)
 
 			ReadinessProbeObject = &k8sapiv1.Probe{
 				InitialDelaySeconds:           &container.ReadinessProbe.InitialDelaySeconds,

--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -89,6 +89,7 @@ func ProtoForDeployment(cluster string, deployment *appsv1.Deployment) *k8sapiv1
 
 func ProcessObjProbe(objProbe *v1.Probe) *k8sapiv1.Probe {
 	HandlerObj := &k8sapiv1.Probe{}
+
 	if objProbe.ProbeHandler.HTTPGet != nil {
 		ObjProbeHTTPHeaders := make([]*k8sapiv1.HTTPHeader, 0, len(objProbe.ProbeHandler.HTTPGet.HTTPHeaders))
 		for _, value := range objProbe.ProbeHandler.HTTPGet.HTTPHeaders {

--- a/backend/service/k8s/deployment.go
+++ b/backend/service/k8s/deployment.go
@@ -87,7 +87,7 @@ func ProtoForDeployment(cluster string, deployment *appsv1.Deployment) *k8sapiv1
 	return k8sDeployment
 }
 
-func ProcessObjProbe(objProbe *v1.Probe) *k8sapiv1.Probe {
+func processObjProbe(objProbe *v1.Probe) *k8sapiv1.Probe {
 	HandlerObj := &k8sapiv1.Probe{}
 
 	if objProbe.ProbeHandler.HTTPGet != nil {
@@ -160,7 +160,7 @@ func ProtoForDeploymentSpec(deploymentSpec appsv1.DeploymentSpec) *k8sapiv1.Depl
 		LivenessProbeObject := &k8sapiv1.Probe{}
 		ReadinessProbeObject := &k8sapiv1.Probe{}
 		if container.LivenessProbe != nil {
-			HandlerObj := ProcessObjProbe(container.LivenessProbe)
+			HandlerObj := processObjProbe(container.LivenessProbe)
 
 			LivenessProbeObject = &k8sapiv1.Probe{
 				InitialDelaySeconds:           &container.LivenessProbe.InitialDelaySeconds,
@@ -174,7 +174,7 @@ func ProtoForDeploymentSpec(deploymentSpec appsv1.DeploymentSpec) *k8sapiv1.Depl
 		}
 
 		if container.ReadinessProbe != nil {
-			HandlerObj := ProcessObjProbe(container.LivenessProbe)
+			HandlerObj := processObjProbe(container.ReadinessProbe)
 
 			ReadinessProbeObject = &k8sapiv1.Probe{
 				InitialDelaySeconds:           &container.ReadinessProbe.InitialDelaySeconds,
@@ -393,18 +393,18 @@ func updateContainerProbes(deployment *appsv1.Deployment, fields *k8sapiv1.Updat
 				if handler := resourceReadinessProbe.Handler; handler != nil {
 					switch resourceReadinessProbe.Handler.(type) {
 					case *k8sapiv1.Probe_Exec:
-						container.LivenessProbe.ProbeHandler.Exec.Command = resourceReadinessProbe.GetExec().Command
+						container.ReadinessProbe.ProbeHandler.Exec.Command = resourceReadinessProbe.GetExec().Command
 					case *k8sapiv1.Probe_Grpc:
-						container.LivenessProbe.ProbeHandler.GRPC.Port = resourceReadinessProbe.GetGrpc().Port
-						container.LivenessProbe.ProbeHandler.GRPC.Service = &resourceReadinessProbe.GetGrpc().Service
+						container.ReadinessProbe.ProbeHandler.GRPC.Port = resourceReadinessProbe.GetGrpc().Port
+						container.ReadinessProbe.ProbeHandler.GRPC.Service = &resourceReadinessProbe.GetGrpc().Service
 					case *k8sapiv1.Probe_TcpSocket:
-						container.LivenessProbe.ProbeHandler.TCPSocket.Port.IntVal = resourceReadinessProbe.GetTcpSocket().Port
-						container.LivenessProbe.ProbeHandler.TCPSocket.Host = resourceReadinessProbe.GetTcpSocket().Host
+						container.ReadinessProbe.ProbeHandler.TCPSocket.Port.IntVal = resourceReadinessProbe.GetTcpSocket().Port
+						container.ReadinessProbe.ProbeHandler.TCPSocket.Host = resourceReadinessProbe.GetTcpSocket().Host
 					case *k8sapiv1.Probe_HttpGet:
-						container.LivenessProbe.ProbeHandler.HTTPGet.Host = resourceReadinessProbe.GetHttpGet().Host
-						container.LivenessProbe.ProbeHandler.HTTPGet.Path = resourceReadinessProbe.GetHttpGet().Path
-						container.LivenessProbe.ProbeHandler.HTTPGet.Port.IntVal = resourceReadinessProbe.GetHttpGet().Port
-						container.LivenessProbe.ProbeHandler.HTTPGet.Scheme = (v1.URIScheme)(resourceReadinessProbe.GetHttpGet().Scheme)
+						container.ReadinessProbe.ProbeHandler.HTTPGet.Host = resourceReadinessProbe.GetHttpGet().Host
+						container.ReadinessProbe.ProbeHandler.HTTPGet.Path = resourceReadinessProbe.GetHttpGet().Path
+						container.ReadinessProbe.ProbeHandler.HTTPGet.Port.IntVal = resourceReadinessProbe.GetHttpGet().Port
+						container.ReadinessProbe.ProbeHandler.HTTPGet.Scheme = (v1.URIScheme)(resourceReadinessProbe.GetHttpGet().Scheme)
 					}
 				}
 			}

--- a/backend/service/k8s/deployment_test.go
+++ b/backend/service/k8s/deployment_test.go
@@ -692,7 +692,7 @@ func TestProtoForDeploymentSpecWithProbesReadinessHTTPGet(t *testing.T) {
 			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
 			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Host, *&probeDeployment.GetHttpGet().Host)
+			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Host, probeDeployment.GetHttpGet().Host)
 
 			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
 			assert.NoError(t, err)
@@ -762,7 +762,7 @@ func TestProtoForDeploymentSpecWithProbesReadinessExec(t *testing.T) {
 			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
 			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command, *&probeDeployment.GetExec().Command)
+			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command, probeDeployment.GetExec().Command)
 
 			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
 			assert.NoError(t, err)
@@ -835,7 +835,7 @@ func TestProtoForDeploymentSpecWithProbesReadinessTCP(t *testing.T) {
 			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
 			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Host, *&probeDeployment.GetTcpSocket().Host)
+			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Host, probeDeployment.GetTcpSocket().Host)
 
 			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
 			assert.NoError(t, err)
@@ -908,7 +908,7 @@ func TestProtoForDeploymentSpecWithProbesReadinessGRPC(t *testing.T) {
 			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
 			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.GRPC.Port, *&probeDeployment.GetGrpc().Port)
+			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.GRPC.Port, probeDeployment.GetGrpc().Port)
 
 			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
 			assert.NoError(t, err)

--- a/backend/service/k8s/deployment_test.go
+++ b/backend/service/k8s/deployment_test.go
@@ -423,6 +423,20 @@ func TestProtoForDeploymentSpecWithProbes(t *testing.T) {
 			deployment := ProtoForDeployment("", tt.deployment)
 			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
 			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
+
+			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+			assert.NoError(t, err)
+			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
+				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+					{
+						LivenessProbe: &k8sapiv1.Probe{
+							InitialDelaySeconds: newInt32(20),
+							PeriodSeconds:       newInt32(15),
+						},
+					},
+				},
+			})
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/backend/service/k8s/deployment_test.go
+++ b/backend/service/k8s/deployment_test.go
@@ -369,35 +369,27 @@ func TestProtoForDeploymentStatus(t *testing.T) {
 func TestProtoForDeploymentSpecWithProbesLivenessHTTPGet(t *testing.T) {
 	t.Parallel()
 	var terminationVar int64 = 30
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "LivenessProbeHttpGetAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									LivenessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											HTTPGet: &v1.HTTPGetAction{
-												Path: "/",
-												Port: intstr.IntOrString{
-													IntVal: 8080,
-												},
-											},
+	var deploymentTestCase = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.IntOrString{
+											IntVal: 8080,
 										},
-										InitialDelaySeconds:           10,
-										PeriodSeconds:                 30,
-										TimeoutSeconds:                1,
-										SuccessThreshold:              1,
-										FailureThreshold:              3,
-										TerminationGracePeriodSeconds: &terminationVar,
 									},
 								},
+								InitialDelaySeconds:           10,
+								PeriodSeconds:                 30,
+								TimeoutSeconds:                1,
+								SuccessThreshold:              1,
+								FailureThreshold:              3,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -406,65 +398,54 @@ func TestProtoForDeploymentSpecWithProbesLivenessHTTPGet(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
+	t.Run("LivenessProbeHttpGetAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCase)
+		assert.Equal(t, deploymentTestCase.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCase.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						LivenessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_HttpGet{
-								HttpGet: &k8sapiv1.HTTPGetAction{
-									Port: 8081,
-								},
+		err := updateContainerProbes(deploymentTestCase, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCase, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					LivenessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_HttpGet{
+							HttpGet: &k8sapiv1.HTTPGetAction{
+								Port: 8081,
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }
 
 func TestProtoForDeploymentSpecWithProbesLivenessExec(t *testing.T) {
 	t.Parallel()
 	var terminationVar int64 = 30
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "LivenessProbeExecAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									LivenessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											Exec: &v1.ExecAction{
-												Command: []string{"ls", "-l"},
-											},
-										},
-										InitialDelaySeconds:           5,
-										PeriodSeconds:                 25,
-										TimeoutSeconds:                5,
-										SuccessThreshold:              4,
-										FailureThreshold:              8,
-										TerminationGracePeriodSeconds: &terminationVar,
+	var deploymentTestCases = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"ls", "-l"},
 									},
 								},
+								InitialDelaySeconds:           5,
+								PeriodSeconds:                 25,
+								TimeoutSeconds:                5,
+								SuccessThreshold:              4,
+								FailureThreshold:              8,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -473,68 +454,57 @@ func TestProtoForDeploymentSpecWithProbesLivenessExec(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
+	t.Run("LivenessProbeExecAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCases)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						LivenessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_Exec{
-								Exec: &k8sapiv1.ExecAction{
-									Command: []string{"ps"},
-								},
+		err := updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					LivenessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_Exec{
+							Exec: &k8sapiv1.ExecAction{
+								Command: []string{"ps"},
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }
 
 func TestProtoForDeploymentSpecWithProbesLivenessTCP(t *testing.T) {
 	t.Parallel()
 	var terminationVar int64 = 30
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "LivenessProbeTCPAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									LivenessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											TCPSocket: &v1.TCPSocketAction{
-												Port: intstr.IntOrString{
-													IntVal: 8080,
-												},
-												Host: "/",
-											},
+	var deploymentTestCases = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.IntOrString{
+											IntVal: 8080,
 										},
-										InitialDelaySeconds:           6,
-										PeriodSeconds:                 26,
-										TimeoutSeconds:                6,
-										SuccessThreshold:              10,
-										FailureThreshold:              9,
-										TerminationGracePeriodSeconds: &terminationVar,
+										Host: "/",
 									},
 								},
+								InitialDelaySeconds:           6,
+								PeriodSeconds:                 26,
+								TimeoutSeconds:                6,
+								SuccessThreshold:              10,
+								FailureThreshold:              9,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -543,34 +513,31 @@ func TestProtoForDeploymentSpecWithProbesLivenessTCP(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
+	t.Run("LivenessProbeTCPAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCases)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						LivenessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_TcpSocket{
-								TcpSocket: &k8sapiv1.TCPSocketAction{
-									Port: 8081,
-								},
+		err := updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					LivenessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_TcpSocket{
+							TcpSocket: &k8sapiv1.TCPSocketAction{
+								Port: 8081,
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }
 
 func TestProtoForDeploymentSpecWithProbesLivenessGRPC(t *testing.T) {
@@ -578,33 +545,25 @@ func TestProtoForDeploymentSpecWithProbesLivenessGRPC(t *testing.T) {
 	var terminationVar int64 = 30
 	var portGRPC int32 = 8080
 	var serviceGRPC string = "service"
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "LivenessProbeGRPCAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									LivenessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											GRPC: &v1.GRPCAction{
-												Port:    portGRPC,
-												Service: &serviceGRPC,
-											},
-										},
-										InitialDelaySeconds:           4,
-										PeriodSeconds:                 24,
-										TimeoutSeconds:                2,
-										SuccessThreshold:              4,
-										FailureThreshold:              5,
-										TerminationGracePeriodSeconds: &terminationVar,
+	var deploymentTestCases = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									GRPC: &v1.GRPCAction{
+										Port:    portGRPC,
+										Service: &serviceGRPC,
 									},
 								},
+								InitialDelaySeconds:           4,
+								PeriodSeconds:                 24,
+								TimeoutSeconds:                2,
+								SuccessThreshold:              4,
+								FailureThreshold:              5,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -613,68 +572,57 @@ func TestProtoForDeploymentSpecWithProbesLivenessGRPC(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
+	t.Run("LivenessProbeGRPCAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCases)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						LivenessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_Grpc{
-								Grpc: &k8sapiv1.GRPCAction{
-									Service: "tmp",
-								},
+		err := updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					LivenessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_Grpc{
+							Grpc: &k8sapiv1.GRPCAction{
+								Service: "tmp",
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }
 
 func TestProtoForDeploymentSpecWithProbesReadinessHTTPGet(t *testing.T) {
 	t.Parallel()
 	var terminationVar int64 = 30
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "ReadinessProbeHttpGetAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									ReadinessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											HTTPGet: &v1.HTTPGetAction{
-												Path: "/",
-												Port: intstr.IntOrString{
-													IntVal: 8080,
-												},
-											},
+	var deploymentTestCases = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.IntOrString{
+											IntVal: 8080,
 										},
-										InitialDelaySeconds:           10,
-										PeriodSeconds:                 30,
-										TimeoutSeconds:                1,
-										SuccessThreshold:              1,
-										FailureThreshold:              3,
-										TerminationGracePeriodSeconds: &terminationVar,
 									},
 								},
+								InitialDelaySeconds:           10,
+								PeriodSeconds:                 30,
+								TimeoutSeconds:                1,
+								SuccessThreshold:              1,
+								FailureThreshold:              3,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -683,68 +631,57 @@ func TestProtoForDeploymentSpecWithProbesReadinessHTTPGet(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
+	t.Run("ReadinessProbeHttpGetAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCases)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
-			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Host, probeDeployment.GetHttpGet().Host)
+		probeDeployment := processObjProbe(deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Host, probeDeployment.GetHttpGet().Host)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						ReadinessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_HttpGet{
-								HttpGet: &k8sapiv1.HTTPGetAction{
-									Host: "/test",
-								},
+		err := updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					ReadinessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_HttpGet{
+							HttpGet: &k8sapiv1.HTTPGetAction{
+								Host: "/test",
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }
 
 func TestProtoForDeploymentSpecWithProbesReadinessExec(t *testing.T) {
 	t.Parallel()
 	var terminationVar int64 = 30
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "ReadinessProbeExecAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									ReadinessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											Exec: &v1.ExecAction{
-												Command: []string{"ls", "-l"},
-											},
-										},
-										InitialDelaySeconds:           5,
-										PeriodSeconds:                 25,
-										TimeoutSeconds:                5,
-										SuccessThreshold:              4,
-										FailureThreshold:              8,
-										TerminationGracePeriodSeconds: &terminationVar,
+	var deploymentTestCases = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"ls", "-l"},
 									},
 								},
+								InitialDelaySeconds:           5,
+								PeriodSeconds:                 25,
+								TimeoutSeconds:                5,
+								SuccessThreshold:              4,
+								FailureThreshold:              8,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -753,71 +690,60 @@ func TestProtoForDeploymentSpecWithProbesReadinessExec(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
+	t.Run("ReadinessProbeExecAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCases)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
-			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command, probeDeployment.GetExec().Command)
+		probeDeployment := processObjProbe(deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command, probeDeployment.GetExec().Command)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						ReadinessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_Exec{
-								Exec: &k8sapiv1.ExecAction{
-									Command: []string{"pwd"},
-								},
+		err := updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					ReadinessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_Exec{
+							Exec: &k8sapiv1.ExecAction{
+								Command: []string{"pwd"},
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }
 
 func TestProtoForDeploymentSpecWithProbesReadinessTCP(t *testing.T) {
 	t.Parallel()
 	var terminationVar int64 = 30
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "ReadinessProbeTCPAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									ReadinessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											TCPSocket: &v1.TCPSocketAction{
-												Port: intstr.IntOrString{
-													IntVal: 8080,
-												},
-												Host: "/",
-											},
+	var deploymentTestCases = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.IntOrString{
+											IntVal: 8080,
 										},
-										InitialDelaySeconds:           6,
-										PeriodSeconds:                 26,
-										TimeoutSeconds:                6,
-										SuccessThreshold:              10,
-										FailureThreshold:              9,
-										TerminationGracePeriodSeconds: &terminationVar,
+										Host: "/",
 									},
 								},
+								InitialDelaySeconds:           6,
+								PeriodSeconds:                 26,
+								TimeoutSeconds:                6,
+								SuccessThreshold:              10,
+								FailureThreshold:              9,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -826,37 +752,34 @@ func TestProtoForDeploymentSpecWithProbesReadinessTCP(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
+	t.Run("ReadinessProbeTCPAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCases)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
-			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Host, probeDeployment.GetTcpSocket().Host)
+		probeDeployment := processObjProbe(deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Host, probeDeployment.GetTcpSocket().Host)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						ReadinessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_TcpSocket{
-								TcpSocket: &k8sapiv1.TCPSocketAction{
-									Host: "/test",
-								},
+		err := updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					ReadinessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_TcpSocket{
+							TcpSocket: &k8sapiv1.TCPSocketAction{
+								Host: "/test",
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }
 
 func TestProtoForDeploymentSpecWithProbesReadinessGRPC(t *testing.T) {
@@ -864,33 +787,25 @@ func TestProtoForDeploymentSpecWithProbesReadinessGRPC(t *testing.T) {
 	var terminationVar int64 = 30
 	var portGRPC int32 = 8080
 	var serviceGRPC string = "service"
-	var deploymentTestCases = []struct {
-		id         string
-		deployment *appsv1.Deployment
-	}{
-		{
-			id: "ReadinessProbeGRPCAction",
-			deployment: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									ReadinessProbe: &v1.Probe{
-										ProbeHandler: v1.ProbeHandler{
-											GRPC: &v1.GRPCAction{
-												Port:    portGRPC,
-												Service: &serviceGRPC,
-											},
-										},
-										InitialDelaySeconds:           4,
-										PeriodSeconds:                 24,
-										TimeoutSeconds:                2,
-										SuccessThreshold:              4,
-										FailureThreshold:              5,
-										TerminationGracePeriodSeconds: &terminationVar,
+	var deploymentTestCases = &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									GRPC: &v1.GRPCAction{
+										Port:    portGRPC,
+										Service: &serviceGRPC,
 									},
 								},
+								InitialDelaySeconds:           4,
+								PeriodSeconds:                 24,
+								TimeoutSeconds:                2,
+								SuccessThreshold:              4,
+								FailureThreshold:              5,
+								TerminationGracePeriodSeconds: &terminationVar,
 							},
 						},
 					},
@@ -899,35 +814,32 @@ func TestProtoForDeploymentSpecWithProbesReadinessGRPC(t *testing.T) {
 		},
 	}
 
-	for _, tt := range deploymentTestCases {
-		tt := tt
-		t.Run(tt.id, func(t *testing.T) {
-			t.Parallel()
-			deployment := ProtoForDeployment("", tt.deployment)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
+	t.Run("ReadinessProbeGRPCAction", func(t *testing.T) {
+		t.Parallel()
+		deployment := ProtoForDeployment("", deploymentTestCases)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds, *deployment.DeploymentSpec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
 
-			probeDeployment := processObjProbe(tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
-			assert.Equal(t, tt.deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.GRPC.Port, probeDeployment.GetGrpc().Port)
+		probeDeployment := processObjProbe(deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe)
+		assert.Equal(t, deploymentTestCases.Spec.Template.Spec.Containers[0].ReadinessProbe.GRPC.Port, probeDeployment.GetGrpc().Port)
 
-			err := updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{})
-			assert.NoError(t, err)
-			err = updateContainerProbes(tt.deployment, &k8sapiv1.UpdateDeploymentRequest_Fields{
-				ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
-					{
-						ReadinessProbe: &k8sapiv1.Probe{
-							Handler: &k8sapiv1.Probe_Grpc{
-								Grpc: &k8sapiv1.GRPCAction{
-									Service: "tmp",
-								},
+		err := updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{})
+		assert.NoError(t, err)
+		err = updateContainerProbes(deploymentTestCases, &k8sapiv1.UpdateDeploymentRequest_Fields{
+			ContainerProbes: []*k8sapiv1.UpdateDeploymentRequest_Fields_ContainerProbes{
+				{
+					ReadinessProbe: &k8sapiv1.Probe{
+						Handler: &k8sapiv1.Probe_Grpc{
+							Grpc: &k8sapiv1.GRPCAction{
+								Service: "tmp",
 							},
-							InitialDelaySeconds: newInt32(20),
-							PeriodSeconds:       newInt32(15),
 						},
+						InitialDelaySeconds: newInt32(20),
+						PeriodSeconds:       newInt32(15),
 					},
 				},
-			})
-			assert.NoError(t, err)
+			},
 		})
-	}
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Backend update probes with validation attributes

### Description
Adding update method to update liveness and readiness probes.
 
https://github.com/lyft/clutch/pull/2702

No frontend changes

### Testing Performed

```
curl -X POST http://localhost:8080/v1/k8s/updateDeployment
-H 'Content-Type: application/json' 
--data 
'{"clientset": "clientset", 
"cluster": "mycluster",
"namespace": "default", 
"name": "two-container-app", 
"fields": 
{ 
"containerProbes": 
[
{"containerName": "container2", 
"readinessProbe": 
  {"initialDelaySeconds": "6", "periodSeconds": "4" }
}]}}'
```
