### PR TITLE
frontend: bump clutch core version

### DIFF
--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -511,7 +511,7 @@ There are two new imports (`@clutch-sh/core` and `@clutch-sh/data-layout`) added
   },
   "dependencies": {
     // highlight-start
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     // highlight-end
     "@clutch-sh/wizard": "^2.0.0-beta",
@@ -629,7 +629,7 @@ There is another new import (`lodash`) added in the code above. Let's also add t
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     // highlight-next-line

--- a/docs/development/feature.md
+++ b/docs/development/feature.md
@@ -512,9 +512,9 @@ There are two new imports (`@clutch-sh/core` and `@clutch-sh/data-layout`) added
   "dependencies": {
     // highlight-start
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
     // highlight-end
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
@@ -630,8 +630,8 @@ There is another new import (`lodash`) added in the code above. Let's also add t
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     // highlight-next-line
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/amiibo/frontend/workflows/amiibo/package.json
+++ b/examples/amiibo/frontend/workflows/amiibo/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/examples/amiibo/frontend/workflows/amiibo/package.json
+++ b/examples/amiibo/frontend/workflows/amiibo/package.json
@@ -18,7 +18,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "lodash": "^4.17.21",

--- a/frontend/lerna.json
+++ b/frontend/lerna.json
@@ -6,5 +6,5 @@
     "packages/*",
     "workflows/*"
   ],
-  "version": "2.0.0-beta"
+  "version": "3.0.0-beta"
 }

--- a/frontend/packages/app/package.json
+++ b/frontend/packages/app/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "cypress run"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "react": "^17.0.2",
     "react-app-rewired": "^2.1.8",
     "react-dom": "^17.0.2"

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/core",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch Core Components",
   "homepage": "https://clutch.sh/docs/development/frontend/overview#clutch-shcore",
   "license": "Apache-2.0",

--- a/frontend/packages/data-layout/package.json
+++ b/frontend/packages/data-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/data-layout",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Data Layout manager for clutch",
   "homepage": "https://clutch.sh/docs/development/frontend/overview#clutch-shdata-layout",
   "license": "Apache-2.0",

--- a/frontend/packages/data-layout/package.json
+++ b/frontend/packages/data-layout/package.json
@@ -25,7 +25,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "lodash": "^4.17.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/packages/wizard/package.json
+++ b/frontend/packages/wizard/package.json
@@ -25,7 +25,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",

--- a/frontend/packages/wizard/package.json
+++ b/frontend/packages/wizard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/wizard",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Wizard Components to drive frontend workflows",
   "homepage": "https://clutch.sh/docs/development/frontend/overview#clutch-shwizard",
   "license": "Apache-2.0",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",
     "clsx": "^1.1.1",

--- a/frontend/workflows/audit/package.json
+++ b/frontend/workflows/audit/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",
     "file-saver": "^2.0.5",

--- a/frontend/workflows/audit/package.json
+++ b/frontend/workflows/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/audit",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": " Clutch Audit Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/dynamodb/package.json
+++ b/frontend/workflows/dynamodb/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@emotion/styled": "^11.1.5",

--- a/frontend/workflows/dynamodb/package.json
+++ b/frontend/workflows/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/dynamodb",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "private": true,
   "description": "Manage Dynamodb resources",
   "license": "Apache-2.0",
@@ -23,8 +23,8 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.1.5",
     "@mui/material": "^5.8.5",
     "lodash": "4.17.21",

--- a/frontend/workflows/ec2/package.json
+++ b/frontend/workflows/ec2/package.json
@@ -23,7 +23,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@mui/material": "^5.8.5",

--- a/frontend/workflows/ec2/package.json
+++ b/frontend/workflows/ec2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/ec2",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch EC2 Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@mui/material": "^5.8.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/workflows/envoy/package.json
+++ b/frontend/workflows/envoy/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@mui/material": "^5.8.5",

--- a/frontend/workflows/envoy/package.json
+++ b/frontend/workflows/envoy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/envoy",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch Envoy Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@mui/material": "^5.8.5",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.15",

--- a/frontend/workflows/experimentation/package.json
+++ b/frontend/workflows/experimentation/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@emotion/styled": "^11.0.0",
     "@mui/material": "^5.8.5",

--- a/frontend/workflows/experimentation/package.json
+++ b/frontend/workflows/experimentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/experimentation",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch Experimentation Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
     "@emotion/styled": "^11.0.0",
     "@mui/material": "^5.8.5",
     "@mui/styles": "^5.8.4",

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/k8s",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch K8s Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.1.5",
     "@hookform/resolvers": "2.8.8",
     "@mui/icons-material": "^5.8.4",

--- a/frontend/workflows/k8s/package.json
+++ b/frontend/workflows/k8s/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@emotion/styled": "^11.1.5",

--- a/frontend/workflows/kinesis/package.json
+++ b/frontend/workflows/kinesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/kinesis",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch Kinesis Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.0.0",
     "@mui/material": "^5.8.5",
     "lodash": "^4.17.21",

--- a/frontend/workflows/kinesis/package.json
+++ b/frontend/workflows/kinesis/package.json
@@ -23,7 +23,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@emotion/styled": "^11.0.0",

--- a/frontend/workflows/projectCatalog/package.json
+++ b/frontend/workflows/projectCatalog/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/project-selector": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",

--- a/frontend/workflows/projectCatalog/package.json
+++ b/frontend/workflows/projectCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/project-catalog",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch Project Catalog",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
@@ -23,9 +23,9 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
     "@clutch-sh/project-selector": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",

