### PR TITLE
frontend: add badge support for quick links

### DIFF
--- a/frontend/packages/core/src/quick-links.tsx
+++ b/frontend/packages/core/src/quick-links.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { Badge, BadgeProps } from "@mui/material";
 
 import { IconButton } from "./button";
 import { Card } from "./card";
@@ -128,6 +129,10 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
 
 interface LinkGroup extends IClutch.core.project.v1.ILinkGroup {
   links?: QLink[];
+  badge?: {
+    color: BadgeProps["color"];
+    content: string;
+  };
 }
 
 export interface QuickLinksProps {
@@ -146,21 +151,34 @@ const SlicedLinkGroup = ({ slicedLinkGroups }: SlicedLinkGroupProps) => {
       {(slicedLinkGroups || []).map(linkGroup => {
         if (linkGroup.links?.length === 1) {
           return (
-            <QuickLink
+            <Badge
               key={`quicklink-${linkGroup.name}`}
-              link={linkGroup.links[0]}
-              linkGroupName={linkGroup.name ?? ""}
-              linkGroupImage={linkGroup.imagePath ?? ""}
-            />
+              badgeContent={linkGroup.badge?.content ?? null}
+              color={linkGroup.badge?.color ?? "default"}
+              overlap="circular"
+            >
+              <QuickLink
+                link={linkGroup.links[0]}
+                linkGroupName={linkGroup.name ?? ""}
+                linkGroupImage={linkGroup.imagePath ?? ""}
+              />
+            </Badge>
           );
         }
         return (
-          <QuickLinkGroup
+          <Badge
             key={`quicklink-${linkGroup.name}`}
-            linkGroupName={linkGroup.name ?? ""}
-            linkGroupImage={linkGroup.imagePath ?? ""}
-            links={linkGroup?.links ?? []}
-          />
+            badgeContent={linkGroup.badge?.content ?? null}
+            color={linkGroup.badge?.color ?? "default"}
+            overlap="circular"
+          >
+            <QuickLinkGroup
+              key={`quicklink-${linkGroup.name}`}
+              linkGroupName={linkGroup.name ?? " "}
+              linkGroupImage={linkGroup.imagePath ?? ""}
+              links={linkGroup?.links ?? []}
+            />
+          </Badge>
         );
       })}
     </>

--- a/frontend/packages/core/src/stories/quick-links.stories.tsx
+++ b/frontend/packages/core/src/stories/quick-links.stories.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+
+import QuickLinksCard, { QuickLinksProps } from "../quick-links";
+
+export default {
+  title: "Core/QuickLinksCard",
+  component: QuickLinksCard,
+} as Meta;
+
+const Template: Story<QuickLinksProps> = args => <QuickLinksCard {...args} />;
+
+const imagePath =
+  "https://user-images.githubusercontent.com/66325812/164936289-6c855c52-1713-4c21-9157-537bf835307e.svg";
+
+const linkGroups = [
+  {
+    name: "Group 1",
+    imagePath,
+    links: [
+      {
+        name: "Link 1",
+        url: "http://example.com/1",
+        trackingId: "track1",
+      },
+      {
+        name: "Link 2",
+        url: "http://example.com/2",
+        trackingId: "track2",
+      },
+    ],
+  },
+  {
+    name: "Group 2",
+    imagePath,
+    links: [
+      {
+        name: "Link 3",
+        url: "http://example.com/3",
+        trackingId: "track3",
+      },
+    ],
+  },
+];
+
+const manyGroups = [
+  ...linkGroups,
+  {
+    name: "Group 3",
+    imagePath,
+    links: [
+      {
+        name: "Link 4",
+        url: "http://example.com/4",
+        trackingId: "track4",
+      },
+      {
+        name: "Link 5",
+        url: "http://example.com/5",
+        trackingId: "track5",
+      },
+      {
+        name: "Link 6",
+        url: "http://example.com/6",
+        trackingId: "track6",
+      },
+    ],
+  },
+  {
+    name: "Group 4",
+    imagePath,
+    links: [
+      {
+        name: "Link 7",
+        url: "http://example.com/7",
+        trackingId: "track7",
+      },
+      {
+        name: "Link 8",
+        url: "http://example.com/8",
+        trackingId: "track8",
+      },
+    ],
+  },
+  {
+    name: "Group 5",
+    imagePath,
+    links: [
+      {
+        name: "Link 9",
+        url: "http://example.com/9",
+        trackingId: "track9",
+      },
+    ],
+  },
+  {
+    name: "Group 6",
+    imagePath,
+    links: [
+      {
+        name: "Link 10",
+        url: "http://example.com/10",
+        trackingId: "track10",
+      },
+    ],
+  },
+  {
+    name: "Group 7",
+    imagePath,
+    links: [
+      {
+        name: "Link 11",
+        url: "http://example.com/11",
+        trackingId: "track11",
+      },
+      {
+        name: "Link 12",
+        url: "http://example.com/12",
+        trackingId: "track12",
+      },
+    ],
+  },
+];
+
+const withBadges = [
+  {
+    ...linkGroups[0],
+    badge: {
+      color: "error",
+      content: "1",
+    },
+  },
+  {
+    ...linkGroups[1],
+    badge: {
+      color: "success",
+      content: " ",
+    },
+  },
+];
+
+export const Default = Template.bind({});
+Default.args = {
+  linkGroups,
+};
+
+export const TooManyGroups = Template.bind({});
+TooManyGroups.args = {
+  linkGroups: manyGroups,
+};
+
+export const WithBadges = Template.bind({});
+WithBadges.args = {
+  linkGroups: withBadges,
+};


### PR DESCRIPTION
This PR extends the Quick Links component to support badges in the link group icon.

Usage:
Pass a badge property to the linkGroup object specifying a color and a string. The string can be a whitespace so as to display an empty badge.

````
linkGroups = [
  {
    name: "Group 1",
    imagePath,
    links: [
      {
        name: "Link 1",
        url: "http://example.com/1",
        trackingId: "track1",
      },
      {
        name: "Link 2",
        url: "http://example.com/2",
        trackingId: "track2",
      },
    ],
  }
````
![image](https://github.com/lyft/clutch/assets/5430603/a6428124-e058-4673-b62d-063c7db32886)


### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
<!-- Describe how you tested this change below. -->

### GitHub Issue
<!-- Link to any existing GitHub issues related to this PR. -->

Fixes #

### TODOs
<!-- Include any TODOs outstanding for the submission of this pull request below. -->

<!--
Example:
- [ ] This is an item on my TODO list.
- [x] This is a completed item.
-->
