### PR TITLE
frontend: Filter out invalid link groups

### DIFF
--- a/frontend/packages/core/src/quick-links.tsx
+++ b/frontend/packages/core/src/quick-links.tsx
@@ -170,10 +170,15 @@ const SlicedLinkGroup = ({ slicedLinkGroups }: SlicedLinkGroupProps) => {
 const QuickLinksCard = ({ linkGroups }: QuickLinksProps) => {
   const anchorRef = React.useRef(null);
   const [open, setOpen] = React.useState(false);
+
+  const filteredLinkGroups = linkGroups.filter(
+    lg => lg.links?.length > 0 && lg.name && lg.imagePath
+  );
+
   // Show only the first five quick links, and put the rest in
   // an overflow popper
-  const firstFive = linkGroups.slice(0, 5);
-  const overflow = linkGroups.slice(5);
+  const firstFive = filteredLinkGroups.slice(0, 5);
+  const overflow = filteredLinkGroups.slice(5);
 
   return (
     <Card>


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

Prevent malformed link groups to show up in QuickLinksCard component by filtering out the invalid ones.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

Manual

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

N/A

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
