### PR TITLE
frontend: type instances of theme in styled components

### DIFF
--- a/frontend/packages/core/src/AppLayout/drawer.tsx
+++ b/frontend/packages/core/src/AppLayout/drawer.tsx
@@ -7,6 +7,7 @@ import {
   Drawer as MuiDrawer,
   List,
   ListItemButton,
+  Theme,
   Typography,
 } from "@mui/material";
 import _ from "lodash";
@@ -22,7 +23,7 @@ import { THEME_VARIANTS } from "../Theme/colors";
 import { filterHiddenRoutes, routesByGrouping, sortedGroupings, workflowByRoute } from "./utils";
 
 // sidebar
-const DrawerPanel = styled(MuiDrawer)(({ theme }) => ({
+const DrawerPanel = styled(MuiDrawer)(({ theme }: { theme: Theme }) => ({
   width: "100px",
   overflowY: "auto",
   ".MuiDrawer-paper": {
@@ -44,7 +45,7 @@ const GroupList = styled(List)({
 });
 
 const GroupListItem = styled(ListItemButton)<{ icon: number }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     flexDirection: "column",
     minHeight: "82px",
     padding: "16px 8px 16px 8px",
@@ -78,7 +79,7 @@ const GroupListItem = styled(ListItemButton)<{ icon: number }>(
   })
 );
 
-const GroupHeading = styled(Typography)(({ theme }) => ({
+const GroupHeading = styled(Typography)(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.6),
   fontWeight: 500,
   fontSize: "14px",
@@ -95,7 +96,7 @@ const IconAvatar = styled(MuiAvatar)({
   width: "24px",
 });
 
-const Avatar = styled(IconAvatar)(({ theme }) => ({
+const Avatar = styled(IconAvatar)(({ theme }: { theme: Theme }) => ({
   background: alpha(theme.palette.secondary[900], 0.6),
   color: theme.palette.contrastColor,
   fontSize: "14px",

--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import styled from "@emotion/styled";
-import { AppBar as MuiAppBar, Box, Grid, Toolbar, Typography } from "@mui/material";
+import { AppBar as MuiAppBar, Box, Grid, Theme, Toolbar, Typography } from "@mui/material";
 
 import type { AppConfiguration } from "../AppProvider";
 import { FeatureOn, SimpleFeatureFlag } from "../flags";
@@ -45,7 +45,7 @@ interface HeaderProps extends AppConfiguration {
   userInfo?: boolean;
 }
 
-const AppBar = styled(MuiAppBar)(({ theme }) => ({
+const AppBar = styled(MuiAppBar)(({ theme }: { theme: Theme }) => ({
   minWidth: "fit-content",
   background: theme.palette.headerGradient,
   zIndex: 1201,
@@ -55,7 +55,7 @@ const AppBar = styled(MuiAppBar)(({ theme }) => ({
 // Since the AppBar is fixed we need a div to take up its height in order to push other content down.
 const ClearAppBar = styled.div({ height: APP_BAR_HEIGHT });
 
-const Title = styled(Typography)(({ theme }) => ({
+const Title = styled(Typography)(({ theme }: { theme: Theme }) => ({
   margin: "12px 0px 12px 8px",
   fontWeight: "bold",
   fontSize: "30px",

--- a/frontend/packages/core/src/AppLayout/notifications.tsx
+++ b/frontend/packages/core/src/AppLayout/notifications.tsx
@@ -11,9 +11,10 @@ import {
   MenuList,
   Paper as MuiPaper,
   Popper as MuiPopper,
+  Theme,
 } from "@mui/material";
 
-const StyledNotificationsIcon = styled(IconButton)(({ theme }) => ({
+const StyledNotificationsIcon = styled(IconButton)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.contrastColor,
   marginRight: "8px",
   padding: "12px",
@@ -30,13 +31,13 @@ const Popper = styled(MuiPopper)({
   marginLeft: "12px",
 });
 
-const Paper = styled(MuiPaper)(({ theme }) => ({
+const Paper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   width: "242px",
   border: `1px solid ${theme.palette.secondary[100]}`,
   boxShadow: `0px 5px 15px ${alpha(theme.palette.primary[600], 0.2)}`,
 }));
 
-const MenuItem = styled(MuiMenuItem)(({ theme }) => ({
+const MenuItem = styled(MuiMenuItem)(({ theme }: { theme: Theme }) => ({
   height: "48px",
   padding: "12px",
   "&:hover": {
@@ -47,7 +48,7 @@ const MenuItem = styled(MuiMenuItem)(({ theme }) => ({
   },
 }));
 
-const ListItemText = styled(MuiListItemText)(({ theme }) => ({
+const ListItemText = styled(MuiListItemText)(({ theme }: { theme: Theme }) => ({
   margin: "0px",
   ".MuiTypography-root": {
     color: theme.palette.secondary[900],

--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -12,6 +12,7 @@ import {
   Popper as MuiPopper,
   TextField,
   TextFieldProps,
+  Theme,
   Typography,
 } from "@mui/material";
 import type { AutocompleteRenderInputParams } from "@mui/material/Autocomplete";
@@ -27,7 +28,7 @@ import { filterHiddenRoutes, searchIndexes } from "./utils";
 
 const hotKey = "/";
 
-const InputField: React.FC<TextFieldProps> = styled(TextField)(({ theme }) => ({
+const InputField: React.FC<TextFieldProps> = styled(TextField)(({ theme }: { theme: Theme }) => ({
   // input field
   maxWidth: "551px",
   minWidth: "551px",
@@ -72,13 +73,13 @@ const ResultGrid = styled(Grid)({
 });
 
 // search's result options
-const ResultLabel = styled(Typography)(({ theme }) => ({
+const ResultLabel = styled(Typography)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[900],
   fontSize: "14px",
 }));
 
 // main search icon on header
-const SearchIconButton = styled(IconButton)(({ theme }) => ({
+const SearchIconButton = styled(IconButton)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.contrastColor,
   fontSize: "24px",
   padding: "12px",
@@ -92,19 +93,19 @@ const SearchIconButton = styled(IconButton)(({ theme }) => ({
 }));
 
 // search icon in input field
-const StartInputAdornment = styled(MuiInputAdornment)(({ theme }) => ({
+const StartInputAdornment = styled(MuiInputAdornment)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[900],
   marginLeft: "8px",
 }));
 
 // closed icon svg
-const StyledCloseIcon = styled(Icon)(({ theme }) => ({
+const StyledCloseIcon = styled(Icon)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[900],
   fontSize: "24px",
 }));
 
 // popper containing the search result options
-const Popper = styled(MuiPopper)(({ theme }) => ({
+const Popper = styled(MuiPopper)(({ theme }: { theme: Theme }) => ({
   ".MuiPaper-root": {
     border: `1px solid ${theme.palette.secondary[100]}`,
     boxShadow: `0px 5px 15px ${alpha(theme.palette.primary[600], 0.2)}`,

--- a/frontend/packages/core/src/AppLayout/shortLinker.tsx
+++ b/frontend/packages/core/src/AppLayout/shortLinker.tsx
@@ -10,6 +10,7 @@ import {
   MenuList,
   Paper as MuiPaper,
   Popper as MuiPopper,
+  Theme,
 } from "@mui/material";
 
 import { generateShortLinkRoute } from "../AppProvider/short-link-proxy";
@@ -34,7 +35,7 @@ const Popper = styled(MuiPopper)({
   zIndex: 1201,
 });
 
-const Paper = styled(MuiPaper)(({ theme }) => ({
+const Paper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   width: "400px",
   height: "100px",
   padding: "15px",
@@ -43,7 +44,7 @@ const Paper = styled(MuiPaper)(({ theme }) => ({
 }));
 
 const StyledLinkIcon = styled(IconButton)<{ $open: boolean }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     color: theme.palette.contrastColor,
     marginRight: "8px",
     padding: "12px",

--- a/frontend/packages/core/src/AppLayout/stories/notifications.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/notifications.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
-import { Grid as MuiGrid } from "@mui/material";
+import { Grid as MuiGrid, Theme } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
+import styled from "../../styled";
 import type { NotificationsProp } from "../notifications";
 import NotificationsComponent from "../notifications";
 
@@ -11,7 +11,7 @@ export default {
   component: NotificationsComponent,
 } as Meta;
 
-const Grid = styled(MuiGrid)(({ theme }) => ({
+const Grid = styled(MuiGrid)(({ theme }: { theme: Theme }) => ({
   height: "64px",
   backgroundColor: theme.palette.primary[900],
 }));

--- a/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { MemoryRouter } from "react-router";
 import styled from "@emotion/styled";
-import { Box, Grid as MuiGrid } from "@mui/material";
+import { Box, Grid as MuiGrid, Theme } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
 import { ApplicationContext } from "../../Contexts/app-context";
@@ -60,7 +60,7 @@ export default {
   ],
 } as Meta;
 
-const Grid = styled(MuiGrid)(({ theme }) => ({
+const Grid = styled(MuiGrid)(({ theme }: { theme: Theme }) => ({
   height: "64px",
   backgroundColor: theme.palette.primary[900],
 }));

--- a/frontend/packages/core/src/AppLayout/stories/user-information.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/user-information.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import { Grid as MuiGrid } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
+import styled from "../../styled";
 import type { UserInformationProps } from "../user";
 import { UserInformation as UserInformationComponent } from "../user";
 

--- a/frontend/packages/core/src/AppLayout/user.tsx
+++ b/frontend/packages/core/src/AppLayout/user.tsx
@@ -13,12 +13,13 @@ import {
   MenuList as MuiMenuList,
   Paper as MuiPaper,
   Popper as MuiPopper,
+  Theme,
 } from "@mui/material";
 import Cookies from "js-cookie";
 import jwtDecode from "jwt-decode";
 import * as _ from "lodash";
 
-const UserPhoto = styled(IconButton)(({ theme }) => ({
+const UserPhoto = styled(IconButton)(({ theme }: { theme: Theme }) => ({
   padding: "12px",
   "&:hover": {
     background: theme.palette.primary[600],
@@ -36,13 +37,13 @@ const UserPhoto = styled(IconButton)(({ theme }) => ({
 }));
 
 // header and menu avatar
-const Avatar = styled(MuiAvatar)(({ theme }) => ({
+const Avatar = styled(MuiAvatar)(({ theme }: { theme: Theme }) => ({
   backgroundColor: theme.palette.primary[500],
   color: theme.palette.contrastColor,
   fontWeight: 500,
 }));
 
-const Paper = styled(MuiPaper)(({ theme }) => ({
+const Paper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   width: "242px",
   border: `1px solid ${theme.palette.secondary[100]}`,
   boxShadow: `0px 5px 15px ${alpha(theme.palette.primary[600], 0.2)}`,
@@ -54,7 +55,7 @@ const Popper = styled(MuiPopper)({
   zIndex: 1201,
 });
 
-const MenuList = styled(MuiMenuList)(({ theme }) => ({
+const MenuList = styled(MuiMenuList)(({ theme }: { theme: Theme }) => ({
   padding: "0px",
   borderRadius: "4px",
   ".MuiMenuItem-root": {
@@ -86,7 +87,7 @@ const AvatarListItemIcon = styled(ListItemIcon)({
   },
 });
 
-const AvatarListItemText = styled(MuiListItemText)(({ theme }) => ({
+const AvatarListItemText = styled(MuiListItemText)(({ theme }: { theme: Theme }) => ({
   paddingLeft: "16px",
   margin: "0px",
   ".MuiTypography-root": {
@@ -102,7 +103,7 @@ const MenuItem = styled(MuiMenuItem)({
   padding: "12px",
 });
 
-const ListItemText = styled(MuiListItemText)(({ theme }) => ({
+const ListItemText = styled(MuiListItemText)(({ theme }: { theme: Theme }) => ({
   margin: "0px",
   ".MuiTypography-root": {
     color: theme.palette.secondary[900],
@@ -111,7 +112,7 @@ const ListItemText = styled(MuiListItemText)(({ theme }) => ({
   },
 }));
 
-const Divider = styled(MuiDivider)(({ theme }) => ({
+const Divider = styled(MuiDivider)(({ theme }: { theme: Theme }) => ({
   backgroundColor: theme.palette.secondary[100],
 }));
 

--- a/frontend/packages/core/src/Feedback/alert.tsx
+++ b/frontend/packages/core/src/Feedback/alert.tsx
@@ -4,12 +4,12 @@ import MuiErrorIcon from "@mui/icons-material/Error";
 import MuiInfoIcon from "@mui/icons-material/Info";
 import MuiWarningIcon from "@mui/icons-material/Warning";
 import type { AlertProps as MuiAlertProps } from "@mui/lab";
-import { Alert as MuiAlert, AlertTitle as MuiAlertTitle, alpha, Grid } from "@mui/material";
+import { Alert as MuiAlert, AlertTitle as MuiAlertTitle, alpha, Grid, Theme } from "@mui/material";
 
 import styled from "../styled";
 
 const StyledAlert = styled(MuiAlert)<{ severity: MuiAlertProps["severity"] }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     borderRadius: "8px",
     padding: "16px",
     paddingLeft: "24px",
@@ -31,7 +31,7 @@ const StyledAlert = styled(MuiAlert)<{ severity: MuiAlertProps["severity"] }>(
       },
     },
   }),
-  props => ({ theme }) => {
+  props => ({ theme }: { theme: Theme }) => {
     const backgroundColors = {
       error: `linear-gradient(to right, ${theme.palette.error[600]} 8px, ${theme.palette.error[100]} 0%)`,
       info: `linear-gradient(to right, ${theme.palette.primary[600]} 8px, ${theme.palette.primary[200]} 0%)`,
@@ -45,23 +45,23 @@ const StyledAlert = styled(MuiAlert)<{ severity: MuiAlertProps["severity"] }>(
   }
 );
 
-const ErrorIcon = styled(MuiErrorIcon)(({ theme }) => ({
+const ErrorIcon = styled(MuiErrorIcon)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.error[700],
 }));
 
-const InfoIcon = styled(MuiInfoIcon)(({ theme }) => ({
+const InfoIcon = styled(MuiInfoIcon)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.primary[600],
 }));
 
-const SuccessIcon = styled(MuiSuccessIcon)(({ theme }) => ({
+const SuccessIcon = styled(MuiSuccessIcon)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.success[500],
 }));
 
-const WarningIcon = styled(MuiWarningIcon)(({ theme }) => ({
+const WarningIcon = styled(MuiWarningIcon)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.warning[500],
 }));
 
-const AlertTitle = styled(MuiAlertTitle)(({ theme }) => ({
+const AlertTitle = styled(MuiAlertTitle)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[900],
   fontWeight: 600,
   fontSize: "16px",

--- a/frontend/packages/core/src/Feedback/error/details.tsx
+++ b/frontend/packages/core/src/Feedback/error/details.tsx
@@ -8,6 +8,7 @@ import {
   alpha,
   Button,
   Grid,
+  Theme,
   useControlled,
   useTheme,
 } from "@mui/material";
@@ -21,7 +22,7 @@ import ErrorDetailsDialog from "./dialog";
 
 const ERROR_DETAILS_RENDER_MAX = 4;
 
-const ErrorDetailDivider = styled("div")(({ theme }) => ({
+const ErrorDetailDivider = styled("div")(({ theme }: { theme: Theme }) => ({
   background: `linear-gradient(to right, ${theme.palette.error[600]} 8px, ${alpha(
     theme.palette.error[600],
     0.4
@@ -40,7 +41,7 @@ const Accordion = styled(MuiAccordion)({
 });
 
 const AccordionSummary = styled(MuiAccordionSummary)<{ $expanded: boolean }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     background: `linear-gradient(to right, ${theme.palette.error[600]} 8px, ${theme.palette.error[100]} 0%)`,
     color: theme.palette.secondary[900],
     fontSize: "14px",
@@ -61,7 +62,7 @@ const AccordionSummary = styled(MuiAccordionSummary)<{ $expanded: boolean }>(
   })
 );
 
-const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
+const AccordionDetails = styled(MuiAccordionDetails)(({ theme }: { theme: Theme }) => ({
   background: `linear-gradient(to right, ${theme.palette.error[600]} 8px, ${theme.palette.contrastColor} 0%)`,
   padding: "0",
   paddingLeft: "8px",
@@ -71,14 +72,14 @@ const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   flexDirection: "column",
 }));
 
-const ListItem = styled("li")(({ theme }) => ({
+const ListItem = styled("li")(({ theme }: { theme: Theme }) => ({
   "::marker": {
     color: alpha(theme.palette.secondary[900], 0.6),
   },
   padding: "2px 0",
 }));
 
-const ErrorDetailContainer = styled("div")(({ theme }) => ({
+const ErrorDetailContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   width: "100%",
   border: `1px solid ${theme.palette.secondary[200]}`,
   padding: "16px 16px 16px 24px",
@@ -86,13 +87,13 @@ const ErrorDetailContainer = styled("div")(({ theme }) => ({
   borderTop: "unset",
 }));
 
-const ErrorDetailText = styled("div")(({ theme }) => ({
+const ErrorDetailText = styled("div")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.6),
   fontSize: "14px",
   lineHeight: "24px",
 }));
 
-const DialogButton = styled(Button)(({ theme }) => ({
+const DialogButton = styled(Button)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.primary[600],
   fontWeight: 700,
   fontSize: "14px",

--- a/frontend/packages/core/src/Feedback/error/index.tsx
+++ b/frontend/packages/core/src/Feedback/error/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import MuiOpenInNewIcon from "@mui/icons-material/OpenInNew";
 import RefreshIcon from "@mui/icons-material/Refresh";
-import { alpha, IconButton } from "@mui/material";
+import { alpha, IconButton, Theme } from "@mui/material";
 
 import { Link } from "../../link";
 import type { ClutchError } from "../../Network/errors";
@@ -23,7 +23,7 @@ const ErrorSummaryMessage = styled("div")({
   flex: "1",
 });
 
-const ErrorSummaryLink = styled(Link)(({ theme }) => ({
+const ErrorSummaryLink = styled(Link)(({ theme }: { theme: Theme }) => ({
   fontSize: "14px",
   fontWeight: 400,
   color: alpha(theme.palette.secondary[900], 0.6),

--- a/frontend/packages/core/src/Feedback/hint.tsx
+++ b/frontend/packages/core/src/Feedback/hint.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import HelpIcon from "@mui/icons-material/Help";
-import { Popover, Typography } from "@mui/material";
+import { Popover, Theme, Typography } from "@mui/material";
 
 import styled from "../styled";
 
-const HelpIconContainer = styled("div")(({ theme }) => ({
+const HelpIconContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   color: theme.palette.secondary[300],
   padding: "5px",

--- a/frontend/packages/core/src/Feedback/tooltip.tsx
+++ b/frontend/packages/core/src/Feedback/tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { TooltipProps as MuiTooltipProps } from "@mui/material";
+import type { Theme, TooltipProps as MuiTooltipProps } from "@mui/material";
 import { Tooltip as MuiTooltip } from "@mui/material";
 
 import styled from "../styled";
@@ -9,23 +9,25 @@ const BaseTooltip = ({ className, ...props }: MuiTooltipProps) => (
 );
 
 // TODO: sync with Design on margins for each possible placement
-const StyledTooltip = styled(BaseTooltip)((props: { maxwidth?: string }) => ({ theme }) => ({
-  maxWidth: props.maxwidth,
-  backgroundColor: theme.palette.secondary[900],
-  borderRadius: "6px",
-  "&.MuiTooltip-tooltipPlacementLeft": {
-    margin: "0 2px",
-  },
-  "&.MuiTooltip-tooltipPlacementRight": {
-    margin: "0 2px",
-  },
-  "&.MuiTooltip-tooltipPlacementTop": {
-    margin: "2px 0",
-  },
-  "&.MuiTooltip-tooltipPlacementBottom": {
-    margin: "2px 0",
-  },
-}));
+const StyledTooltip = styled(BaseTooltip)(
+  (props: { maxwidth?: string }) => ({ theme }: { theme: Theme }) => ({
+    maxWidth: props.maxwidth,
+    backgroundColor: theme.palette.secondary[900],
+    borderRadius: "6px",
+    "&.MuiTooltip-tooltipPlacementLeft": {
+      margin: "0 2px",
+    },
+    "&.MuiTooltip-tooltipPlacementRight": {
+      margin: "0 2px",
+    },
+    "&.MuiTooltip-tooltipPlacementTop": {
+      margin: "2px 0",
+    },
+    "&.MuiTooltip-tooltipPlacementBottom": {
+      margin: "2px 0",
+    },
+  })
+);
 
 export interface TooltipProps
   extends Pick<MuiTooltipProps, "disableInteractive" | "placement" | "arrow"> {

--- a/frontend/packages/core/src/Input/checkbox.tsx
+++ b/frontend/packages/core/src/Input/checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import CheckIcon from "@mui/icons-material/Check";
-import type { CheckboxProps as MuiCheckboxProps } from "@mui/material";
+import type { CheckboxProps as MuiCheckboxProps, Theme } from "@mui/material";
 import {
   alpha,
   Checkbox as MuiCheckbox,
@@ -17,7 +17,7 @@ const FormControl = styled(MuiFormControl)({
   width: "75%",
 });
 
-const StyledCheckbox = styled(MuiCheckbox)(({ theme }) => ({
+const StyledCheckbox = styled(MuiCheckbox)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[400],
   borderRadius: "50%",
   "&:hover": {
@@ -55,7 +55,7 @@ const Icon = styled("div")<StyledIconProps>(
     borderRadius: "2px",
     boxSizing: "border-box",
   },
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     height: props.$size,
     width: props.$size,
     border: props.$disabled
@@ -72,7 +72,7 @@ const SelectedIcon = styled("div")<StyledIconProps>(
       display: "block",
     },
   },
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     height: props.$size,
     width: props.$size,
     background: props.$disabled ? theme.palette.secondary[200] : theme.palette.primary[600],

--- a/frontend/packages/core/src/Input/radio-group.tsx
+++ b/frontend/packages/core/src/Input/radio-group.tsx
@@ -5,11 +5,12 @@ import {
   FormControlLabel,
   FormLabel as MuiFormLabel,
   RadioGroup as MuiRadioGroup,
+  Theme,
 } from "@mui/material";
 
 import Radio from "./radio";
 
-const FormLabel = styled(MuiFormLabel)(({ theme }) => ({
+const FormLabel = styled(MuiFormLabel)(({ theme }: { theme: Theme }) => ({
   "&&": {
     color: theme.palette.secondary[700],
   },

--- a/frontend/packages/core/src/Input/radio.tsx
+++ b/frontend/packages/core/src/Input/radio.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { RadioProps as MuiRadioProps } from "@mui/material";
+import type { RadioProps as MuiRadioProps, Theme } from "@mui/material";
 import { alpha, Radio as MuiRadio } from "@mui/material";
 
 import styled from "../styled";
@@ -13,7 +13,7 @@ const StyledRadio = styled(MuiRadio)<{ checked: RadioProps["selected"] }>(
       boxSizing: "border-box",
     },
   },
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     "&:hover > .MuiIconButton-label > div": {
       border: props.checked
         ? `1px solid ${theme.palette.primary[700]}`
@@ -23,21 +23,21 @@ const StyledRadio = styled(MuiRadio)<{ checked: RadioProps["selected"] }>(
 );
 
 const Icon = styled("div")<{ $disabled?: MuiRadioProps["disabled"] }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     height: "24px",
     width: "24px",
     border: `1px solid ${alpha(theme.palette.secondary[900], 0.38)}`,
     borderRadius: "100px",
     boxSizing: "border-box",
   }),
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     border: props.$disabled
       ? `1px solid ${theme.palette.secondary[200]}`
       : `1px solid ${alpha(theme.palette.secondary[900], 0.38)}`,
   })
 );
 
-const SelectedIcon = styled("div")(({ theme }) => ({
+const SelectedIcon = styled("div")(({ theme }: { theme: Theme }) => ({
   height: "24px",
   width: "24px",
   background: theme.palette.primary[600],
@@ -46,7 +46,7 @@ const SelectedIcon = styled("div")(({ theme }) => ({
   boxSizing: "border-box",
 }));
 
-const SelectedCenter = styled("div")(({ theme }) => ({
+const SelectedCenter = styled("div")(({ theme }: { theme: Theme }) => ({
   height: "12px",
   width: "12px",
   background: theme.palette.contrastColor,

--- a/frontend/packages/core/src/Input/select.tsx
+++ b/frontend/packages/core/src/Input/select.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "@emotion/styled";
 import ErrorIcon from "@mui/icons-material/Error";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import type { SelectProps as MuiSelectProps } from "@mui/material";
+import type { SelectProps as MuiSelectProps, Theme } from "@mui/material";
 import {
   alpha,
   FormControl as MuiFormControl,
@@ -16,7 +16,7 @@ import { flatten } from "lodash";
 
 import { Chip } from "../chip";
 
-const StyledFormHelperText = styled(MuiFormHelperText)(({ theme }) => ({
+const StyledFormHelperText = styled(MuiFormHelperText)(({ theme }: { theme: Theme }) => ({
   alignItems: "center",
   display: "flex",
   position: "relative",
@@ -37,7 +37,7 @@ const StyledFormHelperText = styled(MuiFormHelperText)(({ theme }) => ({
   },
 }));
 
-const StyledInputLabel = styled(MuiInputLabel)(({ theme }) => ({
+const StyledInputLabel = styled(MuiInputLabel)(({ theme }: { theme: Theme }) => ({
   "--label-default-color": alpha(theme.palette.secondary[900], 0.6),
 
   color: "var(--label-default-color)",
@@ -72,7 +72,7 @@ const BaseSelect = ({ className, ...props }: MuiSelectProps) => (
   />
 );
 
-const StyledSelect = styled(BaseSelect)(({ theme }) => ({
+const StyledSelect = styled(BaseSelect)(({ theme }: { theme: Theme }) => ({
   "--notched-border-width": "1px",
   padding: "0",
   backgroundColor: theme.palette.contrastColor,

--- a/frontend/packages/core/src/Input/switchToggle.tsx
+++ b/frontend/packages/core/src/Input/switchToggle.tsx
@@ -6,10 +6,10 @@
 
 import * as React from "react";
 import styled from "@emotion/styled";
-import type { SwitchProps as MuiSwitchProps } from "@mui/material";
+import type { SwitchProps as MuiSwitchProps, Theme } from "@mui/material";
 import { alpha, Switch as MuiSwitch } from "@mui/material";
 
-const SwitchContainer = styled(MuiSwitch)(({ theme }) => ({
+const SwitchContainer = styled(MuiSwitch)(({ theme }: { theme: Theme }) => ({
   ".MuiSwitch-switchBase": {
     ":hover": {
       backgroundColor: alpha(theme.palette.secondary[900], 0.1),

--- a/frontend/packages/core/src/Input/text-field.tsx
+++ b/frontend/packages/core/src/Input/text-field.tsx
@@ -6,6 +6,7 @@ import WarningIcon from "@mui/icons-material/Warning";
 import type {
   InputProps as MuiInputProps,
   StandardTextFieldProps as MuiStandardTextFieldProps,
+  Theme,
 } from "@mui/material";
 import {
   alpha,
@@ -48,7 +49,7 @@ const StyledAutocomplete = styled(Autocomplete)({
 
 const StyledTextField = styled(BaseTextField)<{
   $color?: MuiStandardTextFieldProps["color"];
-}>({}, props => ({ theme }) => {
+}>({}, props => ({ theme }: { theme: Theme }) => {
   const TEXT_FIELD_COLOR_MAP = {
     default: alpha(theme.palette.secondary[900], 0.6),
     inputDefault: alpha(theme.palette.secondary[900], 0.38),
@@ -146,7 +147,7 @@ const StyledTextField = styled(BaseTextField)<{
 });
 
 // popper containing the search result options
-const Popper = styled(MuiPopper)(({ theme }) => ({
+const Popper = styled(MuiPopper)(({ theme }: { theme: Theme }) => ({
   ".MuiPaper-root": {
     boxShadow: `0px 5px 15px ${alpha(theme.palette.primary[600], 0.2)}`,
 
@@ -174,12 +175,12 @@ const ResultGrid = styled(Grid)({
 });
 
 // search's result options
-const ResultLabel = styled(Typography)(({ theme }) => ({
+const ResultLabel = styled(Typography)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[900],
   fontSize: "14px",
 }));
 
-const IconButton = styled(MuiIconButton)(({ theme }) => ({
+const IconButton = styled(MuiIconButton)(({ theme }: { theme: Theme }) => ({
   borderRadius: "0",
   backgroundColor: theme.palette.primary[600],
   color: theme.palette.contrastColor,

--- a/frontend/packages/core/src/NPS/header.tsx
+++ b/frontend/packages/core/src/NPS/header.tsx
@@ -7,6 +7,7 @@ import {
   MenuList,
   Paper as MuiPaper,
   Popper as MuiPopper,
+  Theme,
 } from "@mui/material";
 import { get, sortBy } from "lodash";
 
@@ -28,14 +29,14 @@ const Popper = styled(MuiPopper)({
   zIndex: 1201,
 });
 
-const Paper = styled(MuiPaper)(({ theme }) => ({
+const Paper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   width: "350px",
   boxShadow: `0px 15px 35px ${alpha(theme.palette.primary[600], 0.2)}`,
   borderRadius: "8px",
 }));
 
 const StyledFeedbackIcon = styled(IconButton)<{ $open: boolean }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     color: theme.palette.contrastColor,
     marginRight: "8px",
     padding: "12px",
@@ -46,7 +47,7 @@ const StyledFeedbackIcon = styled(IconButton)<{ $open: boolean }>(
       background: theme.palette.primary[700],
     },
   }),
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     background: props.$open ? theme.palette.primary[600] : "unset",
   })
 );

--- a/frontend/packages/core/src/NPS/wizard.tsx
+++ b/frontend/packages/core/src/NPS/wizard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import type { Theme } from "@mui/material";
 
 import styled from "../styled";
 
@@ -10,7 +11,7 @@ const NPSContainer = styled("div")<{ $submit: boolean }>(
     margin: "auto",
     borderRadius: "8px",
   },
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     background: props.$submit ? "unset" : theme.palette.primary[50],
   })
 );

--- a/frontend/packages/core/src/Table/accordion-table.tsx
+++ b/frontend/packages/core/src/Table/accordion-table.tsx
@@ -1,21 +1,23 @@
 import * as React from "react";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import { IconButton as MuiIconButton, TableRow } from "@mui/material";
+import { IconButton as MuiIconButton, TableRow, Theme } from "@mui/material";
 
 import styled from "../styled";
 
 import type { TableRowProps } from "./table";
 import { TableCell } from "./table";
 
-const IconButton = styled(MuiIconButton)(({ theme }) => ({
+const IconButton = styled(MuiIconButton)(({ theme }: { theme: Theme }) => ({
   padding: "0",
   color: theme.palette.secondary[900],
 }));
 
-const ChevronRight = styled(ChevronRightIcon)<{ $disabled: boolean }>(props => ({ theme }) => ({
-  color: props?.$disabled ? theme.palette.secondary[200] : "unset",
-}));
+const ChevronRight = styled(ChevronRightIcon)<{ $disabled: boolean }>(
+  props => ({ theme }: { theme: Theme }) => ({
+    color: props?.$disabled ? theme.palette.secondary[200] : "unset",
+  })
+);
 
 export interface AccordionRowProps {
   columns: React.ReactElement[];

--- a/frontend/packages/core/src/Table/metadata-table.tsx
+++ b/frontend/packages/core/src/Table/metadata-table.tsx
@@ -13,6 +13,7 @@ import {
   TableCell as MuiTableCell,
   TableContainer as MuiTableContainer,
   TableRow,
+  Theme,
 } from "@mui/material";
 import _ from "lodash";
 import type { BaseSchema } from "yup";
@@ -56,7 +57,7 @@ const TableContainer = styled(MuiTableContainer)<{
   })
 );
 
-const Table = styled(MuiTable)(({ theme }) => ({
+const Table = styled(MuiTable)(({ theme }: { theme: Theme }) => ({
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.12)}`,
   borderRadius: "4px",
   borderCollapse: "unset",
@@ -80,7 +81,7 @@ const TableBody = styled(MuiTableBody)({
   },
 });
 
-const TableCell = styled(MuiTableCell)(({ theme }) => ({
+const TableCell = styled(MuiTableCell)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[900],
   fontSize: "14px",
   fontWeight: "normal",
@@ -108,7 +109,7 @@ const Grid = styled(MuiGrid)({
   },
 });
 
-const KeyCellContainer = styled(TableCell)(({ theme }) => ({
+const KeyCellContainer = styled(TableCell)(({ theme }: { theme: Theme }) => ({
   width: "45%",
   background: alpha(theme.palette.secondary[900], 0.03),
   fontWeight: 500,

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -4,6 +4,7 @@ import type {
   TableCellProps as MuiTableCellProps,
   TableProps as MuiTableProps,
   TableRowProps as MuiTableRowProps,
+  Theme,
 } from "@mui/material";
 import {
   IconButton,
@@ -22,7 +23,7 @@ import { Popper, PopperItem } from "../popper";
 import styled from "../styled";
 import { Typography } from "../typography";
 
-const StyledPaper = styled(MuiPaper)(({ theme }) => ({
+const StyledPaper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   border: `1px solid ${theme.palette.secondary[200]}`,
 }));
 
@@ -53,7 +54,7 @@ const StyledTableBody = styled(MuiTableBody)({
   display: "contents",
 });
 
-const StyledTableHeadRow = styled(MuiTableRow)(({ theme }) => ({
+const StyledTableHeadRow = styled(MuiTableRow)(({ theme }: { theme: Theme }) => ({
   display: "contents",
   backgroundColor: theme.palette.primary[300],
 }));
@@ -61,7 +62,7 @@ const StyledTableHeadRow = styled(MuiTableRow)(({ theme }) => ({
 const StyledTableRow = styled(MuiTableRow)<{
   $responsive?: TableRowProps["responsive"];
 }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     ":nth-of-type(even)": {
       background: theme.palette.secondary[50],
     },
@@ -79,7 +80,7 @@ const StyledTableCell = styled(MuiTableCell)<{
   $responsive?: TableCellProps["responsive"];
   $action?: TableCellProps["action"];
 }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     alignItems: "center",
     fontSize: "14px",
     padding: "15px 16px",
@@ -88,7 +89,7 @@ const StyledTableCell = styled(MuiTableCell)<{
     background: "inherit",
     minHeight: "100%",
   }),
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     borderBottom: props?.$border ? `1px solid ${theme.palette.secondary[200]}` : "0",
     display: props.$responsive ? "flex" : "",
     width: !props.$responsive && props.$action ? "80px" : "",

--- a/frontend/packages/core/src/accordion.tsx
+++ b/frontend/packages/core/src/accordion.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "@emotion/styled";
 import AddIcon from "@mui/icons-material/Add";
 import RemoveIcon from "@mui/icons-material/Remove";
-import type { AccordionProps as MuiAccordionProps } from "@mui/material";
+import type { AccordionProps as MuiAccordionProps, Theme } from "@mui/material";
 import {
   Accordion as MuiAccordion,
   AccordionActions as MuiAccordionActions,
@@ -13,7 +13,7 @@ import {
   useControlled,
 } from "@mui/material";
 
-const StyledAccordion = styled(MuiAccordion)(({ theme }) => ({
+const StyledAccordion = styled(MuiAccordion)(({ theme }: { theme: Theme }) => ({
   borderRadius: "4px",
   boxShadow: "none",
   border: "1px solid transparent",
@@ -59,30 +59,32 @@ const AccordionSummaryBase = ({ children, collapsible, expanded, ...props }) => 
   );
 };
 
-export const StyledAccordionSummary = styled(AccordionSummaryBase)(({ theme }) => ({
-  backgroundColor: theme.palette.secondary[50],
-  borderRadius: "4px",
-  color: theme.palette.secondary[900],
-  height: "48px",
+export const StyledAccordionSummary = styled(AccordionSummaryBase)(
+  ({ theme }: { theme: Theme }) => ({
+    backgroundColor: theme.palette.secondary[50],
+    borderRadius: "4px",
+    color: theme.palette.secondary[900],
+    height: "48px",
 
-  "&:hover": {
-    backgroundColor: alpha(theme.palette.secondary[900], 0.03),
-  },
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.secondary[900], 0.03),
+    },
 
-  "&:active": {
-    backgroundColor: alpha(theme.palette.secondary[900], 0.12),
-  },
+    "&:active": {
+      backgroundColor: alpha(theme.palette.secondary[900], 0.12),
+    },
 
-  ".MuiAccordionSummary-content": {
-    margin: "12px 0",
-    fontSize: "16px",
-  },
+    ".MuiAccordionSummary-content": {
+      margin: "12px 0",
+      fontSize: "16px",
+    },
 
-  "&.Mui-expanded": {
-    backgroundColor: theme.palette.primary[200],
-    minHeight: "48px",
-  },
-}));
+    "&.Mui-expanded": {
+      backgroundColor: theme.palette.primary[200],
+      minHeight: "48px",
+    },
+  })
+);
 
 const StyledAccordionGroup = styled.div({
   width: "100%",

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "@emotion/styled";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import FileCopyOutlinedIcon from "@mui/icons-material/FileCopyOutlined";
 import type {
@@ -17,6 +16,7 @@ import {
 
 import { Tooltip } from "./Feedback/tooltip";
 import type { GridJustification } from "./grid";
+import { styled } from ".";
 
 interface ButtonPalette {
   /** A palette of background colors used for the various button states. */
@@ -93,7 +93,7 @@ const StyledButton = styled(MuiButton)<{
   })
 );
 
-const StyledBorderButton = styled(StyledButton)(({ theme }) => ({
+const StyledBorderButton = styled(StyledButton)(({ theme }: { theme: Theme }) => ({
   border: `1px solid ${theme.palette.secondary[900]}`,
   "&.Mui-disabled": {
     borderColor: alpha(theme.palette.secondary[900], 0.1),
@@ -258,7 +258,7 @@ const ButtonGroupContainer = styled(Grid)(
       margin: "12px 8px",
     },
   },
-  props => ({ theme }) =>
+  props => ({ theme }: { theme: Theme }) =>
     props["data-border"] === "bottom"
       ? {
           marginBottom: "12px",
@@ -288,7 +288,7 @@ const ButtonGroup = ({ children, justify = "flex-end", border = "top" }: ButtonG
   </ButtonGroupContainer>
 );
 
-const StyledClipboardIconButton = styled(MuiIconButton)(({ theme }) => ({
+const StyledClipboardIconButton = styled(MuiIconButton)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.getContrastText(theme.palette.contrastColor),
   ":hover": {
     backgroundColor: "transparent",

--- a/frontend/packages/core/src/button.tsx
+++ b/frontend/packages/core/src/button.tsx
@@ -16,7 +16,7 @@ import {
 
 import { Tooltip } from "./Feedback/tooltip";
 import type { GridJustification } from "./grid";
-import { styled } from ".";
+import styled from "./styled";
 
 interface ButtonPalette {
   /** A palette of background colors used for the various button states. */

--- a/frontend/packages/core/src/card.tsx
+++ b/frontend/packages/core/src/card.tsx
@@ -9,6 +9,7 @@ import {
   CardActionAreaProps,
   Divider,
   Grid,
+  Theme,
   useTheme,
 } from "@mui/material";
 import type { SpacingProps as MuiSpacingProps } from "@mui/system";
@@ -20,7 +21,7 @@ import { Typography, TypographyProps } from "./typography";
 
 // TODO: seperate out the different card parts into various files
 
-const StyledCard = styled(MuiCard)(({ theme }) => ({
+const StyledCard = styled(MuiCard)(({ theme }: { theme: Theme }) => ({
   boxShadow: `0px 4px 6px ${alpha(theme.palette.primary[600], 0.2)}`,
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.1)}`,
 }));
@@ -31,7 +32,7 @@ export interface CardProps {
 
 const Card = ({ children, ...props }: CardProps) => <StyledCard {...props}>{children}</StyledCard>;
 
-const StyledCardHeaderContainer = styled("div")(({ theme }) => ({
+const StyledCardHeaderContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   background: theme.palette.primary[200],
 }));
 
@@ -60,7 +61,7 @@ const StyledCardHeaderAvatar = styled("div")({
 });
 
 // TODO: make the divider a core component
-const StyledDivider = styled(Divider)(({ theme }) => ({
+const StyledDivider = styled(Divider)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.secondary[400],
   height: "24px",
   alignSelf: "center",
@@ -138,7 +139,7 @@ const BaseCardActionArea = styled(CardActionArea)<SpacingProps>`
   ${spacing}
 `;
 
-const StyledCardActionArea = styled(BaseCardActionArea)(({ theme }) => ({
+const StyledCardActionArea = styled(BaseCardActionArea)(({ theme }: { theme: Theme }) => ({
   ":hover": {
     backgroundColor: theme.palette.primary[100],
   },
@@ -148,7 +149,7 @@ const StyledCardActionArea = styled(BaseCardActionArea)(({ theme }) => ({
   },
 }));
 
-const StyledExpandButton = styled(IconButton)(({ theme }) => ({
+const StyledExpandButton = styled(IconButton)(({ theme }: { theme: Theme }) => ({
   width: "32px",
   height: "32px",
   color: theme.palette.primary[600],
@@ -246,7 +247,7 @@ const CardContent = ({
   );
 };
 
-const StyledLandingCard = styled(Card)(({ theme }) => ({
+const StyledLandingCard = styled(Card)(({ theme }: { theme: Theme }) => ({
   border: "none",
   height: "214px",
   maxHeight: "100%",
@@ -284,7 +285,7 @@ const IconAvatar = styled(Avatar)({
   marginRight: "8px",
 });
 
-const StyledAvatar = styled(IconAvatar)(({ theme }) => ({
+const StyledAvatar = styled(IconAvatar)(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.38),
   backgroundColor: alpha(theme.palette.secondary[900], 0.12),
 }));

--- a/frontend/packages/core/src/confirmation.tsx
+++ b/frontend/packages/core/src/confirmation.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import styled from "@emotion/styled";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ThumbUpIcon from "@mui/icons-material/ThumbUp";
-import { alpha, Grid } from "@mui/material";
+import { alpha, Grid, Theme } from "@mui/material";
 
-const IconContainer = styled(Grid)(({ theme }) => ({
+const IconContainer = styled(Grid)(({ theme }: { theme: Theme }) => ({
   paddingTop: "4px",
   display: "flex",
   flexDirection: "column",
@@ -18,7 +18,7 @@ const Icon = styled(ThumbUpIcon)({
   marginBottom: "10px",
 });
 
-const TitleContainer = styled(Grid)(({ theme }) => ({
+const TitleContainer = styled(Grid)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.success[600],
   display: "flex",
   alignItems: "center",
@@ -31,7 +31,7 @@ const CheckmarkIcon = styled(CheckCircleIcon)({
   marginRight: "8px",
 });
 
-const SubtitleContainer = styled.div(({ theme }) => ({
+const SubtitleContainer = styled.div(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.6),
   fontSize: "12px",
 }));

--- a/frontend/packages/core/src/dialog.tsx
+++ b/frontend/packages/core/src/dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import CloseIcon from "@mui/icons-material/Close";
-import type { DialogProps as MuiDialogProps } from "@mui/material";
+import type { DialogProps as MuiDialogProps, Theme } from "@mui/material";
 import {
   alpha,
   Dialog as MuiDialog,
@@ -13,7 +13,7 @@ import {
 
 import styled from "./styled";
 
-const DialogPaper = styled(Paper)(({ theme }) => ({
+const DialogPaper = styled(Paper)(({ theme }: { theme: Theme }) => ({
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.1)}`,
   boxShadow: `0px 10px 24px ${alpha(theme.palette.primary[700], 0.3)}`,
   boxSizing: "border-box",
@@ -22,7 +22,7 @@ const DialogPaper = styled(Paper)(({ theme }) => ({
   maxWidth: "75vw",
 }));
 
-const DialogTitle = styled(MuiDialogTitle)(({ theme }) => ({
+const DialogTitle = styled(MuiDialogTitle)(({ theme }: { theme: Theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   fontSize: "20px",
@@ -35,13 +35,13 @@ const DialogTitleText = styled("div")({
   padding: "14px 0 0 0",
 });
 
-const IconButton = styled(MuiIconButton)(({ theme }) => ({
+const IconButton = styled(MuiIconButton)(({ theme }: { theme: Theme }) => ({
   height: "12px",
   width: "12px",
   color: theme.palette.secondary[900],
 }));
 
-const DialogContent = styled(MuiDialogContent)(({ theme }) => ({
+const DialogContent = styled(MuiDialogContent)(({ theme }: { theme: Theme }) => ({
   padding: "16px 32px 32px 32px",
   fontSize: "16px",
   fontWeight: 400,
@@ -52,7 +52,7 @@ const DialogContent = styled(MuiDialogContent)(({ theme }) => ({
   overflowWrap: "break-word",
 }));
 
-const DialogActions = styled(MuiDialogActions)(({ theme }) => ({
+const DialogActions = styled(MuiDialogActions)(({ theme }: { theme: Theme }) => ({
   borderTop: `1px solid ${alpha(theme.palette.secondary[900], 0.12)}`,
   padding: "0 8px",
   "> *": {

--- a/frontend/packages/core/src/horizontal-rule.tsx
+++ b/frontend/packages/core/src/horizontal-rule.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import styled from "@emotion/styled";
+import type { Theme } from "@mui/material";
 import { alpha } from "@mui/system";
 
 const HorizontalRuleBase = ({ children, ...props }: HorizontalRuleProps) => (
@@ -18,7 +19,7 @@ export type HorizontalRuleProps = {
   children: React.ReactNode;
 };
 
-const StyledHorizontalRule = styled(HorizontalRuleBase)(({ theme }) => ({
+const StyledHorizontalRule = styled(HorizontalRuleBase)(({ theme }: { theme: Theme }) => ({
   alignItems: "center",
   display: "flex",
   flexDirection: "row",

--- a/frontend/packages/core/src/landing.tsx
+++ b/frontend/packages/core/src/landing.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { alpha, Grid } from "@mui/material";
+import { alpha, Grid, Theme } from "@mui/material";
 import Typography from "@mui/material/Typography";
 
 import { userId } from "./AppLayout/user";
@@ -11,7 +11,7 @@ import { LandingCard } from "./card";
 import { useAppContext } from "./Contexts";
 import { useNavigate } from "./navigation";
 
-const StyledLanding = styled.div(({ theme }) => ({
+const StyledLanding = styled.div(({ theme }: { theme: Theme }) => ({
   display: "flex",
   flexDirection: "column",
   flexGrow: 1,

--- a/frontend/packages/core/src/link.tsx
+++ b/frontend/packages/core/src/link.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { LinkProps as MuiLinkProps } from "@mui/material";
+import type { LinkProps as MuiLinkProps, Theme } from "@mui/material";
 import { Link as MuiLink } from "@mui/material";
 
 import styled from "./styled";
@@ -9,7 +9,7 @@ type TextTransform = "none" | "capitalize" | "uppercase" | "lowercase" | "initia
 const StyledLink = styled(MuiLink)<{
   $textTransform: LinkProps["textTransform"];
 }>(
-  ({ theme }) => ({
+  ({ theme }: { theme: Theme }) => ({
     display: "flex",
     width: "100%",
     maxWidth: "fit-content",

--- a/frontend/packages/core/src/loading.tsx
+++ b/frontend/packages/core/src/loading.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { CircularProgress, Grid, Paper } from "@mui/material";
+import { CircularProgress, Grid, Paper, Theme } from "@mui/material";
 
-const LoadingSpinner = styled(CircularProgress)(({ theme }) => ({
+const LoadingSpinner = styled(CircularProgress)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.primary[600],
   position: "absolute",
 }));

--- a/frontend/packages/core/src/not-found.tsx
+++ b/frontend/packages/core/src/not-found.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import styled from "@emotion/styled";
 import ThumbDownIcon from "@mui/icons-material/ThumbDown";
-import { Grid, Typography } from "@mui/material";
+import { Grid, Theme, Typography } from "@mui/material";
 
 const Container = styled(Grid)`
   minheight: 80vh;
 `;
 
-const IconContainer = styled(Grid)(({ theme }) => ({
+const IconContainer = styled(Grid)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.brandColor,
   fontSize: "7rem",
 }));

--- a/frontend/packages/core/src/paper.tsx
+++ b/frontend/packages/core/src/paper.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import type { PaperProps as MuiPaperProps } from "@mui/material";
+import type { PaperProps as MuiPaperProps, Theme } from "@mui/material";
 import { alpha, Paper as MuiPaper } from "@mui/material";
 
 export interface PaperProps extends Pick<MuiPaperProps, "children"> {}
 
-const StyledPaper = styled(MuiPaper)(({ theme }) => ({
+const StyledPaper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   boxShadow: `0px 4px 6px ${alpha(theme.palette.primary[600], 0.2)}`,
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.1)}`,
   background: theme.palette.contrastColor,

--- a/frontend/packages/core/src/popper.tsx
+++ b/frontend/packages/core/src/popper.tsx
@@ -4,6 +4,7 @@ import type {
   ClickAwayListenerProps,
   ListItemProps,
   PopperProps as MuiPopperProps,
+  Theme,
 } from "@mui/material";
 import {
   alpha,
@@ -21,7 +22,7 @@ const StyledPopper = styled(MuiPopper)({
   paddingTop: "16px",
 });
 
-const Paper = styled(MuiPaper)(({ theme }) => ({
+const Paper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   minWidth: "fit-content",
   border: `1px solid ${theme.palette.secondary[200]}`,
   boxShadow: `0px 10px 24px ${alpha(theme.palette.primary[700], 0.3)}`,
@@ -61,7 +62,7 @@ const PopperItemIcon = styled.div({
   width: "24px",
 });
 
-const ListItemText = styled(MuiListItemText)(({ theme }) => ({
+const ListItemText = styled(MuiListItemText)(({ theme }: { theme: Theme }) => ({
   ".MuiTypography-root": {
     color: alpha(theme.palette.secondary[900], 0.6),
     fontWeight: 500,

--- a/frontend/packages/core/src/stepper.tsx
+++ b/frontend/packages/core/src/stepper.tsx
@@ -8,10 +8,11 @@ import {
   StepConnector as MuiStepConnector,
   StepLabel as MuiStepLabel,
   Stepper as MuiStepper,
+  Theme,
   useTheme,
 } from "@mui/material";
 
-const StepContainer = styled.div(({ theme }) => ({
+const StepContainer = styled.div(({ theme }: { theme: Theme }) => ({
   margin: "0px 2px 30px 2px",
   ".MuiStepLabel-label": {
     fontWeight: 500,

--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import styled from "@emotion/styled";
 import { TabContext, TabList, TabPanel as MuiTabPanel } from "@mui/lab";
-import type { TabProps as MuiTabProps, TabsProps as MuiTabsProps } from "@mui/material";
+import type { TabProps as MuiTabProps, TabsProps as MuiTabsProps, Theme } from "@mui/material";
 import { alpha, Tab as MuiTab } from "@mui/material";
 
-const StyledTab = styled(MuiTab)(({ theme }) => ({
+const StyledTab = styled(MuiTab)(({ theme }: { theme: Theme }) => ({
   minWidth: "111px",
   height: "46px",
   padding: "12px 32px",
@@ -41,7 +41,7 @@ const StyledTab = styled(MuiTab)(({ theme }) => ({
   },
 }));
 
-const StyledTabs = styled(TabList)(({ theme }) => ({
+const StyledTabs = styled(TabList)(({ theme }: { theme: Theme }) => ({
   ".MuiTabs-indicator": {
     height: "4px",
     backgroundColor: theme.palette.primary[600],

--- a/frontend/packages/core/src/tests/__snapshots__/landing.test.tsx.snap
+++ b/frontend/packages/core/src/tests/__snapshots__/landing.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-1aarkdb"
+    class="css-1be9aqm"
     id="landing"
   >
     <div

--- a/frontend/packages/core/src/text.tsx
+++ b/frontend/packages/core/src/text.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import { alpha, Fab, Grid } from "@mui/material";
+import { alpha, Fab, Grid, Theme } from "@mui/material";
 
 import { ClipboardButton } from "./button";
 
@@ -13,7 +13,7 @@ const ContentContainer = styled(Grid)({
   flex: 1,
 });
 
-const Pre = styled("pre")(({ theme }) => ({
+const Pre = styled("pre")(({ theme }: { theme: Theme }) => ({
   border: `1px solid ${alpha(theme.palette.secondary[900], 0.38)}`,
   backgroundColor: alpha(theme.palette.secondary[900], 0.12),
   borderRadius: "4px",
@@ -28,7 +28,7 @@ const Pre = styled("pre")(({ theme }) => ({
   overflowY: "scroll",
 }));
 
-const StyledFab = styled(Fab)(({ theme }) => ({
+const StyledFab = styled(Fab)(({ theme }: { theme: Theme }) => ({
   background: theme.palette.secondary[200],
   "&:hover": {
     background: theme.palette.secondary[50],

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -21,6 +21,7 @@ import {
   Container as MuiContainer,
   Grid,
   Paper as MuiPaper,
+  Theme,
   Typography,
 } from "@mui/material";
 
@@ -65,7 +66,7 @@ const Container = styled(MuiContainer)<{ $width: ContainerProps["width"] }>(
   })
 );
 
-const Paper = styled(MuiPaper)(({ theme }) => ({
+const Paper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   boxShadow: `0px 5px 15px ${alpha(theme.palette.primary[600], 0.2)}`,
   padding: "32px",
 }));

--- a/frontend/workflows/audit/src/logs/event-row.tsx
+++ b/frontend/workflows/audit/src/logs/event-row.tsx
@@ -11,12 +11,12 @@ import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import ShareIcon from "@mui/icons-material/Share";
-import { Stack } from "@mui/material";
+import { Stack, Theme } from "@mui/material";
 import FileSaver from "file-saver";
 
 const ENDPOINT = "/v1/audit/getEvents";
 const COLUMN_COUNT = 6;
-const MonospaceText = styled("div")(({ theme }) => ({
+const MonospaceText = styled("div")(({ theme }: { theme: Theme }) => ({
   fontFamily: "monospace",
   padding: "8px",
   border: "1px solid lightgray",

--- a/frontend/workflows/audit/src/logs/index.tsx
+++ b/frontend/workflows/audit/src/logs/index.tsx
@@ -11,7 +11,7 @@ import {
   useTheme,
 } from "@clutch-sh/core";
 import SearchIcon from "@mui/icons-material/Search";
-import { CircularProgress, Stack, useMediaQuery } from "@mui/material";
+import { CircularProgress, Stack, Theme, useMediaQuery } from "@mui/material";
 
 import type { AuditLogProps } from "..";
 
@@ -34,7 +34,7 @@ const LoadingContainer = styled("div")({
   width: "40px",
 });
 
-const LoadingSpinner = styled(CircularProgress)(({ theme }) => ({
+const LoadingSpinner = styled(CircularProgress)(({ theme }: { theme: Theme }) => ({
   color: theme.palette.primary[600],
   position: "absolute",
 }));

--- a/frontend/workflows/envoy/src/remote-triage/clusters.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/clusters.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { AccordionRow, StatusIcon, styled, Table, TableRow, useTheme } from "@clutch-sh/core";
+import type { Theme } from "@mui/material";
 import _ from "lodash";
 
 const BarContainer = styled("rect")<{ $fill: string; $width: string }>(
   {
     height: "12px",
   },
-  props => ({ theme }) => ({
+  props => ({ theme }: { theme: Theme }) => ({
     width: props.$width,
     fill: props.$fill,
     strokeWidth: props.$fill === "transparent" ? "1px" : "0",

--- a/frontend/workflows/envoy/src/remote-triage/dashboard.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/dashboard.tsx
@@ -4,7 +4,7 @@ import { Grid, MetadataTable, Paper, styled } from "@clutch-sh/core";
 import type { Theme } from "@mui/material";
 import { Cell, Pie, PieChart } from "recharts";
 
-const SummaryCardTitle = styled("div")(({ theme }) => ({
+const SummaryCardTitle = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: 600,
   fontSize: "14px",
   color: theme.palette.secondary[900],

--- a/frontend/workflows/envoy/src/remote-triage/server-info.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/server-info.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { MetadataTable, styled } from "@clutch-sh/core";
+import type { Theme } from "@mui/material";
 
 const Container = styled("div")({
   "> *": {
@@ -8,7 +9,7 @@ const Container = styled("div")({
   },
 });
 
-const Title = styled("div")(({ theme }) => ({
+const Title = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: "bold",
   fontSize: "20px",
   color: theme.palette.secondary[900],

--- a/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
+++ b/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`renders correctly 1`] = `
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"
           >
             <div
-              class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
             >
               <label
                 class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"

--- a/frontend/workflows/k8s/src/k8s-dash-header.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-header.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { styled } from "@clutch-sh/core";
-import { alpha } from "@mui/material";
+import { alpha, Theme } from "@mui/material";
 
-const Category = styled("div")(({ theme }) => ({
+const Category = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: 700,
   fontSize: "12px",
   lineHeight: "16px",
@@ -11,7 +11,7 @@ const Category = styled("div")(({ theme }) => ({
   paddingBottom: "8px",
 }));
 
-const HeaderText = styled("div")(({ theme }) => ({
+const HeaderText = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: 700,
   fontSize: "26px",
   lineHeight: "32px",

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -6,7 +6,7 @@ import AppsIcon from "@mui/icons-material/Apps";
 import CropFreeIcon from "@mui/icons-material/CropFree";
 import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined";
 import LoopOutlinedIcon from "@mui/icons-material/LoopOutlined";
-import { alpha } from "@mui/material";
+import { alpha, Theme } from "@mui/material";
 
 import type { WorkflowProps } from ".";
 import CronTable from "./crons-table";
@@ -30,7 +30,7 @@ const Content = styled("div")({
   margin: "32px 0",
 });
 
-const PlaceholderTitle = styled("div")(({ theme }) => ({
+const PlaceholderTitle = styled("div")(({ theme }: { theme: Theme }) => ({
   paddingBottom: "16px",
   fontWeight: 700,
   fontSize: "22px",
@@ -38,7 +38,7 @@ const PlaceholderTitle = styled("div")(({ theme }) => ({
   color: theme.palette.secondary[900],
 }));
 
-const PlaceholderText = styled("div")(({ theme }) => ({
+const PlaceholderText = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: 400,
   fontSize: "16px",
   lineHeight: "22px",

--- a/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
@@ -3,9 +3,9 @@ import type { clutch as IClutch } from "@clutch-sh/api";
 import { Card, Grid, IconButton, styled, Typography, useTheme } from "@clutch-sh/core";
 import CloseIcon from "@mui/icons-material/Close";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
-import { alpha } from "@mui/material";
+import { alpha, Theme } from "@mui/material";
 
-const StyledCard = styled(Card)(({ theme }) => ({
+const StyledCard = styled(Card)(({ theme }: { theme: Theme }) => ({
   display: "flex",
   flexDirection: "column",
   width: "350px",

--- a/frontend/workflows/projectCatalog/src/details/card.tsx
+++ b/frontend/workflows/projectCatalog/src/details/card.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { TypographyProps } from "@clutch-sh/core";
 import { Card, ClutchError, Error, Grid, styled, Typography } from "@clutch-sh/core";
-import { LinearProgress } from "@mui/material";
+import { LinearProgress, Theme } from "@mui/material";
 
 enum CardType {
   DYNAMIC = "Dynamic",
@@ -50,7 +50,7 @@ const StyledCard = styled(Card)({
   padding: "16px",
 });
 
-const StyledProgressContainer = styled("div")(({ theme }) => ({
+const StyledProgressContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   marginBottom: "8px",
   marginTop: "-12px",
   height: "4px",

--- a/frontend/workflows/projectSelector/src/card.tsx
+++ b/frontend/workflows/projectSelector/src/card.tsx
@@ -11,9 +11,9 @@ import {
 } from "@clutch-sh/core";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import { LinearProgress } from "@mui/material";
+import { LinearProgress, Theme } from "@mui/material";
 
-const StyledProgressContainer = styled("div")(({ theme }) => ({
+const StyledProgressContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   height: "4px",
   ".MuiLinearProgress-root": {
     backgroundColor: theme.palette.primary[400],

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -3,7 +3,7 @@ import { Checkbox, checkFeatureEnabled, styled, Switch } from "@clutch-sh/core";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ClearIcon from "@mui/icons-material/Clear";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { alpha } from "@mui/material";
+import { alpha, Theme } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 
 import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
@@ -22,7 +22,7 @@ const StyledGroupTitle = styled("span")({
   display: "inline-block",
 });
 
-const StyledCount = styled("span")(({ theme }) => ({
+const StyledCount = styled("span")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.6),
   backgroundColor: alpha(theme.palette.secondary[900], 0.03),
   fontVariantNumeric: "tabular-nums",
@@ -38,7 +38,7 @@ const StyledCount = styled("span")(({ theme }) => ({
 
 // This div used to have `padding: "0 25px 0 8px"` but that made it look weird when we implemented quicklinks
 // because the "only" and "x" buttons are hidden when the popper is expanded and mouse is no longer hovering.
-const StyledMenuItem = styled("div")(({ theme }) => ({
+const StyledMenuItem = styled("div")(({ theme }: { theme: Theme }) => ({
   height: "48px",
   display: "flex",
   alignItems: "center",
@@ -66,14 +66,14 @@ const StyledHeaderColumn = styled("div")((props: { grow?: boolean }) => ({
   flexGrow: props.grow ? 1 : 0,
 }));
 
-const StyledNoProjectsText = styled("div")(({ theme }) => ({
+const StyledNoProjectsText = styled("div")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.38),
   textAlign: "center",
   fontSize: "12px",
   marginBottom: "16px",
 }));
 
-const StyledAllText = styled("div")(({ theme }) => ({
+const StyledAllText = styled("div")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.38),
 }));
 
@@ -88,7 +88,7 @@ const StyledMenuItemName = styled("span")({
   maxWidth: "160px",
 });
 
-const StyledClearIcon = styled("span")(({ theme }) => ({
+const StyledClearIcon = styled("span")(({ theme }: { theme: Theme }) => ({
   ".MuiIconButton-root": {
     padding: "6px",
     color: alpha(theme.palette.secondary[900], 0.38),
@@ -101,7 +101,7 @@ const StyledClearIcon = styled("span")(({ theme }) => ({
   },
 }));
 
-const StyledOnlyButton = styled("button")(({ theme }) => ({
+const StyledOnlyButton = styled("button")(({ theme }: { theme: Theme }) => ({
   border: "none",
   cursor: "pointer",
   borderRadius: "4px",

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { Link, Popper, styled, Typography, useTheme } from "@clutch-sh/core";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { alpha } from "@mui/material";
+import { alpha, Theme } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 
 interface LinkGroupProps {
@@ -12,7 +12,7 @@ interface LinkGroupProps {
 
 const ICON_SIZE = "16px";
 
-const StyledMoreVertIcon = styled("span")(({ theme }) => ({
+const StyledMoreVertIcon = styled("span")(({ theme }: { theme: Theme }) => ({
   ".MuiIconButton-root": {
     padding: "6px",
     color: alpha(theme.palette.secondary[900], 0.38),

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -18,7 +18,7 @@ import {
 import AddIcon from "@mui/icons-material/Add";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import UpdateIcon from "@mui/icons-material/Update";
-import { alpha, Divider, LinearProgress } from "@mui/material";
+import { alpha, Divider, LinearProgress, Theme } from "@mui/material";
 import _ from "lodash";
 
 import { useDashUpdater, useRefreshRateState, useRefreshUpdater } from "./dash-hooks";
@@ -64,7 +64,7 @@ const initialState: State = {
   error: undefined,
 };
 
-const StyledSelectorContainer = styled("div")(({ theme }) => ({
+const StyledSelectorContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   backgroundColor: theme.palette.primary[50],
   borderRight: `1px solid ${alpha(theme.palette.secondary[900], 0.1)}`,
   boxShadow: `0px 4px 6px ${alpha(theme.palette.primary[600], 0.2)}`,
@@ -93,7 +93,7 @@ const StyledProjectTextField = styled(TextField)({
   padding: "16px 16px 8px 16px",
 });
 
-const StyledProgressContainer = styled("div")(({ theme }) => ({
+const StyledProgressContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   height: "4px",
   ".MuiLinearProgress-root": {
     backgroundColor: theme.palette.primary[400],

--- a/frontend/workflows/redisexperimentation/src/tests/__snapshots__/experiment-details.test.tsx.snap
+++ b/frontend/workflows/redisexperimentation/src/tests/__snapshots__/experiment-details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
     class="css-1dkqlr9"
   >
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -42,7 +42,7 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -78,7 +78,7 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -124,7 +124,7 @@ exports[`renders correctly 1`] = `
         Fault Type
       </label>
       <div
-        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
       >
         <div
           aria-expanded="false"

--- a/frontend/workflows/redisexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
+++ b/frontend/workflows/redisexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`renders correctly 1`] = `
           class="css-1dkqlr9"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -58,7 +58,7 @@ exports[`renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -94,7 +94,7 @@ exports[`renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
               Fault Type
             </label>
             <div
-              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
             >
               <div
                 aria-expanded="false"

--- a/frontend/workflows/serverexperimentation/src/tests/__snapshots__/experiment-details.test.tsx.snap
+++ b/frontend/workflows/serverexperimentation/src/tests/__snapshots__/experiment-details.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders correctly 1`] = `
       Cluster Pair
     </h3>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -47,7 +47,7 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -83,7 +83,7 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -134,7 +134,7 @@ exports[`renders correctly 1`] = `
         Fault Type
       </label>
       <div
-        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
       >
         <div
           aria-expanded="false"
@@ -183,7 +183,7 @@ exports[`renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -254,7 +254,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
       Cluster Pair
     </h3>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -290,7 +290,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -336,7 +336,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
         Upstream Cluster Type
       </label>
       <div
-        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
       >
         <div
           aria-expanded="false"
@@ -385,7 +385,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -436,7 +436,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
         Fault Type
       </label>
       <div
-        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
       >
         <div
           aria-expanded="false"
@@ -485,7 +485,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
     >
       <label
         class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"

--- a/frontend/workflows/serverexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
+++ b/frontend/workflows/serverexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`renders correctly 1`] = `
             Cluster Pair
           </h3>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -63,7 +63,7 @@ exports[`renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -99,7 +99,7 @@ exports[`renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -150,7 +150,7 @@ exports[`renders correctly 1`] = `
               Fault Type
             </label>
             <div
-              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
             >
               <div
                 aria-expanded="false"
@@ -199,7 +199,7 @@ exports[`renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -289,7 +289,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
             Cluster Pair
           </h3>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -325,7 +325,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -371,7 +371,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
               Upstream Cluster Type
             </label>
             <div
-              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
             >
               <div
                 aria-expanded="false"
@@ -420,7 +420,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
@@ -471,7 +471,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
               Fault Type
             </label>
             <div
-              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-y8yi4s-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
             >
               <div
                 aria-expanded="false"
@@ -520,7 +520,7 @@ exports[`renders correctly with upstream cluster type selection enabled 1`] = `
             </div>
           </div>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-14umvlt-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
           >
             <label
               class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"


### PR DESCRIPTION
When using the `theme` prop in `styled` components, it is not typed, causing it to not have type checking. 

This PR replaces all instances of `({ theme })` an adds its type as `({ theme }: { theme: Theme })`

### Testing Performed
manual, unit tests