### PR TITLE
Remove clutchdotsh Twitter references

### DIFF
--- a/docs/_website/docusaurus.config.js
+++ b/docs/_website/docusaurus.config.js
@@ -194,10 +194,6 @@ module.exports = {
               label: "Slack",
               to: "https://join.slack.com/t/lyftoss/shared_invite/zt-casz6lz4-G7gOx1OhHfeMsZKFe1emSA",
             },
-            {
-              label: "Twitter",
-              to: "https://twitter.com/clutchdotsh",
-            },
             { label: "Blog", to: "blog" },
             {
               label: "More",

--- a/docs/_website/src/theme/Footer/index.tsx
+++ b/docs/_website/src/theme/Footer/index.tsx
@@ -24,10 +24,6 @@ const socialLinks = [
     href: "https://github.com/lyft/clutch",
   },
   {
-    icon: "fe fe-twitter",
-    href: "https://twitter.com/clutchdotsh",
-  },
-  {
     icon: "fe fe-slack",
     href: "https://join.slack.com/t/lyftoss/shared_invite/zt-casz6lz4-G7gOx1OhHfeMsZKFe1emSA",
   },

--- a/docs/community.md
+++ b/docs/community.md
@@ -14,12 +14,6 @@ Join the **Lyft OSS Slack** and come see us in channel **`#clutch`**!
 
 </CommunityCard>
 
-<CommunityCard icon="twitter" to="https://twitter.com/clutchdotsh">
-
-Follow us on **Twitter** for news and updates `@clutchdotsh`.
-
-</CommunityCard>
-
 <CommunityCard icon="github" to="https://github.com/lyft/clutch/issues">
 
 File a GitHub issue in **`lyft/clutch`**.


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->
Remove Twitter references to the now deactivated _clutchdotsh_ account

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->
Attaching some screenshots
<img width="693" alt="image" src="https://github.com/lyft/clutch/assets/21126594/a1ab5479-e9d6-49c9-ab4d-b04edbfd2857">
<img width="304" alt="image" src="https://github.com/lyft/clutch/assets/21126594/de31ab98-06da-4300-bad5-6f5c09e3fe2b">
<img width="116" alt="image" src="https://github.com/lyft/clutch/assets/21126594/7a6bd8bb-3441-47a8-8bb2-0073621c604d">

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #
N/A
### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->
N/A
<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
