### PR TITLE
frontend: Autocomplete Adjustments

### DIFF
--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -385,7 +385,6 @@ const TextFieldRef = (
           // Will call onChange with the value of the selected option before calling onReturn, allowing
           // the calling component to submit the form with the selected value.
           if (v && onReturn) {
-            console.log("CALLIING ONRETURN", { v });
             changeCallback({
               ...e,
               target: { ...e.target, value: v?.label || v?.id },

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -255,6 +255,7 @@ const TextFieldRef = (
   const formValidation =
     formRegistration !== undefined ? formRegistration(name, { required }) : undefined;
   const changeCallback = onChange !== undefined ? onChange : e => {};
+  const returnCallback = _.debounce(onReturn !== undefined ? onReturn : () => {}, 100);
   const onKeyDown = (
     e: React.KeyboardEvent<HTMLDivElement | HTMLTextAreaElement | HTMLInputElement>
   ) => {
@@ -263,7 +264,7 @@ const TextFieldRef = (
     }
     changeCallback(e as React.ChangeEvent<any>);
     if (e.keyCode === KEY_ENTER && onReturn && !error) {
-      onReturn();
+      returnCallback();
     }
   };
 
@@ -380,9 +381,16 @@ const TextFieldRef = (
         // the choice has updated. Note that this does not work if the `value` prop is being set
         // manually (as is the case in proj selector and proj catalog)
         // TODO: Make it work for all cases, not just the resolver and k8s dash.
-        onChange={(_e, v) => {
+        onChange={(e, v: AutocompleteResultProps) => {
+          // Will call onChange with the value of the selected option before calling onReturn, allowing
+          // the calling component to submit the form with the selected value.
           if (v && onReturn) {
-            onReturn();
+            console.log("CALLIING ONRETURN", { v });
+            changeCallback({
+              ...e,
+              target: { ...e.target, value: v?.label || v?.id },
+            } as React.ChangeEvent<any>);
+            returnCallback();
           }
         }}
       />

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -277,20 +277,20 @@ const ProjectSelector = ({ onError }: ProjectSelectorProps) => {
     updateSelected(dashState);
   }, [state]);
 
-  const handleAdd = () => {
-    if (customProject === "") {
+  const handleAdd = v => {
+    if (!v.project || v?.project === "") {
       return;
     }
     dispatch({
       type: "ADD_PROJECTS",
-      payload: { group: Group.PROJECTS, projects: [customProject] },
+      payload: { group: Group.PROJECTS, projects: [v.project] },
     });
     setCustomProject("");
   };
 
   const hasError = state.error !== undefined && state.error !== null;
 
-  const { handleSubmit } = useForm({
+  const { handleSubmit, register } = useForm({
     mode: "onSubmit",
     reValidateMode: "onSubmit",
     shouldFocusError: false,
@@ -299,6 +299,10 @@ const ProjectSelector = ({ onError }: ProjectSelectorProps) => {
   const handleChanges = event => {
     setCustomProject(event.target.value);
   };
+
+  const handleSubmission = _.debounce(() => {
+    handleSubmit(handleAdd)();
+  }, 100);
 
   const { updateRefreshRate } = useRefreshUpdater();
 
@@ -398,15 +402,24 @@ const ProjectSelector = ({ onError }: ProjectSelectorProps) => {
             {state.loading && <LinearProgress color="secondary" />}
           </StyledProgressContainer>
           <Divider />
-          <Form noValidate onSubmit={handleSubmit(handleAdd)}>
+          <Form
+            noValidate
+            onSubmit={e => {
+              e.preventDefault();
+              handleSubmission();
+            }}
+          >
             <StyledProjectTextField
               disabled={state.loading}
               placeholder="Add a project"
+              name="project"
               value={customProject}
               onChange={handleChanges}
+              onReturn={handleSubmission}
               helperText={state.error?.message}
               error={hasError}
               autocompleteCallback={v => autoComplete(v)}
+              formRegistration={register}
               endAdornment={<AddIcon />}
             />
           </Form>


### PR DESCRIPTION
### Description
Makes modifications to autocomplete onReturn flow as well as the ProjectSelector usage of it to fix autocomplete issues.

- modifies the onReturn caller to be a debounced version so it doesn't call it multiple times from pressing enter or selecting from a dropdown
- Will fire an onChange event for onReturn so that when selecting an item from the dropdown it doesn't submit with what is currently typed in
- Adds form handling for the ProjectSelector to correctly grab the field and adds an onReturn so that it can fire when selecting something from the dropdown

### Testing Performed
manual
