### PR TITLE
frontend: Updating Default Chart Colors based on guide

### DIFF
--- a/frontend/packages/core/src/Charts/pie.tsx
+++ b/frontend/packages/core/src/Charts/pie.tsx
@@ -91,13 +91,20 @@ interface PieChartState {
 }
 
 const DEFAULT_COLORS = [
-  "#3548D4",
-  "#40A05A",
-  "#B09027",
-  "#D87313",
-  "#C2302E",
-  "#0D1030",
-  "#8884D8",
+  "#651FFF",
+  "#FF4081",
+  "#0091EA",
+  "#00695C",
+  "#9E9D24",
+  "#880E4F",
+  "#01579B",
+  "#F4511E",
+  "#009688",
+  "#C2185B",
+  "#1A237E",
+  "#7C4DFF",
+  "#88451D",
+  "#AA00FF",
 ];
 
 const renderActiveShape = (props, options) => {


### PR DESCRIPTION
### Description
Updates the default colors used in the Pie chart to reference the design guide.

![Screenshot 2024-01-31 at 11 16 40 AM](https://github.com/lyft/clutch/assets/8338893/be4f8bf3-4400-4f55-b925-7261804fe654)

### Testing Performed
manual
