### PR TITLE
topology: fix search api sort

### DIFF
--- a/backend/service/topology/querybuilder.go
+++ b/backend/service/topology/querybuilder.go
@@ -150,13 +150,13 @@ func sortQueryBuilder(query sq.SelectBuilder, s *topologyv1.SearchRequest_Sort) 
 	}
 
 	if identifer == column {
-		query = query.OrderByClause(fmt.Sprintf("? %s", direction), strings.TrimPrefix(s.Field, columnIdentifer))
+		query = query.OrderBy(fmt.Sprintf("%s %s", strings.TrimPrefix(s.Field, columnIdentifer), direction))
 	} else if identifer == metadata {
 		mdQuery, err := convertMetadataToQuery(s.Field)
 		if err != nil {
 			return sq.SelectBuilder{}, err
 		}
-		query = query.OrderByClause(fmt.Sprintf("? %s", direction), mdQuery)
+		query = query.OrderBy(fmt.Sprintf("%s %s", mdQuery, direction))
 	}
 
 	return query, nil


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The topology search API was not sorting as expected when one specifies a specific sort option. The issue was essentially the same as this [one](https://github.com/Masterminds/squirrel/issues/249). I later learned that postgres does not support parameterized `ORDER BY` values, and the recommended way to do that in a query is to create a sql function with the usage of `format` to populate your `ORDER BY` value. We don't need to do that here, but that was the most recommended for pure sql.

### Testing Performed
Local / Unit.


Ascending
```
➜  ~ curl --location 'http://localhost:8080/v1/topology/search' \
--header 'Content-Type: application/json' \
--data '{
    "limit": 2,
    "page_token": "0",
    "sort": {
        "direction": "ASCENDING",
        "field":"column.id"
    },
    "filter": {
        "search": {
            "field":"column.id",
            "text": "clutch"
        },
        "typeUrl": "type.googleapis.com/lyft.lyftk8s.v1.Facet"
    }
}'| jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   692  100   389  100   303   7511   5850 --:--:-- --:--:-- --:--:-- 14723
{
  "resources": [
    {
      "id": "production/clutch-canary",
      "pb": {
        "@type": "type.googleapis.com/lyft.lyftk8s.v1.Facet",
        "cluster": "",
        "name": "canary",
        "namespace": "",
        "shortSha": ""
      },
      "metadata": {}
    },
    {
      "id": "production/clutch-dbmigration",
      "pb": {
        "@type": "type.googleapis.com/lyft.lyftk8s.v1.Facet",
        "cluster": "",
        "name": "dbmigration",
        "namespace": "",
        "shortSha": ""
      },
      "metadata": {}
    }
  ],
  "nextPageToken": "1"
}
```

Descending
```
curl --location 'http://localhost:8080/v1/topology/search' \
--header 'Content-Type: application/json' \
--data '{
    "limit": 2,
    "page_token": "0",
    "sort": {
        "direction": "DESCENDING",
        "field":"column.id"
    },
    "filter": {
        "search": {
            "field":"column.id",
            "text": "clutch"
        },
        "typeUrl": "type.googleapis.com/lyft.lyftk8s.v1.Facet"
    }
}'|jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   739  100   435  100   304  14099   9853 --:--:-- --:--:-- --:--:-- 28423
{
  "resources": [
    {
      "id": "staging/mobilefaultinjection-syncclutchdatastoretotcs",
      "pb": {
        "@type": "type.googleapis.com/lyft.lyftk8s.v1.Facet",
        "cluster": "",
        "name": "syncclutchdatastoretotcs",
        "namespace": "",
        "shortSha": ""
      },
      "metadata": {}
    },
    {
      "id": "staging/clutchdata-datadeploy",
      "pb": {
        "@type": "type.googleapis.com/lyft.lyftk8s.v1.Facet",
        "cluster": "",
        "name": "datadeploy",
        "namespace": "",
        "shortSha": ""
      },
      "metadata": {}
    }
  ],
  "nextPageToken": "1"
}
```
