### PR TITLE
[backend] add account field to aws mock for ddb table

### DIFF
--- a/backend/mock/service/awsmock/awsmock.go
+++ b/backend/mock/service/awsmock/awsmock.go
@@ -128,8 +128,9 @@ func (s *svc) S3GetBucketPolicy(ctx context.Context, account, region, bucket, ac
 
 func (s *svc) DescribeTable(ctx context.Context, account, region, tableName string) (*dynamodbv1.Table, error) {
 	ret := &dynamodbv1.Table{
-		Name:   tableName,
-		Region: region,
+		Name:    tableName,
+		Region:  region,
+		Account: "default",
 		ProvisionedThroughput: &dynamodbv1.Throughput{
 			ReadCapacityUnits:  100,
 			WriteCapacityUnits: 200,
@@ -194,6 +195,7 @@ func (s *svc) UpdateCapacity(ctx context.Context, account, region, tableName str
 	ret := &dynamodbv1.Table{
 		Name:                   tableName,
 		Region:                 region,
+		Account:                "default",
 		ProvisionedThroughput:  currentThroughput,
 		Status:                 dynamodbv1.Table_Status(3),
 		GlobalSecondaryIndexes: gsis,

--- a/backend/module/dynamodb/aws_test.go
+++ b/backend/module/dynamodb/aws_test.go
@@ -51,6 +51,7 @@ var g = []*dynamodbv1.GlobalSecondaryIndex{
 var testTable = &dynamodbv1.Table{
 	Name:                   "",
 	Region:                 "",
+	Account:                "default",
 	ProvisionedThroughput:  pt,
 	GlobalSecondaryIndexes: g,
 	Status:                 dynamodbv1.Table_Status(3),


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
This PR adds `account` field to the mock for AWS dynamodb service functions, following the changes for other AWS mocked resources in #1873. Noticed this was missing from dynamodb mocks when trying to display account info during local testing of frontend changes.
 
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Tested by manually modifying files in the submodule used for local Clutch development; adding the `account` field to the mock fixed the errors I was running into

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
