### PR TITLE
frontend: adjust tab hover color

### DIFF
--- a/frontend/packages/core/src/tab.tsx
+++ b/frontend/packages/core/src/tab.tsx
@@ -9,7 +9,7 @@ const StyledTab = styled(MuiTab)(({ theme }: { theme: Theme }) => ({
   height: "46px",
   padding: "12px 32px",
   color: alpha(theme.palette.secondary[900], 0.6),
-  borderBottom: `3px solid ${theme.palette.secondary[200]}`,
+  borderBottom: `3px solid ${theme.palette.secondary[100]}`,
   fontSize: "14px",
   fontWeight: "bold",
   opacity: "1",
@@ -21,7 +21,7 @@ const StyledTab = styled(MuiTab)(({ theme }: { theme: Theme }) => ({
   },
   "&:hover": {
     color: alpha(theme.palette.secondary[900], 0.6),
-    backgroundColor: theme.palette.secondary[200],
+    backgroundColor: theme.palette.secondary[100],
     outline: "none",
   },
   "&:focus": {


### PR DESCRIPTION
Readability of tabs when hovered was reduced with the updated shade, this pr adjusts it by making the using a lighter color shade for the background.

before:
![image](https://github.com/lyft/clutch/assets/5430603/b1dd6f44-0bd4-4026-88d3-ca18b7e10cfa)

after:
![image](https://github.com/lyft/clutch/assets/5430603/95b89c27-0a1d-4f3b-abf1-cd2d799f9cc8)



### Testing Performed
manual, unit tests