### PR TITLE
frontend: point to error palette

### DIFF
--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { CssBaseline, StyledEngineProvider, useTheme as useMuiTheme } from "@mui/material";
+import { useTheme as useMuiTheme } from "@mui/material";
 import type { Theme as MuiTheme } from "@mui/material/styles";
-import { StylesProvider } from "@mui/styles";
 
 import { ThemeProvider } from "../Theme";
 import { THEME_VARIANTS } from "../Theme/colors";
@@ -30,12 +29,9 @@ const Theme: React.FC = ({ children }) => {
     window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches; */
   const prefersDarkMode = false;
   return (
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider variant={prefersDarkMode ? THEME_VARIANTS.dark : THEME_VARIANTS.light}>
-        <CssBaseline />
-        <StylesProvider>{children}</StylesProvider>
-      </ThemeProvider>
-    </StyledEngineProvider>
+    <ThemeProvider variant={prefersDarkMode ? THEME_VARIANTS.dark : THEME_VARIANTS.light}>
+      {children}
+    </ThemeProvider>
   );
 };
 

--- a/frontend/packages/core/src/Feedback/error/details.tsx
+++ b/frontend/packages/core/src/Feedback/error/details.tsx
@@ -158,7 +158,7 @@ const ErrorDetails = ({ error }: ErrorDetailsProps) => {
                         <>
                           {renderItems.map((wrapped, idx) => {
                             // TODO: This color should be colored according to status code
-                            const color = theme.palette.secondary[600];
+                            const color = theme.palette.error[600];
                             return (
                               // eslint-disable-next-line react/no-array-index-key
                               <ListItem key={`${idx}-${wrapped.message}`}>

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -45,7 +45,7 @@ const StyledInputLabel = styled(MuiInputLabel)(({ theme }) => ({
     color: "var(--label-default-color)",
   },
   "&.Mui-error": {
-    color: theme.palette.secondary[600],
+    color: theme.palette.error[600],
   },
 }));
 

--- a/frontend/packages/core/src/Theme/theme.tsx
+++ b/frontend/packages/core/src/Theme/theme.tsx
@@ -6,15 +6,10 @@ import {
   StyledEngineProvider,
   ThemeProvider as MuiThemeProvider,
 } from "@mui/material";
-import { StylesProvider } from "@mui/styles";
 
 import { clutchColors, THEME_VARIANTS } from "./colors";
 import palette from "./palette";
 import type { ThemeVariant } from "./types";
-
-declare module "@mui/styles/defaultTheme" {
-  interface DefaultTheme extends MuiTheme {}
-}
 
 declare module "@emotion/react" {
   export interface Theme extends MuiTheme {}
@@ -83,10 +78,9 @@ const ThemeProvider = ({ children, variant = THEME_VARIANTS.light }: ThemeProps)
   <StyledEngineProvider injectFirst>
     <MuiThemeProvider theme={createTheme(variant)}>
       <CssBaseline />
-      <StylesProvider injectFirst>{children}</StylesProvider>
+      {children}
     </MuiThemeProvider>
   </StyledEngineProvider>
 );
 
-// Note that ThemeProvider can't be used until the Theme component can be replaced.
 export default ThemeProvider;

--- a/frontend/packages/core/src/tests/__snapshots__/landing.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/landing.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-1aarkdb"
+    class="css-1be9aqm"
     id="landing"
   >
     <div


### PR DESCRIPTION
Palette usage instances were pointing to the secondary palette instead of the error one.

before:
<img width="368" alt="image" src="https://github.com/lyft/clutch/assets/5430603/37bb7a83-c78a-4fca-a04f-93cbbccb20ca">

after:
<img width="358" alt="image" src="https://github.com/lyft/clutch/assets/5430603/a4d9591c-dafd-41c6-8910-f7752a54af03">

before:
<img width="971" alt="image" src="https://github.com/lyft/clutch/assets/5430603/b1d86efb-379a-4f65-940a-8bababf62996">

after:
<img width="978" alt="image" src="https://github.com/lyft/clutch/assets/5430603/791cf77f-be12-4b24-9c5a-a1ef46c3cb4f">

Also noticed there are some redundant usages of style providers around the app, so removed those.

### Testing Performed
manual, unit tests