--- a/frontend/workflows/projectCatalog/package.json
+++ b/frontend/workflows/projectCatalog/package.json
@@ -24,7 +24,7 @@
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^3.0.0-beta",
-    "@clutch-sh/project-selector": "^2.0.0-beta",
+    "@clutch-sh/project-selector": "^3.0.0-beta",
     "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/frontend/workflows/projectSelector/package.json
+++ b/frontend/workflows/projectSelector/package.json
@@ -17,7 +17,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.8.4",

--- a/frontend/workflows/projectSelector/package.json
+++ b/frontend/workflows/projectSelector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/project-selector",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": " Filter your projects",
   "license": "Apache-2.0",
   "author": "hello@example.com",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",

--- a/frontend/workflows/redisexperimentation/package.json
+++ b/frontend/workflows/redisexperimentation/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^3.0.0-beta",
-    "@clutch-sh/experimentation": "^2.0.0-beta",
+    "@clutch-sh/experimentation": "^3.0.0-beta",
     "@clutch-sh/wizard": "^3.0.0-beta",
     "@hookform/resolvers": "2.8.8",
     "@mui/material": "^5.8.5",

--- a/frontend/workflows/redisexperimentation/package.json
+++ b/frontend/workflows/redisexperimentation/package.json
@@ -18,7 +18,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/experimentation": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",

--- a/frontend/workflows/redisexperimentation/package.json
+++ b/frontend/workflows/redisexperimentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/redis-experimentation",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "private": true,
   "description": "Redis Fault Experimentation Workflows",
   "license": "Apache-2.0",
@@ -19,9 +19,9 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
     "@clutch-sh/experimentation": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@hookform/resolvers": "2.8.8",
     "@mui/material": "^5.8.5",
     "history": "^5.0.0",

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/experimentation": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -21,7 +21,7 @@
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^3.0.0-beta",
-    "@clutch-sh/experimentation": "^2.0.0-beta",
+    "@clutch-sh/experimentation": "^3.0.0-beta",
     "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.0.0",
     "@hookform/resolvers": "2.8.8",

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/server-experimentation",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "private": true,
   "description": "Clutch Server Experimentation Workflows",
   "license": "Apache-2.0",
@@ -20,9 +20,9 @@
   "dependencies": {
     "@clutch-sh/api": "^2.0.0-beta",
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
     "@clutch-sh/experimentation": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.0.0",
     "@hookform/resolvers": "2.8.8",
     "@mui/material": "^5.8.5",

--- a/frontend/workflows/sourcecontrol/package.json
+++ b/frontend/workflows/sourcecontrol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clutch-sh/sourcecontrol",
-  "version": "2.0.0-beta",
+  "version": "3.0.0-beta",
   "description": "Clutch Source Control Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@emotion/styled": "^11.0.0",
     "@hookform/resolvers": "2.8.8",
     "@mui/icons-material": "^5.8.4",

--- a/frontend/workflows/sourcecontrol/package.json
+++ b/frontend/workflows/sourcecontrol/package.json
@@ -22,7 +22,7 @@
     "test:watch": "yarn run test --watch"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@emotion/styled": "^11.0.0",

--- a/tools/scaffolding/templates/frontend/package.json
+++ b/tools/scaffolding/templates/frontend/package.json
@@ -19,9 +19,9 @@
   },
   "dependencies": {
     {{- if .IsWizardTemplate}}
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     {{- else}}
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     {{- end}}
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -24,7 +24,7 @@
     "lerna": "^4.0.0",
     "@clutch-sh/ec2": "^2.0.0-beta",
     "@{{ .RepoName }}/echo": "^0.0.0",
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/tools": "^2.0.0-beta",
     "history": "^5.0.0",
     "react": "^17.0.2",

--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "lerna": "^4.0.0",
-    "@clutch-sh/ec2": "^2.0.0-beta",
+    "@clutch-sh/ec2": "^3.0.0-beta",
     "@{{ .RepoName }}/echo": "^0.0.0",
     "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/tools": "^2.0.0-beta",

--- a/tools/scaffolding/templates/gateway/frontend/workflows/echo/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/workflows/echo/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@clutch-sh/core": "^3.0.0-beta",
-    "@clutch-sh/data-layout": "^2.0.0-beta",
-    "@clutch-sh/wizard": "^2.0.0-beta",
+    "@clutch-sh/data-layout": "^3.0.0-beta",
+    "@clutch-sh/wizard": "^3.0.0-beta",
     "@mui/material": "^5.8.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/tools/scaffolding/templates/gateway/frontend/workflows/echo/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/workflows/echo/package.json
@@ -17,7 +17,7 @@
     "upgrade": "yarn upgrade"
   },
   "dependencies": {
-    "@clutch-sh/core": "^2.0.0-beta",
+    "@clutch-sh/core": "^3.0.0-beta",
     "@clutch-sh/data-layout": "^2.0.0-beta",
     "@clutch-sh/wizard": "^2.0.0-beta",
     "@mui/material": "^5.8.5",


### PR DESCRIPTION
Given the update from https://github.com/lyft/clutch/pull/2851 and since it is a major update to clutch, this PR updates the current version of clutch-sh/core (2.0.0-beta) to 3.0.0-beta to better represent the changes.

Additionally updates the dependency versions in packages within the current repo.

### Testing Performed
manual