### PR TITLE
frontend: Adjusting Colors for Vertical Stepper Active/Completion

### DIFF
--- a/frontend/packages/core/src/stepper.tsx
+++ b/frontend/packages/core/src/stepper.tsx
@@ -64,12 +64,6 @@ const StepContainer = styled("div")<{ $orientation: StepperOrientation }>(
     ".MuiStepLabel-label.Mui-completed": {
       color: alpha(theme.palette.secondary[900], 0.38),
     },
-    ".Mui-active .MuiStepConnector-line": {
-      backgroundColor: theme.palette.primary[600],
-    },
-    ".Mui-completed .MuiStepConnector-line": {
-      backgroundColor: theme.palette.primary[600],
-    },
     ...(props.$orientation === "horizontal"
       ? {
           margin: "0px 2px 30px 2px",
@@ -89,11 +83,23 @@ const StepContainer = styled("div")<{ $orientation: StepperOrientation }>(
             backgroundColor: theme.palette.secondary[200],
             borderRadius: "4px",
           },
+          ".Mui-active .MuiStepConnector-line": {
+            backgroundColor: theme.palette.primary[600],
+          },
+          ".Mui-completed .MuiStepConnector-line": {
+            backgroundColor: theme.palette.primary[600],
+          },
         }
       : {
           margin: "0px 2px 8px 2px",
           ".MuiStepConnector-line": {
             borderColor: theme.palette.secondary[300],
+          },
+          ".Mui-active .MuiStepConnector-line": {
+            borderColor: theme.palette.primary[600],
+          },
+          ".Mui-completed .MuiStepConnector-line": {
+            borderColor: theme.palette.primary[600],
           },
         }),
   })

--- a/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-omj7fc-MuiGrid-root"
         >
           <div
-            class="css-bsysql"
+            class="css-146xe7x"
           >
             <div
               class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-omj7fc-MuiGrid-root"
         >
           <div
-            class="css-bsysql"
+            class="css-146xe7x"
           >
             <div
               class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-omj7fc-MuiGrid-root"
         >
           <div
-            class="css-bsysql"
+            class="css-146xe7x"
           >
             <div
               class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
+++ b/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-omj7fc-MuiGrid-root"
         >
           <div
-            class="css-bsysql"
+            class="css-146xe7x"
           >
             <div
               class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -100,7 +100,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
+++ b/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -100,7 +100,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-omj7fc-MuiGrid-root"
         >
           <div
-            class="css-bsysql"
+            class="css-146xe7x"
           >
             <div
               class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-omj7fc-MuiGrid-root"
         >
           <div
-            class="css-bsysql"
+            class="css-146xe7x"
           >
             <div
               class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-omj7fc-MuiGrid-root"
         >
           <div
-            class="css-bsysql"
+            class="css-146xe7x"
           >
             <div
               class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root MuiContainer-maxWidthLg css-1yzw3lr-MuiContainer-root"
+    class="MuiContainer-root css-1ylvkhp-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-jaq6nv-MuiGrid-root"
@@ -140,7 +140,7 @@ exports[`renders correctly 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1lwj3w1-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1kkx6az-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-55fo0g-MuiPaper-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1ewlecp-MuiGrid-root"


### PR DESCRIPTION
### Description
Active and Completed steps were missed in previous iterations of vertical stepper integration. This caused some weird CSS, so adjusting that now.

#### Before
![Screenshot 2024-02-26 at 9 20 23 AM](https://github.com/lyft/clutch/assets/8338893/930fd165-1094-4386-901e-e539a5f37539)

#### After
![Screenshot 2024-02-26 at 9 23 47 AM](https://github.com/lyft/clutch/assets/8338893/a0c511fb-ca04-40c9-bcce-cb9047b75914)

### Testing Performed
manual