### PR TITLE
frontend: Extending Wizard props and fixing issue with user info not breaking

### DIFF
--- a/frontend/packages/core/src/AppLayout/user.tsx
+++ b/frontend/packages/core/src/AppLayout/user.tsx
@@ -90,6 +90,8 @@ const AvatarListItemIcon = styled(ListItemIcon)({
 const AvatarListItemText = styled(MuiListItemText)(({ theme }: { theme: Theme }) => ({
   paddingLeft: "16px",
   margin: "0px",
+  wordBreak: "break-all",
+  textWrap: "wrap",
   ".MuiTypography-root": {
     color: alpha(theme.palette.secondary[900], 0.9),
     fontSize: "14px",

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -31,7 +31,10 @@ import type { WizardStepProps } from "./step";
 interface WizardProps
   extends Pick<ContainerProps, "width" | "className">,
     Pick<MuiStepperProps, "orientation"> {
-  children: React.ReactElement<WizardStepProps> | React.ReactElement<WizardStepProps>[];
+  children:
+    | React.ReactNode
+    | React.ReactElement<WizardStepProps>
+    | React.ReactElement<WizardStepProps>[];
   dataLayout: ManagerLayout;
   heading?: string | React.ReactElement;
 }


### PR DESCRIPTION
### Description
- Fixes an issue where long user names would break out of container
- Extends properties of the Wizard component to allow for showing/hiding the NPS feedback, the start over button and copy text and saving the search params on back

### Testing Performed
manual
