### PR TITLE
frontend: Adjusting Wizard to allow for styling

### DIFF
--- a/frontend/packages/core/src/paper.tsx
+++ b/frontend/packages/core/src/paper.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import type { PaperProps as MuiPaperProps, Theme } from "@mui/material";
 import { alpha, Paper as MuiPaper } from "@mui/material";
 
-export interface PaperProps extends Pick<MuiPaperProps, "children"> {}
+export interface PaperProps extends Pick<MuiPaperProps, "children" | "className"> {}
 
 const StyledPaper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   boxShadow: `0px 4px 6px ${alpha(theme.palette.primary[600], 0.2)}`,
@@ -14,8 +14,8 @@ const StyledPaper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   minHeight: "inherit",
 }));
 
-const Paper = ({ children, ...props }: PaperProps) => (
-  <StyledPaper {...props}>{children}</StyledPaper>
+const Paper = ({ children, className }: PaperProps) => (
+  <StyledPaper className={className}>{children}</StyledPaper>
 );
 
 export default Paper;

--- a/frontend/packages/core/src/paper.tsx
+++ b/frontend/packages/core/src/paper.tsx
@@ -14,8 +14,8 @@ const StyledPaper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   minHeight: "inherit",
 }));
 
-const Paper = ({ children, className }: PaperProps) => (
-  <StyledPaper className={className}>{children}</StyledPaper>
+const Paper = ({ children, ...props }: PaperProps) => (
+  <StyledPaper {...props}>{children}</StyledPaper>
 );
 
 export default Paper;

--- a/frontend/packages/core/src/paper.tsx
+++ b/frontend/packages/core/src/paper.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import type { PaperProps as MuiPaperProps, Theme } from "@mui/material";
 import { alpha, Paper as MuiPaper } from "@mui/material";
 
-export interface PaperProps extends Pick<MuiPaperProps, "children" | "className"> {}
+export interface PaperProps extends Pick<MuiPaperProps, "children"> {}
 
 const StyledPaper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
   boxShadow: `0px 4px 6px ${alpha(theme.palette.primary[600], 0.2)}`,

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -5,6 +5,7 @@ import {
   FeatureOn,
   Grid,
   NPSWizard,
+  Paper,
   SimpleFeatureFlag,
   Step,
   Stepper,
@@ -18,13 +19,18 @@ import {
 } from "@clutch-sh/core";
 import type { ManagerLayout } from "@clutch-sh/data-layout";
 import { DataLayoutContext, useDataLayoutManager } from "@clutch-sh/data-layout";
-import type { StepperProps as MuiStepperProps } from "@mui/material";
-import { alpha, Container as MuiContainer, Paper as MuiPaper, Theme } from "@mui/material";
+import type {
+  ContainerProps as MuiContainerProps,
+  StepperProps as MuiStepperProps,
+} from "@mui/material";
+import { alpha, Container as MuiContainer, Theme } from "@mui/material";
 
 import { useWizardState, WizardAction } from "./state";
 import type { WizardStepProps } from "./step";
 
-interface WizardProps extends Pick<ContainerProps, "width">, Pick<MuiStepperProps, "orientation"> {
+interface WizardProps
+  extends Pick<ContainerProps, "width" | "className">,
+    Pick<MuiStepperProps, "orientation"> {
   children: React.ReactElement<WizardStepProps> | React.ReactElement<WizardStepProps>[];
   dataLayout: ManagerLayout;
   heading?: string;
@@ -42,7 +48,7 @@ interface WizardStepData {
   [index: string]: any;
 }
 
-interface ContainerProps {
+interface ContainerProps extends Pick<MuiContainerProps, "className"> {
   width?: "default" | "full";
 }
 
@@ -58,7 +64,6 @@ const Header = styled(Grid)<{ $orientation: MuiStepperProps["orientation"] }>(
 const Container = styled(MuiContainer)<{ $width: ContainerProps["width"] }>(
   {
     padding: "32px",
-    maxWidth: "unset",
     height: "100%",
   },
   props => ({
@@ -88,7 +93,7 @@ const StyledStepContainer = styled(Grid)({
   marginTop: "-16px",
 });
 
-const Paper = styled(MuiPaper)(({ theme }: { theme: Theme }) => ({
+const StyledPaper = styled(Paper)(({ theme }: { theme: Theme }) => ({
   boxShadow: `0px 5px 15px ${alpha(theme.palette.primary[600], 0.2)}`,
   padding: "32px",
 }));
@@ -99,6 +104,7 @@ const Wizard = ({
   dataLayout,
   orientation = "horizontal",
   children,
+  className,
 }: WizardProps) => {
   const [state, dispatch] = useWizardState();
   const [wizardStepData, setWizardStepData] = React.useState<WizardStepData>({});
@@ -206,7 +212,11 @@ const Wizard = ({
   };
 
   return (
-    <Container $width={orientation === "vertical" ? "full" : width}>
+    <Container
+      $width={orientation === "vertical" ? "full" : width}
+      maxWidth={false}
+      className={className}
+    >
       <MaxHeightGrid container alignItems="stretch" spacing={2}>
         {heading && (
           <Header item $orientation={orientation}>
@@ -230,7 +240,7 @@ const Wizard = ({
             </Stepper>
           </StepperContainer>
           <StyledStepContainer item xs={12}>
-            <Paper elevation={0}>{steps[state.activeStep]}</Paper>
+            <StyledPaper elevation={0}>{steps[state.activeStep]}</StyledPaper>
           </StyledStepContainer>
         </MaxHeightGrid>
       </MaxHeightGrid>

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -212,11 +212,7 @@ const Wizard = ({
   };
 
   return (
-    <Container
-      $width={orientation === "vertical" ? "full" : width}
-      maxWidth={false}
-      className={className}
-    >
+    <Container $width={width} maxWidth={false} className={className}>
       <MaxHeightGrid container alignItems="stretch" spacing={2}>
         {heading && (
           <Header item $orientation={orientation}>

--- a/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
+++ b/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -100,7 +100,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"


### PR DESCRIPTION
### Description
Was having issues styling the wizard and realized something I had previously missed in the documentation. Namely https://emotion.sh/docs/styled#styling-any-component `styled can style any component as long as it accepts a className prop.`. Adding this in alleviates the issues with styling the Container for the Wizard.

At the same time, the MuiContainer was ignoring the `maxWidth: unset` so I did some digging and it seems it must be done via the `maxWidth={false}`. So adding that in so it correctly unsets the width versus just ignoring it entirely.

### Testing Performed
manual