### PR TITLE
proxy module: update stats

### DIFF
--- a/backend/module/proxy/proxy.go
+++ b/backend/module/proxy/proxy.go
@@ -117,6 +117,7 @@ func (m *mod) RequestProxy(ctx context.Context, req *proxyv1.RequestProxyRequest
 	if err != nil {
 		m.scope.Tagged(map[string]string{
 			"service": service.Name,
+			"path":    req.Path,
 		}).Counter("request.error").Inc(1)
 		m.logger.Error("proxy request error", zap.Error(err))
 		return nil, err
@@ -124,6 +125,7 @@ func (m *mod) RequestProxy(ctx context.Context, req *proxyv1.RequestProxyRequest
 
 	m.scope.Tagged(map[string]string{
 		"service":     service.Name,
+		"path":        req.Path,
 		"status_code": fmt.Sprintf("%d", response.StatusCode),
 	}).Counter("request").Inc(1)
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
PR updates the proxy module stats to include the request path. This is helpful when a `service` has several `allowed requests` and you want to know which paths returned a success/error response.

### Testing Performed
manual

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
