### PR TITLE
frontend: Removing private variable on OSS workflows and add publishBeta script

### DIFF
--- a/frontend/workflows/dynamodb/package.json
+++ b/frontend/workflows/dynamodb/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
     "test": "jest --passWithNoTests",
+    "publishBeta": "../../../tools/publish-frontend.sh dynamodb",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"
   },

--- a/frontend/workflows/dynamodb/package.json
+++ b/frontend/workflows/dynamodb/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@clutch-sh/dynamodb",
   "version": "3.0.0-beta",
-  "private": true,
   "description": "Manage Dynamodb resources",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/projectCatalog/package.json
+++ b/frontend/workflows/projectCatalog/package.json
@@ -16,6 +16,7 @@
     "compile:watch": "yarn compile:dev -w",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
+    "publishBeta": "../../../tools/publish-frontend.sh project-catalog",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"

--- a/frontend/workflows/projectSelector/package.json
+++ b/frontend/workflows/projectSelector/package.json
@@ -12,6 +12,7 @@
     "compile:watch": "yarn compile:dev --watch=forever",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
+    "publishBeta": "../../../tools/publish-frontend.sh project-selector",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"

--- a/frontend/workflows/redisexperimentation/package.json
+++ b/frontend/workflows/redisexperimentation/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@clutch-sh/redis-experimentation",
   "version": "3.0.0-beta",
-  "private": true,
   "description": "Redis Fault Experimentation Workflows",
   "license": "Apache-2.0",
   "author": "resilience@lyft.com",

--- a/frontend/workflows/redisexperimentation/package.json
+++ b/frontend/workflows/redisexperimentation/package.json
@@ -12,6 +12,7 @@
     "compile:watch": "yarn compile:dev --watch=forever",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
+    "publishBeta": "../../../tools/publish-frontend.sh redis-experimentation",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@clutch-sh/server-experimentation",
   "version": "3.0.0-beta",
-  "private": true,
   "description": "Clutch Server Experimentation Workflows",
   "license": "Apache-2.0",
   "author": "clutch@lyft.com",

--- a/frontend/workflows/serverexperimentation/package.json
+++ b/frontend/workflows/serverexperimentation/package.json
@@ -12,6 +12,7 @@
     "compile:watch": "yarn compile:dev --watch=forever",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn run lint --fix",
+    "publishBeta": "../../../tools/publish-frontend.sh server-experimentation",
     "test": "jest --passWithNoTests",
     "test:coverage": "yarn run test --collect-coverage",
     "test:watch": "yarn run test --watch"


### PR DESCRIPTION
### Description
- Doesn't really make any sense for these workflows to hold the `private: true` variable when they're all part of an OSS repository. Removing them to fix issues found with versioning.
- Also adding the `publishBeta` script where it was missing, to allow for successful publishing.
