### PR TITLE
docs: Remove calendly from community

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -20,14 +20,6 @@ File a GitHub issue in **`lyft/clutch`**.
 
 </CommunityCard>
 
-<CommunityCard icon="calendar" to="https://calendly.com/clutchsh/office-hours">
-
-Schedule time during our office hours with **Calendly**.
-
-*Available in 15-minute slots on Tuesdays from 11am - 12pm Pacific.*
-
-</CommunityCard>
-
 ## Contributing
 
 Please view the [Code of Conduct](https://github.com/lyft/clutch/blob/main/CODE_OF_CONDUCT.md) if you're interested in contributing.


### PR DESCRIPTION
Remove Calendly from Clutch.sh

### Description
Calendly option removed from _Community_ page on Clutch.sh

Before:
<img width="1137" alt="Screenshot 2023-11-30 at 12 44 02 p m" src="https://github.com/lyft/clutch/assets/25833665/1d0aa750-4b0b-4adf-b75d-456ffb8e0448">

After:
<img width="1126" alt="Screenshot 2023-11-30 at 12 44 16 p m" src="https://github.com/lyft/clutch/assets/25833665/32ac0011-5ad8-44eb-bd75-ec5852ac4157">

### Testing Performed
* Click on _Community_ option on the top left header
* Confirm that the "_Schedule time during our office hours with Calendly_" option is no longer visible