### PR TITLE
frontend: Fixing Default for UserInfo component

### DIFF
--- a/frontend/packages/core/src/AppLayout/user.tsx
+++ b/frontend/packages/core/src/AppLayout/user.tsx
@@ -166,7 +166,7 @@ export interface UserInformationProps {
 const UserInformation: React.FC<UserInformationProps> = ({
   data,
   user = userId(),
-  children = null,
+  children = [],
 }) => {
   const userInitials = user.slice(0, 2).toUpperCase();
   const [open, setOpen] = React.useState(false);


### PR DESCRIPTION
### Description
Issue found with the new changes to the UserInfo component. Was defaulting children to `null` which when being cast to an array was treating it as a single entry. Instead defaulting to an empty array to fix the issue.

#### Broken
![Screenshot 2023-09-19 at 9 11 33 AM](https://github.com/lyft/clutch/assets/8338893/bb996152-0c2e-4e8b-8b62-a176d6fd8039)

#### Fixed
![Screenshot 2023-09-19 at 9 08 53 AM](https://github.com/lyft/clutch/assets/8338893/a4ba03c4-ea2c-4f2f-8e3f-7e009ac79465)

### Testing Performed
manual
