### PR TITLE
frontend: add forever option to watch flag in scaffolded workflows

### DIFF
--- a/tools/scaffolding/templates/frontend/package.json
+++ b/tools/scaffolding/templates/frontend/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf ./dist && rm -f tsconfig.tsbuildinfo",
     "compile": "tsc -b",
     "compile:dev": "esbuild --target=es2019 --outdir=dist --sourcemap src/*.tsx",
-    "compile:watch": "yarn compile:dev --watch",
+    "compile:watch": "yarn compile:dev --watch=forever",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
     "test": "jest --passWithNoTests",


### PR DESCRIPTION
The generated workflows via `make scaffold-workflow` weren't compiling successfully due to their `package.json` file missing the `forever` option in the `watch` flag of the `compile:dev` script.
e.g.
```sh
@clutch-sh/amiibo: [watch] stopped because stdin was closed (use "--watch=forever" to keep watching even after stdin is closed)
```

### Testing Performed
manual