### PR TITLE
frontend: Adjusting QuickLinks wrapper to utilize a key to stop errors

### DIFF
--- a/frontend/packages/core/src/quick-links.tsx
+++ b/frontend/packages/core/src/quick-links.tsx
@@ -184,9 +184,10 @@ const SlicedLinkGroup = ({ slicedLinkGroups }: SlicedLinkGroupProps) => {
     <>
       {(slicedLinkGroups || []).map(linkGroup => {
         return (
-          <QuickLinkWrapper linkGroup={linkGroup}>
+          <QuickLinkWrapper linkGroup={linkGroup} key={linkGroup.name}>
             {linkGroup.links?.length === 1 ? (
               <QuickLink
+                key={`quicklink-${linkGroup.name}`}
                 link={linkGroup.links[0]}
                 linkGroupName={linkGroup.name ?? ""}
                 linkGroupImage={linkGroup.imagePath ?? ""}


### PR DESCRIPTION
### Description
Console log was throwing errors about missing a key for the wrapper, adjusting this.

### Testing Performed
manual
