### PR TITLE
housekeeping: Adding no-immutable flag for scaffolding since it's failing in CI

### DIFF
--- a/tools/scaffolding/templates/gateway/Makefile
+++ b/tools/scaffolding/templates/gateway/Makefile
@@ -43,7 +43,7 @@ yarn-install: yarn-ensure
 ifneq ("$(wildcard frontend/yarn.lock)","")
 	$(YARN) --cwd frontend install --immutable
 else
-	$(YARN) --cwd frontend install
+	$(YARN) --cwd frontend install --no-immutable
 endif 
 
 .PHONY: yarn-ensure


### PR DESCRIPTION
### Description
Yarn will fail `yarn install` if it would update/create a lock file in CI. Adjusting to pass no-immutable for the makefile, which makes sense if there isn't a lock file already anyhow.
