### PR TITLE
fontend: leverage theme palette for misc components

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -17,6 +17,7 @@ import { useAppContext } from "../Contexts";
 import { useNavigate } from "../navigation";
 import type { PopperItemProps } from "../popper";
 import { Popper, PopperItem } from "../popper";
+import { THEME_VARIANTS } from "../Theme/colors";
 
 import { filterHiddenRoutes, routesByGrouping, sortedGroupings, workflowByRoute } from "./utils";
 
@@ -28,7 +29,9 @@ const DrawerPanel = styled(MuiDrawer)(({ theme }) => ({
     top: "unset",
     width: "inherit",
     backgroundColor:
-      theme.palette.mode === "light" ? theme.palette.common.white : theme.palette.background.paper,
+      theme.palette.mode === THEME_VARIANTS.light
+        ? theme.palette.common.white
+        : theme.palette.background.paper,
     boxShadow: `0px 5px 15px ${alpha(theme.palette.primary[400], 0.2)}`,
     position: "relative",
     display: "flex",

--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -4,6 +4,7 @@ import type { Theme as MuiTheme } from "@mui/material/styles";
 import { StylesProvider } from "@mui/styles";
 
 import { ThemeProvider } from "../Theme";
+import { THEME_VARIANTS } from "../Theme/colors";
 import type { ClutchColors } from "../Theme/types";
 
 declare module "@mui/material/styles" {
@@ -16,6 +17,7 @@ declare module "@mui/material/styles" {
   interface Palette {
     contrastColor: string;
     headerGradient: string;
+    brandColor: string;
   }
 }
 
@@ -29,7 +31,7 @@ const Theme: React.FC = ({ children }) => {
   const prefersDarkMode = false;
   return (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider variant={prefersDarkMode ? "dark" : "light"}>
+      <ThemeProvider variant={prefersDarkMode ? THEME_VARIANTS.dark : THEME_VARIANTS.light}>
         <CssBaseline />
         <StylesProvider>{children}</StylesProvider>
       </ThemeProvider>

--- a/frontend/packages/core/src/Theme/colors.tsx
+++ b/frontend/packages/core/src/Theme/colors.tsx
@@ -1,5 +1,12 @@
 import type { ClutchColors, ComponentState, ThemeVariant } from "./types";
 
+export enum THEME_VARIANTS {
+  light = "light",
+  dark = "dark",
+}
+
+export const brandColor = "#02acbe";
+
 export const LIGHT_COLORS: ClutchColors = {
   neutral: {
     50: "#F8F8F9",
@@ -175,7 +182,7 @@ export const STATE_OPACITY: { [key in ComponentState]: number } = {
 };
 
 const clutchColors = (variant: ThemeVariant) => {
-  const colors = variant === "light" ? LIGHT_COLORS : DARK_COLORS;
+  const colors = variant === THEME_VARIANTS.light ? LIGHT_COLORS : DARK_COLORS;
   return {
     ...colors,
   };

--- a/frontend/packages/core/src/Theme/palette.tsx
+++ b/frontend/packages/core/src/Theme/palette.tsx
@@ -1,13 +1,14 @@
 import type { PaletteOptions as MuiPaletteOptions } from "@mui/material/styles";
 import { alpha, TypeText } from "@mui/material/styles";
 
-import { DARK_COLORS, LIGHT_COLORS } from "./colors";
+import { brandColor, DARK_COLORS, LIGHT_COLORS, THEME_VARIANTS } from "./colors";
 import type { ClutchColors, ThemeVariant } from "./types";
 
 interface PaletteOptions extends MuiPaletteOptions {
   type: ThemeVariant;
   contrastColor: string;
   headerGradient: string;
+  brandColor: string;
 }
 
 const lightText: Partial<TypeText> = {
@@ -25,13 +26,14 @@ const darkText: Partial<TypeText> = {
 };
 
 const palette = (variant: ThemeVariant): PaletteOptions => {
-  const isLightMode = variant === "light";
+  const isLightMode = variant === THEME_VARIANTS.light;
   const color = (isLightMode ? LIGHT_COLORS : DARK_COLORS) as ClutchColors;
 
   // TODO: add all clutch colors to "common colors"
   return {
     type: variant,
     mode: variant,
+    brandColor,
     primary: color.blue,
     secondary: color.neutral,
     error: color.red,

--- a/frontend/packages/core/src/Theme/theme.tsx
+++ b/frontend/packages/core/src/Theme/theme.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { StylesProvider } from "@mui/styles";
 
-import { clutchColors } from "./colors";
+import { clutchColors, THEME_VARIANTS } from "./colors";
 import palette from "./palette";
 import type { ThemeVariant } from "./types";
 
@@ -66,11 +66,11 @@ const createTheme = (variant: ThemeVariant): MuiTheme => {
 };
 
 interface ThemeProps {
-  variant?: "light" | "dark";
+  variant?: ThemeVariant;
   children: React.ReactNode;
 }
 
-const ThemeProvider = ({ children, variant = "light" }: ThemeProps) => (
+const ThemeProvider = ({ children, variant = THEME_VARIANTS.light }: ThemeProps) => (
   <StyledEngineProvider injectFirst>
     <MuiThemeProvider theme={createTheme(variant)}>
       <CssBaseline />

--- a/frontend/packages/core/src/Theme/types.tsx
+++ b/frontend/packages/core/src/Theme/types.tsx
@@ -2,6 +2,11 @@ import type { Color } from "@mui/material";
 
 export type ThemeVariant = "light" | "dark";
 
+export enum THEME_VARIANTS {
+  light = "light",
+  dark = "dark",
+}
+
 export interface StrokeColor {
   primary: string;
   secondary: string;

--- a/frontend/packages/core/src/landing.tsx
+++ b/frontend/packages/core/src/landing.tsx
@@ -6,6 +6,7 @@ import Typography from "@mui/material/Typography";
 import { userId } from "./AppLayout/user";
 import { workflowsByTrending } from "./AppLayout/utils";
 import { MonsterGraphic } from "./Assets/Graphics";
+import { THEME_VARIANTS } from "./Theme/colors";
 import { LandingCard } from "./card";
 import { useAppContext } from "./Contexts";
 import { useNavigate } from "./navigation";
@@ -17,7 +18,9 @@ const StyledLanding = styled.div(({ theme }) => ({
   "& .welcome": {
     display: "flex",
     backgroundColor:
-      theme.palette.mode === "light" ? theme.palette.common.white : theme.palette.background.paper,
+      theme.palette.mode === THEME_VARIANTS.light
+        ? theme.palette.common.white
+        : theme.palette.background.paper,
     padding: "32px 80px",
   },
 

--- a/frontend/packages/core/src/not-found.tsx
+++ b/frontend/packages/core/src/not-found.tsx
@@ -7,10 +7,10 @@ const Container = styled(Grid)`
   minheight: 80vh;
 `;
 
-const IconContainer = styled(Grid)({
-  color: "#02acbe",
+const IconContainer = styled(Grid)(({ theme }) => ({
+  color: theme.palette.brandColor,
   fontSize: "7rem",
-});
+}));
 
 const NotFound: React.FC<{}> = () => (
   <Container

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Link, Popper, Typography } from "@clutch-sh/core";
+import { Link, Popper, Typography, useTheme } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { alpha } from "@mui/material";
@@ -12,25 +12,6 @@ interface LinkGroupProps {
 }
 
 const ICON_SIZE = "16px";
-
-const itemHoverStyle = {
-  display: "flex",
-  alignItems: "center",
-  "&:hover": {
-    backgroundColor: "rgba(theme.palette.secondary[900], 0.05)",
-  },
-};
-
-const StyledMenuItem = styled.div({
-  ...itemHoverStyle,
-});
-
-const StyledSubLink = styled.div({
-  ...itemHoverStyle,
-  paddingBottom: "8px",
-  paddingTop: "8px",
-  paddingLeft: "40px",
-});
 
 const StyledMoreVertIcon = styled.span(({ theme }) => ({
   ".MuiIconButton-root": {
@@ -74,6 +55,27 @@ interface QuickLinkGroupProps extends LinkGroupProps {
 }
 
 const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroupProps) => {
+  const theme = useTheme();
+
+  const itemHoverStyle = {
+    display: "flex",
+    alignItems: "center",
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.secondary[900], 0.05),
+    },
+  };
+
+  const StyledMenuItem = styled.div({
+    ...itemHoverStyle,
+  });
+
+  const StyledSubLink = styled.div({
+    ...itemHoverStyle,
+    paddingBottom: "8px",
+    paddingTop: "8px",
+    paddingLeft: "40px",
+  });
+
   const [validLinks, setValidLinks] = React.useState<IClutch.core.project.v1.ILink[]>([]);
 
   React.useEffect(() => {

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Link, Popper, Typography, useTheme } from "@clutch-sh/core";
-import styled from "@emotion/styled";
+import { Link, Popper, styled, Typography, useTheme } from "@clutch-sh/core";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { alpha } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
@@ -13,7 +12,7 @@ interface LinkGroupProps {
 
 const ICON_SIZE = "16px";
 
-const StyledMoreVertIcon = styled.span(({ theme }) => ({
+const StyledMoreVertIcon = styled("span")(({ theme }) => ({
   ".MuiIconButton-root": {
     padding: "6px",
     color: alpha(theme.palette.secondary[900], 0.38),
@@ -30,22 +29,22 @@ const StyledLinkTitle = styled(Typography)({
   padding: "7px 0px",
 });
 
-const StyledLinkBox = styled.div({
+const StyledLinkBox = styled("div")({
   borderRadius: "4px",
   width: "160px",
 });
 
-const StyledMultilinkImage = styled.div({
+const StyledMultilinkImage = styled("div")({
   display: "flex",
   padding: "8px",
 });
 
-const StyledMultilinkHeader = styled.div({
+const StyledMultilinkHeader = styled("div")({
   display: "flex",
   alignItems: "center",
 });
 
-const StyledCenterImgSpan = styled.span({
+const StyledCenterImgSpan = styled("span")({
   display: "flex",
   alignItems: "center",
   padding: "8px",
@@ -65,11 +64,11 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
     },
   };
 
-  const StyledMenuItem = styled.div({
+  const StyledMenuItem = styled("div")({
     ...itemHoverStyle,
   });
 
-  const StyledSubLink = styled.div({
+  const StyledSubLink = styled("div")({
     ...itemHoverStyle,
     paddingBottom: "8px",
     paddingTop: "8px",
@@ -151,7 +150,7 @@ const ExpandedLinks = ({ linkGroups }: ExpandedLinksProps) => (
   </StyledLinkBox>
 );
 
-const StyledFlexEnd = styled.div({
+const StyledFlexEnd = styled("div")({
   justifyContent: "right",
 });
 


### PR DESCRIPTION
This PR adds a brand color that matches the color used in the Clutch logo, and updates the Not Found component to use this color from the current theme. 
Replaced string theme variation values (light, dark) with a shared variable.
Fixed a miss-written theme usage in the project links component.

### Not found
No noticeable change was made:
before/after
<img width="1482" alt="image" src="https://github.com/lyft/clutch/assets/5430603/48663ff9-a3ec-45c1-84cb-106f3c418823">


### Testing Performed
manual, unit testing