### PR TITLE
frontend: Updating bg color on tab component for active state

### DIFF
--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -34,7 +34,7 @@ const StyledTab = styled(MuiTab)(({ theme }) => ({
   },
   "&:active": {
     color: alpha(theme.palette.secondary[900], 0.6),
-    backgroundColor: theme.palette.secondary[200],
+    backgroundColor: theme.palette.secondary[300],
   },
   ".MuiTab-wrapper": {
     margin: "auto",


### PR DESCRIPTION
Active state of the tab component was the same as the hover state, now is darker.