### PR TITLE
frontend: Fixing feature flags and workflow routes

### DIFF
--- a/frontend/packages/core/src/AppProvider/registrar.tsx
+++ b/frontend/packages/core/src/AppProvider/registrar.tsx
@@ -65,6 +65,7 @@ const registeredWorkflows = async (
   configuration: UserConfiguration,
   filters: { (workflows: Workflow[]): Promise<Workflow[]> }[] = []
 ): Promise<Workflow[]> => {
+  // eslint-disable-next-line no-async-promise-executor
   return new Promise(async resolve => {
     let validWorkflows = Object.keys(workflows || [])
       .map((workflowId: string) => {
@@ -87,7 +88,13 @@ const registeredWorkflows = async (
       })
       .filter(workflow => workflow !== null);
     try {
-      await Promise.all(filters.map(f => f(validWorkflows).then(w => (validWorkflows = w))));
+      await Promise.all(
+        filters.map(f =>
+          f(validWorkflows).then(w => {
+            validWorkflows = w;
+          })
+        )
+      );
     } catch (e) {
       /* eslint-disable-next-line no-console */
       console.warn("Error applying filters to workflows", e);

--- a/frontend/packages/core/src/AppProvider/registrar.tsx
+++ b/frontend/packages/core/src/AppProvider/registrar.tsx
@@ -65,32 +65,35 @@ const registeredWorkflows = async (
   configuration: UserConfiguration,
   filters: { (workflows: Workflow[]): Promise<Workflow[]> }[] = []
 ): Promise<Workflow[]> => {
-  let validWorkflows = Object.keys(workflows || [])
-    .map((workflowId: string) => {
-      const workflow = workflows[workflowId]();
-      const icon = configuration?.[workflowId]?.icon || { path: "" };
-      try {
-        return {
-          ...workflow,
-          icon,
-          routes: workflowRoutes(workflowId, workflow, configuration),
-        };
-      } catch {
-        // n.b. if the routes aren't configured properly we drop the workflow
-        /* eslint-disable-next-line no-console */
-        console.warn(
-          `Skipping registration of ${workflowId || "unknown"} workflow due to invalid config`
-        );
-        return null;
-      }
-    })
-    .filter(workflow => workflow !== null);
-  filters.forEach(f => {
-    f(validWorkflows).then(w => {
-      validWorkflows = w;
-    });
+  return new Promise(async resolve => {
+    let validWorkflows = Object.keys(workflows || [])
+      .map((workflowId: string) => {
+        const workflow = workflows[workflowId]();
+        const icon = configuration?.[workflowId]?.icon || { path: "" };
+        try {
+          return {
+            ...workflow,
+            icon,
+            routes: workflowRoutes(workflowId, workflow, configuration),
+          };
+        } catch {
+          // n.b. if the routes aren't configured properly we drop the workflow
+          /* eslint-disable-next-line no-console */
+          console.warn(
+            `Skipping registration of ${workflowId || "unknown"} workflow due to invalid config`
+          );
+          return null;
+        }
+      })
+      .filter(workflow => workflow !== null);
+    try {
+      await Promise.all(filters.map(f => f(validWorkflows).then(w => (validWorkflows = w))));
+    } catch (e) {
+      /* eslint-disable-next-line no-console */
+      console.warn("Error applying filters to workflows", e);
+    }
+    resolve(validWorkflows);
   });
-  return validWorkflows;
 };
 
 export { registeredWorkflows, workflowRoutes };


### PR DESCRIPTION
### Description
Found that if a user were to directly navigate to a route that is gated by a feature flag, there was a race condition on the first load. This was due to the loadWorkflows function expecting a promise but everything was just synchronous so it wasn't waiting correctly. This returns a promise and waits appropriately.

### Testing Performed
manual
