### PR TITLE
housekeeping: Adjust algolia search params

### DIFF
--- a/docs/_website/docusaurus.config.js
+++ b/docs/_website/docusaurus.config.js
@@ -113,6 +113,7 @@ module.exports = {
       apiKey: "e9fd4dc1b48bb4b9e8763d3adc9df6d1",
       appId: "XFPMTG0051",
       indexName: "lyft_clutch",
+      contextualSearch: false,
     },
     prism: {
       additionalLanguages: ["protobuf", "typescript"],


### PR DESCRIPTION
### Description
Issues with algolia search, found that if we set `contextualSearch` to false it actually fixes it.

#### Without Setting (Local)
![Screenshot 2023-07-25 at 11 56 53 AM](https://github.com/lyft/clutch/assets/8338893/2ba5cd1a-14ac-4412-a177-e67a7ec0b281)

#### With setting (Local)
![Screenshot 2023-07-25 at 11 56 13 AM](https://github.com/lyft/clutch/assets/8338893/fa2ce08d-9b66-4274-84d1-4b7aebd0c841)

### Testing Performed
local

### References
https://github.com/facebook/docusaurus/issues/3805
https://github.com/facebook/docusaurus/issues/5084