### PR TITLE
change to v1 from v1beta1

### DIFF
--- a/backend/service/k8s/cronjob.go
+++ b/backend/service/k8s/cronjob.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	v1beta1 "k8s.io/api/batch/v1beta1"
+	v1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k8sapiv1 "github.com/lyft/clutch/backend/api/k8s/v1"
@@ -19,7 +19,7 @@ func (s *svc) DescribeCronJob(ctx context.Context, clientset, cluster, namespace
 		return nil, err
 	}
 
-	cronJobs, err := cs.BatchV1beta1().CronJobs(cs.Namespace()).List(ctx, metav1.ListOptions{
+	cronJobs, err := cs.BatchV1().CronJobs(cs.Namespace()).List(ctx, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + name,
 	})
 	if err != nil {
@@ -45,7 +45,7 @@ func (s *svc) ListCronJobs(ctx context.Context, clientset, cluster, namespace st
 		return nil, err
 	}
 
-	cronJobList, err := cs.BatchV1beta1().CronJobs(cs.Namespace()).List(ctx, opts)
+	cronJobList, err := cs.BatchV1().CronJobs(cs.Namespace()).List(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -66,10 +66,10 @@ func (s *svc) DeleteCronJob(ctx context.Context, clientset, cluster, namespace, 
 	}
 
 	opts := metav1.DeleteOptions{}
-	return cs.BatchV1beta1().CronJobs(cs.Namespace()).Delete(ctx, name, opts)
+	return cs.BatchV1().CronJobs(cs.Namespace()).Delete(ctx, name, opts)
 }
 
-func ProtoForCronJob(cluster string, k8scronJob *v1beta1.CronJob) *k8sapiv1.CronJob {
+func ProtoForCronJob(cluster string, k8scronJob *v1.CronJob) *k8sapiv1.CronJob {
 	clusterName := GetKubeClusterName(k8scronJob)
 	if clusterName == "" {
 		clusterName = cluster

--- a/backend/service/k8s/cronjob_test.go
+++ b/backend/service/k8s/cronjob_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -15,7 +15,7 @@ import (
 )
 
 func testCronService() *svc {
-	cron := &v1beta1.CronJob{
+	cron := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "testing-cron-name",
 			Namespace:   "testing-namespace",
@@ -78,14 +78,14 @@ func TestProtoForCron(t *testing.T) {
 		inputClusterName    string
 		expectedClusterName string
 		expectedName        string
-		cron                *v1beta1.CronJob
+		cron                *batchv1.CronJob
 	}{
 		{
 			id:                  "clustername already set",
 			inputClusterName:    "abc",
 			expectedClusterName: "production",
 			expectedName:        "test1",
-			cron: &v1beta1.CronJob{
+			cron: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						clutchLabelClusterName: "production",
@@ -99,20 +99,20 @@ func TestProtoForCron(t *testing.T) {
 			inputClusterName:    "staging",
 			expectedClusterName: "staging",
 			expectedName:        "test2",
-			cron: &v1beta1.CronJob{
+			cron: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						clutchLabelClusterName: "",
 					},
 					Name: "test2",
 				},
-				Spec: v1beta1.CronJobSpec{
-					ConcurrencyPolicy:       v1beta1.AllowConcurrent,
+				Spec: batchv1.CronJobSpec{
+					ConcurrencyPolicy:       batchv1.AllowConcurrent,
 					Schedule:                "5 4 * * *",
 					Suspend:                 &[]bool{true}[0],
 					StartingDeadlineSeconds: &[]int64{69}[0],
 				},
-				Status: v1beta1.CronJobStatus{
+				Status: batchv1.CronJobStatus{
 					Active: []v1.ObjectReference{{}, {}},
 				},
 			},


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Currently we see warnings about using the v1beta1 version so we can use the v1 to fix it
`13 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob`

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
