### PR TITLE
frontend: Adjusting resolution of react-hook-form

### DIFF
--- a/tools/scaffolding/templates/frontend/package.json
+++ b/tools/scaffolding/templates/frontend/package.json
@@ -32,7 +32,8 @@
     "@mui/material": "5.8.5",
     "@mui/lab": "5.0.0-alpha.87",
     "@mui/styles": "5.8.4",
-    "@mui/system": "5.8.5"
+    "@mui/system": "5.8.5",
+    "react-hook-form": "7.25.3"
   },
   "devDependencies": {
     "@clutch-sh/tools": "^2.0.0-beta"


### PR DESCRIPTION
### Description
- fixes #2874 
- Was found that when running the scaffold build that there was a node version issue, this was due to the peer-dependency of react-hook-form being installed by `@hookform/resolvers` in core. The version being installed was requiring a node version of 18 while the package.json engine requires 16.

### Testing Performed
manual
