### PR TITLE
golangcli: increase timeout

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -36,6 +36,6 @@ issues:
       linters:
         - staticcheck
 run:
-  timeout: 5m
+  timeout: 10m
   skip-dirs:
     - api/


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
Our lint CI has been timing out consistently at the current setting so updating to 10m, which we also set internally.

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
