### PR TITLE
frontend: leverage theme palette for misc components

### DIFF
--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -14,7 +14,7 @@ import {
 
 const DialogPaper = styled(Paper)(({ theme }) => ({
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.1)}`,
-  boxShadow: "0px 10px 24px rgba(35, 48, 143, 0.3)",
+  boxShadow: `0px 10px 24px ${alpha(theme.palette.primary[700], 0.3)}}`,
   boxSizing: "border-box",
   backgroundColor: theme.palette.contrastColor,
   width: "max-content",

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import CloseIcon from "@mui/icons-material/Close";
 import type { DialogProps as MuiDialogProps } from "@mui/material";
 import {
@@ -12,9 +11,11 @@ import {
   Paper,
 } from "@mui/material";
 
+import styled from "./styled";
+
 const DialogPaper = styled(Paper)(({ theme }) => ({
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.1)}`,
-  boxShadow: `0px 10px 24px ${alpha(theme.palette.primary[700], 0.3)}}`,
+  boxShadow: `0px 10px 24px ${alpha(theme.palette.primary[700], 0.3)}`,
   boxSizing: "border-box",
   backgroundColor: theme.palette.contrastColor,
   width: "max-content",
@@ -30,7 +31,7 @@ const DialogTitle = styled(MuiDialogTitle)(({ theme }) => ({
   color: theme.palette.secondary[900],
 }));
 
-const DialogTitleText = styled.div({
+const DialogTitleText = styled("div")({
   padding: "14px 0 0 0",
 });
 

--- a/frontend/packages/core/src/icon.tsx
+++ b/frontend/packages/core/src/icon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
 import FiberManualRecordTwoToneIcon from "@mui/icons-material/FiberManualRecordTwoTone";
-import { Grid } from "@mui/material";
+import { Grid, useTheme } from "@mui/material";
 
 import type { GridJustification } from "./grid";
 
@@ -28,6 +28,7 @@ export const StatusIcon: React.FC<StatusProps> = ({
   align = "left",
   ...props
 }) => {
+  const theme = useTheme();
   let justifyContent: GridJustification = "flex-start";
   if (align === "right") {
     justifyContent = "flex-end";
@@ -38,17 +39,17 @@ export const StatusIcon: React.FC<StatusProps> = ({
     <Grid container alignItems="center" justifyContent={justifyContent} {...props}>
       {variant === "neutral" && (
         <>
-          <StyledStatusIcon data-color="#C2C8F2" /> {children}
+          <StyledStatusIcon data-color={theme.palette.primary[400]} /> {children}
         </>
       )}
       {variant === "success" && (
         <>
-          <StyledStatusIcon data-color="#69F0AE" /> {children}
+          <StyledStatusIcon data-color={theme.palette.success[300]} /> {children}
         </>
       )}
       {variant === "failure" && (
         <>
-          <StyledStatusIcon data-color="#FF8A80" /> {children}
+          <StyledStatusIcon data-color={theme.palette.error[300]} /> {children}
         </>
       )}
     </Grid>

--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -24,7 +24,7 @@ const StyledPopper = styled(MuiPopper)({
 const Paper = styled(MuiPaper)(({ theme }) => ({
   minWidth: "fit-content",
   border: `1px solid ${theme.palette.secondary[200]}`,
-  boxShadow: "0px 10px 24px rgba(35, 48, 143, 0.3)",
+  boxShadow: `0px 10px 24px ${alpha(theme.palette.primary[700], 0.3)}`,
   ".MuiListItem-root[id='popperItem']": {
     backgroundColor: theme.palette.contrastColor,
     height: "48px",

--- a/frontend/packages/core/src/text.tsx
+++ b/frontend/packages/core/src/text.tsx
@@ -15,10 +15,10 @@ const ContentContainer = styled(Grid)({
 
 const Pre = styled("pre")(({ theme }) => ({
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.38)}`,
-  backgroundColor: "rgba(13,16,48,0.12)",
+  backgroundColor: alpha(theme.palette.secondary[900], 0.12),
   borderRadius: "4px",
   fontSize: "16px",
-  color: "#242b8c",
+  color: theme.palette.primary[800],
   padding: "12px 16px",
   flex: 1,
   whiteSpace: "pre-wrap",

--- a/frontend/packages/core/src/text.tsx
+++ b/frontend/packages/core/src/text.tsx
@@ -28,6 +28,13 @@ const Pre = styled("pre")(({ theme }) => ({
   overflowY: "scroll",
 }));
 
+const StyledFab = styled(Fab)(({ theme }) => ({
+  background: theme.palette.secondary[200],
+  "&:hover": {
+    background: theme.palette.secondary[50],
+  },
+}));
+
 interface CodeProps {
   children: string;
   showCopyButton?: boolean;
@@ -38,9 +45,9 @@ const Code = ({ children, showCopyButton = true }: CodeProps) => (
     {showCopyButton && (
       // TODO: Figure out a more permanent fix for the copy button
       <CopyButtonContainer container justifyContent="flex-end">
-        <Fab variant="circular" size="small">
+        <StyledFab variant="circular" size="small">
           <ClipboardButton text={children} />
-        </Fab>
+        </StyledFab>
       </CopyButtonContainer>
     )}
     <ContentContainer justifyContent="flex-start" alignItems="center">

--- a/frontend/workflows/envoy/src/remote-triage/clusters.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/clusters.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { AccordionRow, StatusIcon, styled, Table, TableRow } from "@clutch-sh/core";
+import { AccordionRow, StatusIcon, styled, Table, TableRow, useTheme } from "@clutch-sh/core";
 import _ from "lodash";
 
 const BarContainer = styled("rect")<{ $fill: string; $width: string }>(
   {
     height: "12px",
   },
-  props => ({
+  props => ({ theme }) => ({
     width: props.$width,
     fill: props.$fill,
     strokeWidth: props.$fill === "transparent" ? "1px" : "0",
-    stroke: "#C2C8F2",
+    stroke: theme.palette.primary[400],
   })
 );
 
@@ -27,11 +27,16 @@ interface RatioStatusProps {
 }
 
 const RatioStatus: React.FC<RatioStatusProps> = ({ succeeded, failed }) => {
+  const theme = useTheme();
   const total = succeeded + failed;
   return (
     <>
-      {succeeded !== 0 && <Bar fill="#69F0AE" width={`${(succeeded / total) * 100}px`} />}
-      {failed !== 0 && <Bar fill="#FF8A80" width={`${(failed / total) * 100}px`} />}
+      {succeeded !== 0 && (
+        <Bar fill={theme.palette.success[300]} width={`${(succeeded / total) * 100}px`} />
+      )}
+      {failed !== 0 && (
+        <Bar fill={theme.palette.error[300]} width={`${(failed / total) * 100}px`} />
+      )}
     </>
   );
 };

--- a/frontend/workflows/envoy/src/remote-triage/index.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/index.tsx
@@ -8,6 +8,7 @@ import {
   Tab,
   Tabs,
   TextField,
+  useTheme,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
@@ -68,6 +69,7 @@ const download = (data, host) => {
 };
 
 const TriageDetails: React.FC<WizardChild> = () => {
+  const theme = useTheme();
   const remoteData = useDataLayout("remoteData");
   const metadata = remoteData.value.nodeMetadata as IClutch.envoytriage.v1.NodeMetadata;
   const { clusters, configDump, listeners, runtime, stats, serverInfo } =
@@ -82,12 +84,12 @@ const TriageDetails: React.FC<WizardChild> = () => {
     {
       id: "Running",
       value: healthyClusterCount,
-      color: "#69F0AE",
+      color: theme.palette.success[300],
     },
     {
       id: "Failing",
       value: failingClusterCount,
-      color: "#FF8A80",
+      color: theme.palette.error[300],
     },
   ];
   const dashboardFeaturedSummary = { name: "Clusters", data };


### PR DESCRIPTION
This PR updates the following components to use the current theme colors, additionally, updates matching colors across the whole app to mantain consistency. 

_before/after screenshots_

### Dialog
<img width="1470" alt="image" src="https://github.com/lyft/clutch/assets/5430603/17f8f76a-02ca-480e-bae8-38d8bcde54ff">

<img width="1480" alt="image" src="https://github.com/lyft/clutch/assets/5430603/92483239-2054-45d2-a1a2-8bdd022cc72d">


### Icon
<img width="550" alt="image" src="https://github.com/lyft/clutch/assets/5430603/abab2f22-4469-40ed-b066-51f6f20fbfca">

<img width="547" alt="image" src="https://github.com/lyft/clutch/assets/5430603/41144f74-77ea-4055-a2cf-113e7f23e62f">

<img width="555" alt="image" src="https://github.com/lyft/clutch/assets/5430603/4edde15f-cbcd-4446-9e85-418ec2e00d99">

### Text
<img width="993" alt="image" src="https://github.com/lyft/clutch/assets/5430603/98f09ddd-ffde-4fb8-b573-becd69ee495a">


_Note_
This PR mainly aims to update ungrouped components within frontend/packages/core/src/, while updating all instances of widespread colors as to avoid possible mismatches from working them on a directory basis. Odd instances of hardcoded colors elsewhere will be addressed in future PRs.

### Testing Performed
manual, unit testing