### PR TITLE
DateTimePicker - trigger onChange method when value is empty

### DIFF
--- a/frontend/packages/core/src/Input/date-time.tsx
+++ b/frontend/packages/core/src/Input/date-time.tsx
@@ -20,7 +20,7 @@ const PaddedTextField = styled(TextField)({
 
 export interface DateTimePickerProps
   extends Pick<MuiDateTimePickerProps<Date, Date>, "disabled" | "value" | "onChange" | "label"> {
-  allowEmpty: boolean;
+  allowEmpty?: boolean;
 }
 
 const DateTimePicker = ({ onChange, allowEmpty = false, ...props }: DateTimePickerProps) => (

--- a/frontend/packages/core/src/Input/date-time.tsx
+++ b/frontend/packages/core/src/Input/date-time.tsx
@@ -26,8 +26,9 @@ const DateTimePicker = ({ onChange, ...props }: DateTimePickerProps) => (
     <MuiDateTimePicker
       renderInput={inputProps => <PaddedTextField {...inputProps} />}
       onChange={(value: Dayjs | null) => {
-        if (value && value.isValid()) {
-          onChange(value.toDate());
+        if (!value || value.isValid()) {
+          const dateValue = value ? value.toDate() : null;
+          onChange(dateValue);
         }
       }}
       {...props}

--- a/frontend/packages/core/src/Input/date-time.tsx
+++ b/frontend/packages/core/src/Input/date-time.tsx
@@ -19,16 +19,22 @@ const PaddedTextField = styled(TextField)({
 });
 
 export interface DateTimePickerProps
-  extends Pick<MuiDateTimePickerProps<Date, Date>, "disabled" | "value" | "onChange" | "label"> {}
+  extends Pick<MuiDateTimePickerProps<Date, Date>, "disabled" | "value" | "onChange" | "label"> {
+  allowEmpty: boolean;
+}
 
-const DateTimePicker = ({ onChange, ...props }: DateTimePickerProps) => (
+const DateTimePicker = ({ onChange, allowEmpty = false, ...props }: DateTimePickerProps) => (
   <LocalizationProvider dateAdapter={AdapterDayjs}>
     <MuiDateTimePicker
       renderInput={inputProps => <PaddedTextField {...inputProps} />}
       onChange={(value: Dayjs | null) => {
-        if (!value || value.isValid()) {
+        if (!allowEmpty && value && value.isValid()) {
           const dateValue = value ? value.toDate() : null;
           onChange(dateValue);
+        }
+
+        if (allowEmpty && !value) {
+          onChange(null);
         }
       }}
       {...props}

--- a/frontend/packages/core/src/Input/tests/date-time.test.tsx
+++ b/frontend/packages/core/src/Input/tests/date-time.test.tsx
@@ -38,6 +38,20 @@ test("onChange is called when valid value", () => {
   expect(onChange).toHaveBeenCalled();
 });
 
+test("onChange is called when value is empty", () => {
+  render(
+    <ThemeProvider>
+      <DateTimePicker value={new Date()} onChange={onChange} />
+    </ThemeProvider>
+  );
+
+  expect(screen.getByPlaceholderText("mm/dd/yyyy hh:mm (a|p)m")).toBeVisible();
+  fireEvent.change(screen.getByPlaceholderText("mm/dd/yyyy hh:mm (a|p)m"), {
+    target: { value: "" },
+  });
+  expect(onChange).toHaveBeenCalled();
+});
+
 test("onChange is not called when invalid value", () => {
   render(
     <ThemeProvider>

--- a/frontend/packages/core/src/Input/tests/date-time.test.tsx
+++ b/frontend/packages/core/src/Input/tests/date-time.test.tsx
@@ -41,7 +41,7 @@ test("onChange is called when valid value", () => {
 test("onChange is called when value is empty", () => {
   render(
     <ThemeProvider>
-      <DateTimePicker value={new Date()} onChange={onChange} />
+      <DateTimePicker value={new Date()} onChange={onChange} allowEmpty />
     </ThemeProvider>
   );
 
@@ -62,6 +62,20 @@ test("onChange is not called when invalid value", () => {
   expect(screen.getByPlaceholderText("mm/dd/yyyy hh:mm (a|p)m")).toBeVisible();
   fireEvent.change(screen.getByPlaceholderText("mm/dd/yyyy hh:mm (a|p)m"), {
     target: { value: "invalid" },
+  });
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test("onChange is not called when value is empty and empty flag is false", () => {
+  render(
+    <ThemeProvider>
+      <DateTimePicker value={new Date()} onChange={onChange} allowEmpty={false} />
+    </ThemeProvider>
+  );
+
+  expect(screen.getByPlaceholderText("mm/dd/yyyy hh:mm (a|p)m")).toBeVisible();
+  fireEvent.change(screen.getByPlaceholderText("mm/dd/yyyy hh:mm (a|p)m"), {
+    target: { value: "" },
   });
   expect(onChange).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
Scope: Update onChange trigger validation to allow trigger when the value of the DateTimePicker is empty