### PR TITLE
frontend: Project Catalog - Allowing disabled projects to be found and returned

### DIFF
--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -63,6 +63,7 @@ export { useTheme } from "./AppProvider/themes";
 
 export { css as EMOTION_CSS, keyframes as EMOTION_KEYFRAMES } from "@emotion/react";
 
+export type { QLink as QuickLink, LinkGroup as QuickLinkGroup } from "./quick-links";
 export type { BaseWorkflowProps, WorkflowConfiguration } from "./AppProvider/workflow";
 export type { ButtonProps } from "./button";
 export type { CardHeaderSummaryProps } from "./card";

--- a/frontend/packages/core/src/quick-links.tsx
+++ b/frontend/packages/core/src/quick-links.tsx
@@ -58,7 +58,7 @@ interface LinkGroupProps {
   linkGroupImage: string;
 }
 
-interface QLink extends IClutch.core.project.v1.ILink {
+export interface QLink extends IClutch.core.project.v1.ILink {
   trackingId?: string;
   icon?: React.ElementType;
 }
@@ -161,7 +161,7 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
   );
 };
 
-interface LinkGroup extends IClutch.core.project.v1.ILinkGroup {
+export interface LinkGroup extends IClutch.core.project.v1.ILinkGroup {
   links?: QLink[];
   badge?: {
     color: BadgeProps["color"];

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -58,7 +58,7 @@ const autoComplete = async (search: string): Promise<any> => {
 
 const Form = styled.form({});
 
-const Catalog: React.FC<WorkflowProps> = () => {
+const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
   const theme = useTheme();
   const navigate = useNavigate();
   const [state, dispatch] = React.useReducer(catalogReducer, initialState);
@@ -74,7 +74,8 @@ const Catalog: React.FC<WorkflowProps> = () => {
     getProjects(
       projects => dispatch({ type: "HYDRATE_END", payload: { result: projects } }),
       setError,
-      !hasState()
+      !hasState(),
+      allowDisabled
     );
   }, []);
 
@@ -96,7 +97,8 @@ const Catalog: React.FC<WorkflowProps> = () => {
       e => {
         dispatch({ type: "SEARCH_END" });
         setError(e);
-      }
+      },
+      allowDisabled
     );
   };
 
@@ -104,7 +106,8 @@ const Catalog: React.FC<WorkflowProps> = () => {
     removeProject(
       project.name,
       projects => dispatch({ type: "REMOVE_PROJECT", payload: { projects } }),
-      setError
+      setError,
+      allowDisabled
     );
   };
 
@@ -122,7 +125,7 @@ const Catalog: React.FC<WorkflowProps> = () => {
     <Box style={{ padding: "32px" }}>
       <div style={{ marginBottom: "8px" }}>
         <Typography variant="caption2" color={alpha(theme.palette.secondary[900], 0.48)}>
-          Project Catalog&nbsp;/&nbsp;Index
+          Project Catalog
         </Typography>
       </div>
       <div style={{ marginBottom: "32px" }}>
@@ -167,7 +170,8 @@ const Catalog: React.FC<WorkflowProps> = () => {
               getProjects(
                 projects => dispatch({ type: "HYDRATE_END", payload: { result: projects } }),
                 setError,
-                true
+                true,
+                allowDisabled
               );
             }}
           >

--- a/frontend/workflows/projectCatalog/src/config/index.tsx
+++ b/frontend/workflows/projectCatalog/src/config/index.tsx
@@ -101,7 +101,7 @@ const Config: React.FC<ProjectDetailsConfigWorkflowProps> = ({ children, default
           <ProjectHeader
             title={`${projectInfo?.name ?? projectId} Configuration`}
             routes={[
-              { title: "Details", path: `${projectId}` },
+              { title: projectId, path: `${projectId}` },
               { title: "Configuration" },
               { title: configType || defaultRoute },
             ]}

--- a/frontend/workflows/projectCatalog/src/details/helpers.tsx
+++ b/frontend/workflows/projectCatalog/src/details/helpers.tsx
@@ -22,12 +22,16 @@ const fetchProjectInfo = (
 
       if (_.isEmpty(projectResults) && allowDisabled && partialFailures) {
         // Will add disabled projects to the list of projects to display if requested
-        let failuresMap = partialFailures
+        const failuresMap = partialFailures
           .map(p => {
             if ((_.get(p, "message", "") ?? "").includes("disabled")) {
-              const project = _.get(p, "details.[0]");
-              _.set(project, ["data", "description"], `${project.name} is disabled.`);
-              return project;
+              const disabledProject = _.get(p, "details.[0]");
+              _.set(
+                disabledProject,
+                ["data", "description"],
+                `${disabledProject.name} is disabled.`
+              );
+              return disabledProject;
             }
             return null;
           })

--- a/frontend/workflows/projectCatalog/src/details/helpers.tsx
+++ b/frontend/workflows/projectCatalog/src/details/helpers.tsx
@@ -3,18 +3,42 @@ import type { clutch as IClutch } from "@clutch-sh/api";
 import { client, Grid, Link, styled, TimeAgo as EventTime, Typography } from "@clutch-sh/core";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import * as _ from "lodash";
 
 const StyledLink = styled(Link)({
   whiteSpace: "nowrap",
 });
 
-const fetchProjectInfo = (project: string): Promise<IClutch.core.project.v1.IProject> =>
+const fetchProjectInfo = (
+  project: string,
+  allowDisabled: boolean = false
+): Promise<IClutch.core.project.v1.IProject> =>
   client
     .post("/v1/project/getProjects", { projects: [project], excludeDependencies: true })
     .then(resp => {
-      const { results = {} } = resp.data as IClutch.project.v1.GetProjectsResponse;
+      const { results = {}, partialFailures } = resp.data as IClutch.project.v1.GetProjectsResponse;
 
-      return results[project] ? results[project].project ?? {} : {};
+      const projectResults = _.get(results, [project, "project"], {});
+
+      if (_.isEmpty(projectResults) && allowDisabled && partialFailures) {
+        // Will add disabled projects to the list of projects to display if requested
+        let failuresMap = partialFailures
+          .map(p => {
+            if ((_.get(p, "message", "") ?? "").includes("disabled")) {
+              const project = _.get(p, "details.[0]");
+              _.set(project, ["data", "description"], `${project.name} is disabled.`);
+              return project;
+            }
+            return null;
+          })
+          .filter(Boolean);
+
+        if (failuresMap.length) {
+          return failuresMap[0];
+        }
+      }
+
+      return projectResults;
     });
 
 const LinkText = ({ text, link }: { text: string; link?: string }) => {

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -109,7 +109,7 @@ const QuickLinksAndSettingsBtn = ({ linkGroups, configLinks = [] }: QuickLinksAn
           >
             {links.map(link => (
               <StyledPopperItem key={link.title}>
-                <Link href={link.path}>
+                <Link href={link.path} target="_self">
                   <Grid container gap={0.5}>
                     {link.icon && <Grid item>{link.icon}</Grid>}
                     <Grid item>

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -14,10 +14,10 @@ import {
   Tooltip,
   Typography,
 } from "@clutch-sh/core";
+import CodeOffIcon from "@mui/icons-material/CodeOff";
 import GroupIcon from "@mui/icons-material/Group";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { capitalize, isEmpty } from "lodash";
-import CodeOffIcon from "@mui/icons-material/CodeOff";
 
 import type { CatalogDetailsChild, ProjectConfigLink, ProjectDetailsWorkflowProps } from "..";
 

--- a/frontend/workflows/projectCatalog/src/details/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/index.tsx
@@ -1,28 +1,36 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import {
-  FeatureOn,
+  checkFeatureEnabled,
   Grid,
   IconButton,
+  Link,
+  Popper,
+  PopperItem,
+  QuickLinkGroup,
   QuickLinksCard,
-  SimpleFeatureFlag,
   styled,
   Tooltip,
+  Typography,
 } from "@clutch-sh/core";
-import { faLock } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import GroupIcon from "@mui/icons-material/Group";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { capitalize, isEmpty } from "lodash";
+import CodeOffIcon from "@mui/icons-material/CodeOff";
 
-import type { CatalogDetailsChild, ProjectDetailsWorkflowProps } from "..";
+import type { CatalogDetailsChild, ProjectConfigLink, ProjectDetailsWorkflowProps } from "..";
 
 import { CardType, DynamicCard, MetaCard } from "./card";
 import { ProjectDetailsContext } from "./context";
 import ProjectHeader from "./header";
 import { fetchProjectInfo } from "./helpers";
 import ProjectInfoCard from "./info";
+
+interface QuickLinksAndSettingsProps {
+  linkGroups: QuickLinkGroup[];
+  configLinks?: ProjectConfigLink[];
+}
 
 const StyledContainer = styled(Grid)({
   padding: "16px",
@@ -32,16 +40,45 @@ const StyledHeadingContainer = styled(Grid)({
   marginBottom: "24px",
 });
 
+const StyledPopperItem = styled(PopperItem)({
+  "&&&": {
+    height: "auto",
+  },
+  "& span.MuiTypography-root": {
+    padding: "0",
+  },
+  "& a.MuiTypography-root": {
+    padding: "4px 16px",
+  },
+});
+
 const DisabledItem = ({ name }: { name: string }) => (
   <Grid item>
     <Tooltip title={`${capitalize(name)} is disabled`}>
-      <FontAwesomeIcon icon={faLock} size="lg" />
+      <CodeOffIcon />
     </Tooltip>
   </Grid>
 );
 
-const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
-  const navigate = useNavigate();
+const QuickLinksAndSettingsBtn = ({ linkGroups, configLinks = [] }: QuickLinksAndSettingsProps) => {
+  const { projectId } = useParams();
+  const anchorRef = React.useRef(null);
+  const [open, setOpen] = React.useState(false);
+  const [links, setLinks] = React.useState<ProjectConfigLink[]>(configLinks);
+
+  React.useEffect(() => {
+    const projectConfigFlag = checkFeatureEnabled({ feature: "projectCatalogSettings" });
+    if (projectConfigFlag) {
+      setLinks([
+        {
+          title: "Project Configuration",
+          path: `/catalog/${projectId}/config`,
+          icon: <SettingsIcon fontSize="small" />,
+        },
+        ...links,
+      ]);
+    }
+  }, []);
 
   return (
     <Grid
@@ -59,20 +96,44 @@ const QuickLinksAndSettingsBtn = ({ linkGroups }) => {
           <QuickLinksCard linkGroups={linkGroups} />
         </Grid>
       )}
-      <SimpleFeatureFlag feature="projectCatalogSettings">
-        <FeatureOn>
-          <Grid item>
-            <IconButton onClick={() => navigate("config")} size="medium">
-              <SettingsIcon />
-            </IconButton>
-          </Grid>
-        </FeatureOn>
-      </SimpleFeatureFlag>
+      {links && links.length > 0 && (
+        <Grid item>
+          <IconButton ref={anchorRef} onClick={() => setOpen(o => !o)} size="medium">
+            <SettingsIcon />
+          </IconButton>
+          <Popper
+            open={open}
+            anchorRef={anchorRef}
+            onClickAway={() => setOpen(false)}
+            placement="bottom-end"
+          >
+            {links.map(link => (
+              <StyledPopperItem key={link.title}>
+                <Link href={link.path}>
+                  <Grid container gap={0.5}>
+                    {link.icon && <Grid item>{link.icon}</Grid>}
+                    <Grid item>
+                      <Typography variant="body2" color="inherit">
+                        {link.title}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                </Link>
+              </StyledPopperItem>
+            ))}
+          </Popper>
+        </Grid>
+      )}
     </Grid>
   );
 };
 
-const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => {
+const Details: React.FC<ProjectDetailsWorkflowProps> = ({
+  children,
+  chips,
+  allowDisabled,
+  configLinks = [],
+}) => {
   const { projectId } = useParams();
   const [projectInfo, setProjectInfo] = React.useState<IClutch.core.project.v1.IProject | null>(
     null
@@ -141,13 +202,16 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
               {/* Static Header */}
               <ProjectHeader
                 title={projectId}
-                routes={[{ title: "Details" }]}
+                routes={[{ title: projectId }]}
                 description={projectInfo?.data?.description as string}
               />
             </StyledHeadingContainer>
             {projectInfo && (
               <Grid container item xs={12} sm={12} md={5} lg={4} xl={3} spacing={2}>
-                <QuickLinksAndSettingsBtn linkGroups={projectInfo.linkGroups || []} />
+                <QuickLinksAndSettingsBtn
+                  linkGroups={(projectInfo.linkGroups as QuickLinkGroup[]) || []}
+                  configLinks={configLinks ?? []}
+                />
               </Grid>
             )}
           </Grid>
@@ -158,7 +222,7 @@ const Details: React.FC<ProjectDetailsWorkflowProps> = ({ children, chips }) => 
                 <MetaCard
                   title={getOwner(projectInfo?.owners ?? []) || projectId}
                   titleIcon={<GroupIcon />}
-                  fetchDataFn={() => fetchProjectInfo(projectId)}
+                  fetchDataFn={() => fetchProjectInfo(projectId, allowDisabled)}
                   onSuccess={(data: unknown) =>
                     setProjectInfo(data as IClutch.core.project.v1.IProject)
                   }

--- a/frontend/workflows/projectCatalog/src/details/info/messengerRow.tsx
+++ b/frontend/workflows/projectCatalog/src/details/info/messengerRow.tsx
@@ -29,14 +29,14 @@ const MessengerRow = ({ projectData }: { projectData: IClutch.core.project.v1.IP
     }
   }, [projectData]);
 
-  return (
+  return link ? (
     <Grid container item spacing={1}>
       <Grid item>
         <FontAwesomeIcon icon={icon} size="lg" />
       </Grid>
       <Grid item>{text && <LinkText text={text} link={link} />}</Grid>
     </Grid>
-  );
+  ) : null;
 };
 
 export default MessengerRow;

--- a/frontend/workflows/projectCatalog/src/index.tsx
+++ b/frontend/workflows/projectCatalog/src/index.tsx
@@ -9,6 +9,16 @@ import Details from "./details";
 
 type DetailCard = CatalogDetailsCard | typeof DynamicCard | typeof MetaCard;
 
+interface ProjectCatalogProps {
+  allowDisabled?: boolean;
+}
+
+export interface ProjectConfigLink {
+  title: string;
+  path: string;
+  icon?: React.ReactElement;
+}
+
 export interface ProjectConfigProps {
   title: string;
   path: string;
@@ -19,14 +29,15 @@ type CatalogDetailsChild = React.ReactElement<DetailCard>;
 
 export type ProjectConfigPage = React.ReactElement<ProjectConfigProps>;
 
-export interface WorkflowProps extends BaseWorkflowProps {}
+export interface WorkflowProps extends BaseWorkflowProps, ProjectCatalogProps {}
 
-export interface ProjectDetailsWorkflowProps extends WorkflowProps {
+export interface ProjectDetailsWorkflowProps extends WorkflowProps, ProjectCatalogProps {
   children?: CatalogDetailsChild | CatalogDetailsChild[];
   chips?: ProjectInfoChip[];
+  configLinks?: ProjectConfigLink[];
 }
 
-export interface ProjectDetailsConfigWorkflowProps extends WorkflowProps {
+export interface ProjectDetailsConfigWorkflowProps extends WorkflowProps, ProjectCatalogProps {
   children?: ProjectConfigPage | ProjectConfigPage[];
   defaultRoute?: string;
 }


### PR DESCRIPTION
### Description
- Adjusts the projectCatalog to accept an additional componentProp in its configuration of `allowDisabled`. This will be propagated to the API requests and allow the system to accept and return disabled projects so that they can be navigated to.
- Modifies the settings button to accept additional links and renders a popper to show them
- Adjusts the breadcrumbs to reference the project now

### Screenshots
#### Breadcrumbs
<img width="200" alt="Screenshot 2024-04-17 at 12 05 51 PM" src="https://github.com/lyft/clutch/assets/8338893/f3b0e3ab-b126-4e12-9f17-f43b0bb589e7">
<img width="219" alt="Screenshot 2024-04-17 at 12 05 47 PM" src="https://github.com/lyft/clutch/assets/8338893/d70d8677-813a-4cb9-bc51-409e9cfcd2eb">

#### Catalog Settings Button
<img width="267" alt="Screenshot 2024-04-17 at 12 05 41 PM" src="https://github.com/lyft/clutch/assets/8338893/1cfe2f00-b692-4685-88e7-3ee6cabad6f2">

### Testing Performed
manual
