### PR TITLE
frontend: Alert Component Adding Icon Prop

### DIFF
--- a/frontend/packages/core/src/Feedback/alert.tsx
+++ b/frontend/packages/core/src/Feedback/alert.tsx
@@ -75,7 +75,10 @@ const iconMappings = {
 export const SEVERITIES = Object.keys(iconMappings);
 
 export interface AlertProps
-  extends Pick<MuiAlertProps, "severity" | "action" | "onClose" | "elevation" | "variant"> {
+  extends Pick<
+    MuiAlertProps,
+    "severity" | "action" | "onClose" | "elevation" | "variant" | "icon"
+  > {
   title?: React.ReactNode;
 }
 


### PR DESCRIPTION
### Description
Enables the icon prop in the Alert component. This allows for overriding the icon used from the defaults based on severity.

#### Screenshot
![Screenshot 2023-09-25 at 11 24 36 AM](https://github.com/lyft/clutch/assets/8338893/85e13c70-966f-455e-9e47-42fda63c5ef1)

### Testing Performed
manual
