### PR TITLE
remove sorting and let fe do it

### DIFF
--- a/backend/service/k8s/event.go
+++ b/backend/service/k8s/event.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"sort"
 	"strings"
 
 	"github.com/iancoleman/strcase"
@@ -33,13 +32,6 @@ func (s *svc) ListEvents(ctx context.Context, clientset, cluster, namespace, obj
 	}
 
 	return events, nil
-}
-
-// For ease of use, we can sort the events in reverse chronological order
-func sortEventsByLastTime(events []*k8sapiv1.Event) {
-	sort.Slice(events, func(i, j int) bool {
-		return events[i].LastTimestampMillis > events[j].LastTimestampMillis
-	})
 }
 
 func ProtoForEvent(cluster string, k8sEvent *corev1.Event) *k8sapiv1.Event {
@@ -125,9 +117,6 @@ func (s *svc) ListNamespaceEvents(ctx context.Context, clientset, cluster, names
 		ev := ev
 		events = append(events, ProtoForEvent(cs.Cluster(), &ev))
 	}
-	// Sort in reverse chronological order (by LastTimestampMillis),
-	// this is needed because we might have multiple types of events
-	sortEventsByLastTime(events)
 
 	return events, nil
 }


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
It was decided that we will let the FE do its sorting however it wants and not have the backend worry about it.
context https://lyft.slack.com/archives/C05FPGRQLSY/p1690400933790829
<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
