### PR TITLE
frontend: Adding User Preferences Context and Customizable Header

### DIFF
--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -23,6 +23,11 @@ interface HeaderProps extends AppConfiguration {
    * Will enable the NPS feedback component in the header
    */
   enableNPS?: boolean;
+  search?: boolean;
+  feedback?: boolean;
+  shortLinks?: boolean;
+  notifications?: boolean;
+  userInfo?: boolean;
 }
 
 const AppBar = styled(MuiAppBar)({
@@ -54,9 +59,13 @@ const Header: React.FC<HeaderProps> = ({
   title = "clutch",
   logo = <Logo />,
   enableNPS = false,
+  search = true,
+  feedback = true,
+  shortLinks = true,
+  notifications = false,
+  userInfo = true,
+  children = null,
 }) => {
-  const showNotifications = false;
-
   return (
     <>
       <AppBar position="fixed" elevation={0}>
@@ -64,26 +73,34 @@ const Header: React.FC<HeaderProps> = ({
           <Link to="/">{typeof logo === "string" ? <StyledLogo src={logo} /> : logo}</Link>
           <Title>{title}</Title>
           <Grid container alignItems="center" justifyContent="flex-end">
-            <Box>
-              <SearchField />
-            </Box>
-            <SimpleFeatureFlag feature="shortLinks">
-              <FeatureOn>
-                <ShortLinker />
-              </FeatureOn>
-            </SimpleFeatureFlag>
-            {showNotifications && <Notifications />}
-            {enableNPS ? (
-              <NPSHeader />
-            ) : (
-              <SimpleFeatureFlag feature="npsHeader">
+            {search && (
+              <Box>
+                <SearchField />
+              </Box>
+            )}
+            {shortLinks && (
+              <SimpleFeatureFlag feature="shortLinks">
                 <FeatureOn>
-                  <NPSHeader />
+                  <ShortLinker />
                 </FeatureOn>
               </SimpleFeatureFlag>
             )}
-
-            <UserInformation />
+            {notifications && <Notifications />}
+            {feedback && (
+              <>
+                {enableNPS ? (
+                  <NPSHeader />
+                ) : (
+                  <SimpleFeatureFlag feature="npsHeader">
+                    <FeatureOn>
+                      <NPSHeader />
+                    </FeatureOn>
+                  </SimpleFeatureFlag>
+                )}
+              </>
+            )}
+            {children && children}
+            {userInfo && <UserInformation />}
           </Grid>
         </Toolbar>
       </AppBar>

--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -23,10 +23,25 @@ interface HeaderProps extends AppConfiguration {
    * Will enable the NPS feedback component in the header
    */
   enableNPS?: boolean;
+  /**
+   * Will enable the workflow search component in the header
+   */
   search?: boolean;
+  /**
+   * Will enable the NPS feedback component in the header
+   */
   feedback?: boolean;
+  /**
+   * Will enable the shortlinks component in the header
+   */
   shortLinks?: boolean;
+  /**
+   * Will enable the notifications component in the header
+   */
   notifications?: boolean;
+  /**
+   * Will enable the user information component in the header
+   */
   userInfo?: boolean;
 }
 

--- a/frontend/packages/core/src/AppLayout/index.tsx
+++ b/frontend/packages/core/src/AppLayout/index.tsx
@@ -23,12 +23,18 @@ const MainContent = styled.div({ overflowY: "auto", width: "100%" });
 interface AppLayoutProps {
   isLoading?: boolean;
   configuration?: AppConfiguration;
+  header?: React.ReactElement<any>;
 }
 
-const AppLayout: React.FC<AppLayoutProps> = ({ isLoading = false, configuration = {} }) => {
+const AppLayout: React.FC<AppLayoutProps> = ({
+  isLoading = false,
+  configuration = {},
+  header = null,
+}) => {
   return (
     <AppGrid container direction="column" data-testid="app-layout-component">
-      <Header {...configuration} />
+      {header && React.cloneElement(header, { ...configuration, ...header.props })}
+      {!header && <Header {...configuration} />}
       <ContentGrid container wrap="nowrap">
         {isLoading ? (
           <Loadable isLoading={isLoading} variant="overlay" />

--- a/frontend/packages/core/src/AppLayout/user.tsx
+++ b/frontend/packages/core/src/AppLayout/user.tsx
@@ -15,6 +15,7 @@ import {
 } from "@mui/material";
 import Cookies from "js-cookie";
 import jwtDecode from "jwt-decode";
+import * as _ from "lodash";
 
 const UserPhoto = styled(IconButton)({
   padding: "12px",
@@ -162,7 +163,11 @@ export interface UserInformationProps {
 }
 
 // TODO (sperry): investigate using popover instead of popper
-const UserInformation: React.FC<UserInformationProps> = ({ data, user = userId() }) => {
+const UserInformation: React.FC<UserInformationProps> = ({
+  data,
+  user = userId(),
+  children = null,
+}) => {
   const userInitials = user.slice(0, 2).toUpperCase();
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef(null);
@@ -172,12 +177,14 @@ const UserInformation: React.FC<UserInformationProps> = ({ data, user = userId()
   };
 
   const handleClose = event => {
+    if (event.target.localName === "body") {
+      return;
+    }
     if (anchorRef.current && anchorRef.current.contains(event.target)) {
       return;
     }
     setOpen(false);
   };
-
   const handleListKeyDown = event => {
     if (event.key === "Tab") {
       event.preventDefault();
@@ -219,6 +226,15 @@ const UserInformation: React.FC<UserInformationProps> = ({ data, user = userId()
                       {i > 0 && i < data.length && <Divider />}
                     </>
                   ))}
+                  {_.castArray(children).length > 0 && <Divider />}
+                  <div style={{ marginBottom: "8px" }}>
+                    {_.castArray(children)?.map((c, i) => (
+                      <>
+                        <MenuItem>{c}</MenuItem>
+                        {i < _.castArray(children).length - 1 && <Divider />}
+                      </>
+                    ))}
+                  </div>
                 </MenuList>
               </ClickAwayListener>
             </Paper>

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -59,21 +59,33 @@ const featureFlagFilter = (workflows: Workflow[]): Promise<Workflow[]> => {
   );
 };
 
+enum ChildType {
+  HEADER = "header",
+}
+
+interface ChildTypes {
+  type: ChildType;
+}
+
+type ClutchAppChildType = ChildTypes;
+
+type ClutchAppChild = React.ReactElement<ClutchAppChildType>;
+
 interface ClutchAppProps {
   availableWorkflows: {
     [key: string]: () => WorkflowConfiguration;
   };
   configuration: UserConfiguration;
   appConfiguration: AppConfiguration;
-  children?: React.ReactElement<any> | React.ReactElement<any>[];
+  children?: ClutchAppChild | ClutchAppChild[];
 }
 
-const ClutchApp: React.FC<ClutchAppProps> = ({
+const ClutchApp = ({
   availableWorkflows,
   configuration: userConfiguration,
   appConfiguration,
   children,
-}) => {
+}: ClutchAppProps) => {
   const [workflows, setWorkflows] = React.useState<Workflow[]>([]);
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
   const [workflowSessionStore, setWorkflowSessionStore] = React.useState<HydratedData>();
@@ -136,9 +148,9 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
     if (children) {
       React.Children.forEach(children, child => {
         if (React.isValidElement(child)) {
-          const { type } = child?.props || {};
+          const { type = "" } = child?.props || {};
 
-          if (type === "HEADER") {
+          if (type.toLowerCase() === ChildType.HEADER) {
             setCustomHeader(child);
           }
         }
@@ -236,7 +248,7 @@ const ClutchApp: React.FC<ClutchAppProps> = ({
   );
 };
 
-const BugSnagApp = props => {
+const BugSnagApp = (props: ClutchAppProps) => {
   if (process.env.REACT_APP_BUGSNAG_API_TOKEN) {
     // eslint-disable-next-line no-underscore-dangle
     if (!(Bugsnag as any)._client) {

--- a/frontend/packages/core/src/Contexts/index.tsx
+++ b/frontend/packages/core/src/Contexts/index.tsx
@@ -7,3 +7,4 @@ export type {
   WorkflowRetrieveDataFn,
   WorkflowStoreDataFn,
 } from "./workflow-storage-context";
+export { useUserPreferences, UserPreferencesProvider } from "./preferences-context";

--- a/frontend/packages/core/src/Contexts/preferences-context.tsx
+++ b/frontend/packages/core/src/Contexts/preferences-context.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+export type ActionType = "SetPref" | "RemovePref" | "SetLocalPref" | "RemoveLocalPref";
+const STORAGE_KEY = "userPreferences";
+type State = { key: string; value?: unknown };
+type Action = { type: ActionType; payload: State };
+type Dispatch = (action: Action) => void;
+type UserPreferencesProviderProps = { children: React.ReactNode };
+const DEFAULT_PREFERENCES = {} as State;
+interface ContextProps {
+  preferences: State;
+  dispatch: Dispatch;
+}
+
+type ContextType = ContextProps | undefined;
+
+export interface PreferencesContextProps {
+  preferences: {
+    [key: string]: unknown;
+  };
+  getPref: (key: string) => unknown;
+  setPref: (key: string, value: unknown) => void;
+}
+
+const preferencesReducer = (preferences: State, action: Action): State => {
+  switch (action.type) {
+    case "SetPref": {
+      const updatedPref = { ...preferences, [action.payload.key]: action.payload.value };
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedPref));
+      } catch {}
+      return updatedPref;
+    }
+    case "RemovePref": {
+      const updatedPref = { ...preferences };
+      delete updatedPref[action.payload.key];
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedPref));
+      } catch {}
+      return updatedPref;
+    }
+    case "SetLocalPref": {
+      return { ...preferences, [action.payload.key]: action.payload.value };
+    }
+    case "RemoveLocalPref": {
+      const updatedPref = { ...preferences };
+      delete updatedPref[action.payload.key];
+      return updatedPref;
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`);
+    }
+  }
+};
+
+const UserPreferencesContext = React.createContext<ContextType>(undefined);
+
+const UserPreferencesProvider = ({ children }: UserPreferencesProviderProps) => {
+  // Load preferences as default value and if none then default to value
+  let pref = DEFAULT_PREFERENCES;
+  try {
+    pref = JSON.parse(localStorage.getItem(STORAGE_KEY) || "");
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(pref));
+  const [state, dispatch] = React.useReducer(preferencesReducer, pref);
+
+  const value = React.useMemo(() => ({ preferences: state, dispatch }), [state, dispatch]);
+
+  return (
+    <UserPreferencesContext.Provider value={value}>{children}</UserPreferencesContext.Provider>
+  );
+};
+
+const useUserPreferences = () => {
+  const context = React.useContext(UserPreferencesContext);
+  if (!context) {
+    throw new Error("useUserPreferences was invoked outside of a valid context");
+  }
+  return context;
+};
+
+export { useUserPreferences, UserPreferencesProvider };

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -5,7 +5,8 @@ export {
   AccordionDivider,
   AccordionGroup,
 } from "./accordion";
-export { userId } from "./AppLayout/user";
+export { default as Header } from "./AppLayout/header";
+export { UserInformation, userId } from "./AppLayout/user";
 export * from "./Assets/emojis";
 export * from "./Assets/icons";
 export { Button, ButtonGroup, ClipboardButton, IconButton } from "./button";
@@ -13,7 +14,12 @@ export { Card, CardContent, CardHeader } from "./card";
 export * from "./Charts";
 export * from "./chip";
 export { default as Confirmation } from "./confirmation";
-export { useWorkflowStorageContext, useWizardContext, WizardContext } from "./Contexts";
+export {
+  useWorkflowStorageContext,
+  useWizardContext,
+  WizardContext,
+  useUserPreferences,
+} from "./Contexts";
 export { Dialog, DialogActions, DialogContent } from "./dialog";
 export * from "./Feedback";
 export { FeatureOff, FeatureOn, SimpleFeatureFlag } from "./flags";


### PR DESCRIPTION
### Description
- Modifies the header to take customizable settings for what to display/hide.
- Can now pass in a header with a `type="HEADER"` as a child to `<ClutchApp />` and it will take over as the main header, this allows for customizing the header entirely
- Can pass children to the newly passed in Header (if you just reuse the exported one from Clutch) that will place them inside the header component
- The userInfo component now also takes children so small options or buttons can be expanded for use on the dropdown

### Testing Performed
manual