### PR TITLE
backend: Extending GitHub service to have the ability to get files based on a path

### DIFF
--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -25,6 +25,10 @@ func (s svc) GetFile(ctx context.Context, ref *github.RemoteRef, path string) (*
 	panic("implement me")
 }
 
+func (s svc) GetFilePath(ctx context.Context, ref *github.RemoteRef, path string) (*github.FilePath, error) {
+	panic("implement me")
+}
+
 func (s svc) CreateBranch(ctx context.Context, req *github.CreateBranchRequest) error {
 	panic("implement me")
 }

--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -25,7 +25,7 @@ func (s svc) GetFile(ctx context.Context, ref *github.RemoteRef, path string) (*
 	panic("implement me")
 }
 
-func (s svc) GetFilePath(ctx context.Context, ref *github.RemoteRef, path string) (*github.FilePath, error) {
+func (s svc) GetDirectory(ctx context.Context, ref *github.RemoteRef, path string) (*github.Directory, error) {
 	panic("implement me")
 }
 

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -96,7 +96,7 @@ type File struct {
 	LastModifiedSHA  string
 }
 
-type DirectoryEntry struct {
+type Entry struct {
 	Name string
 	Type string
 }
@@ -105,7 +105,7 @@ type Directory struct {
 	Path             string
 	LastModifiedTime time.Time
 	LastModifiedSHA  string
-	Files            []*DirectoryEntry
+	Entries          []*Entry
 }
 
 // Client allows various interactions with remote repositories on GitHub.
@@ -505,9 +505,9 @@ func (s *svc) GetDirectory(ctx context.Context, ref *RemoteRef, path string) (*D
 		return nil, errors.New("directory not found")
 	}
 
-	var entries []*DirectoryEntry
+	var entries []*Entry
 	for _, obj := range q.Repository.Object.Tree.Entries {
-		entries = append(entries, &DirectoryEntry{
+		entries = append(entries, &Entry{
 			Name: string(obj.Name),
 			Type: string(obj.Type),
 		})
@@ -515,7 +515,7 @@ func (s *svc) GetDirectory(ctx context.Context, ref *RemoteRef, path string) (*D
 
 	d := &Directory{
 		Path:             path,
-		Files:            entries,
+		Entries:          entries,
 		LastModifiedTime: q.Repository.Ref.Commit.History.Nodes[0].CommittedDate.Time,
 		LastModifiedSHA:  string(q.Repository.Ref.Commit.History.Nodes[0].OID),
 	}

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -48,7 +48,7 @@ type getdirectoryMock struct {
 
 	queryError   bool
 	refID, objID string
-	entries      []*DirectoryEntry
+	entries      []*Entry
 }
 
 func (g *getfileMock) Query(ctx context.Context, query interface{}, variables map[string]interface{}) error {
@@ -277,7 +277,7 @@ func TestGetFile(t *testing.T) {
 	}
 }
 
-var directoryEntries = []*DirectoryEntry{{Name: "foo", Type: "blob"}}
+var directoryEntries = []*Entry{{Name: "foo", Type: "blob"}}
 
 var getDirectoryTests = []struct {
 	name    string
@@ -333,7 +333,7 @@ func TestGetDirectory(t *testing.T) {
 			}
 
 			a.Equal("data/foo", f.Path)
-			a.Equal(directoryEntries, f.Files)
+			a.Equal(directoryEntries, f.Entries)
 			a.Equal("otherSHA", f.LastModifiedSHA)
 			a.Equal(timestamp, f.LastModifiedTime)
 		})

--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -43,6 +43,14 @@ type getfileMock struct {
 	truncated, binary bool
 }
 
+type getfilepathMock struct {
+	v4client
+
+	queryError   bool
+	refID, objID string
+	entries      []*FileEntry
+}
+
 func (g *getfileMock) Query(ctx context.Context, query interface{}, variables map[string]interface{}) error {
 	q, ok := query.(*getFileQuery)
 	if !ok {
@@ -73,6 +81,40 @@ func (g *getfileMock) Query(ctx context.Context, query interface{}, variables ma
 			OID           githubv4.GitObjectID
 		}{githubv4.DateTime{Time: timestamp}, "otherSHA"},
 	)
+	return nil
+}
+
+func (g *getfilepathMock) Query(ctx context.Context, query interface{}, variables map[string]interface{}) error {
+	q, ok := query.(*getFilePathQuery)
+	if !ok {
+		panic("not a query")
+	}
+
+	if g.queryError {
+		return errors.New(problem)
+	}
+
+	if g.refID != "" {
+		q.Repository.Ref.Commit.ID = g.refID
+		q.Repository.Ref.Commit.OID = githubv4.GitObjectID(g.refID)
+	}
+	if g.objID != "" {
+		q.Repository.Object.Tree.Entries = append(
+			q.Repository.Object.Tree.Entries,
+			struct {
+				Name githubv4.String
+				Type githubv4.String
+			}{Name: githubv4.String(g.entries[0].Name), Type: githubv4.String(g.entries[0].Type)})
+	}
+
+	q.Repository.Ref.Commit.History.Nodes = append(
+		q.Repository.Ref.Commit.History.Nodes,
+		struct {
+			CommittedDate githubv4.DateTime
+			OID           githubv4.GitObjectID
+		}{githubv4.DateTime{Time: timestamp}, "otherSHA"},
+	)
+
 	return nil
 }
 
@@ -229,6 +271,69 @@ func TestGetFile(t *testing.T) {
 			a.Equal("text", string(contents))
 			a.Equal("data/foo", f.Path)
 			a.Equal("abcdef12345", f.SHA)
+			a.Equal("otherSHA", f.LastModifiedSHA)
+			a.Equal(timestamp, f.LastModifiedTime)
+		})
+	}
+}
+
+var filePathEntries = []*FileEntry{{Name: "foo", Type: "blob"}}
+
+var getFilePathTests = []struct {
+	name    string
+	v4      getfilepathMock
+	errText string
+}{
+	{
+		name:    "queryError",
+		v4:      getfilepathMock{queryError: true},
+		errText: problem,
+	},
+	{
+		name:    "noRef",
+		v4:      getfilepathMock{},
+		errText: "ref not found",
+	},
+	{
+		name:    "noObject",
+		v4:      getfilepathMock{refID: "abcdef12345"},
+		errText: "path not found",
+	},
+	{
+		name: "happyPath",
+		v4:   getfilepathMock{refID: "abcdef12345", objID: "abcdef12345", entries: filePathEntries},
+	},
+}
+
+func TestGetFilePath(t *testing.T) {
+	for _, tt := range getFilePathTests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := assert.New(t)
+
+			s := &svc{graphQL: &tt.v4}
+			f, err := s.GetFilePath(context.Background(),
+				&RemoteRef{
+					RepoOwner: "owner",
+					RepoName:  "myRepo",
+					Ref:       "master",
+				},
+				"data/foo",
+			)
+
+			if tt.errText != "" {
+				a.Error(err)
+				a.Contains(err.Error(), tt.errText)
+				return
+			}
+			if err != nil {
+				a.FailNow("unexpected error")
+				return
+			}
+
+			a.Equal("data/foo", f.Path)
+			a.Equal(filePathEntries, filePathEntries)
 			a.Equal("otherSHA", f.LastModifiedSHA)
 			a.Equal(timestamp, f.LastModifiedTime)
 		})

--- a/backend/service/github/graphql.go
+++ b/backend/service/github/graphql.go
@@ -37,6 +37,34 @@ type getFileQuery struct {
 	} `graphql:"repository(owner:$owner,name:$name)"`
 }
 
+type getFilePathQuery struct {
+	Repository struct {
+		// Get more information about desired ref and last modified ref for the file.
+		Ref struct {
+			Commit struct {
+				ID      githubv4.ID
+				OID     githubv4.GitObjectID
+				History struct {
+					Nodes []struct {
+						CommittedDate githubv4.DateTime
+						OID           githubv4.GitObjectID
+					}
+				} `graphql:"history(path:$path,first:1)"`
+			} `graphql:"... on Commit"`
+		} `graphql:"ref: object(expression:$ref)"`
+
+		// Fetch requested tree and its entries.
+		Object struct {
+			Tree struct {
+				Entries []struct {
+					Name githubv4.String
+					Type githubv4.String
+				} `graphql:"entries"`
+			} `graphql:"... on Tree"`
+		} `graphql:"object(expression:$refPath)"`
+	} `graphql:"repository(owner:$owner,name:$name)"`
+}
+
 type getRepositoryQuery struct {
 	Repository struct {
 		DefaultBranchRef struct {

--- a/backend/service/github/graphql.go
+++ b/backend/service/github/graphql.go
@@ -37,7 +37,7 @@ type getFileQuery struct {
 	} `graphql:"repository(owner:$owner,name:$name)"`
 }
 
-type getFilePathQuery struct {
+type getDirectoryQuery struct {
 	Repository struct {
 		// Get more information about desired ref and last modified ref for the file.
 		Ref struct {


### PR DESCRIPTION
### Description
Currently the GitHub client has the ability to get a file at a specific path but if we need to fetch the contents of a directory we were out of luck, this addresses that and allows us to navigate around based on paths.

#### Test Query against `clutch/frontend`
```
HTTP/1.1 200 OK
Content-Type: application/json
Grpc-Metadata-Content-Type: application/grpc
Grpc-Metadata-Trailer: Grpc-Status
Grpc-Metadata-Trailer: Grpc-Message
Grpc-Metadata-Trailer: Grpc-Status-Details-Bin
Date: Wed, 15 May 2024 20:11:29 GMT
Content-Length: 653

{
  "path": "frontend",
  "lastModifiedTime": "2024-05-15 18:34:45 +0000 UTC",
  "lastModifiedSha": "3bc4eb7da42ee2adc089bc9db2441233503b9c9e",
  "entries": [
    { "name": ".gitignore", "type": "blob" },
    { "name": ".nvmrc", "type": "blob" },
    { "name": ".storybook", "type": "tree" },
    { "name": ".yarnrc.yml", "type": "blob" },
    { "name": "api", "type": "tree" },
    { "name": "license-linter.js", "type": "blob" },
    { "name": "netlify", "type": "tree" },
    { "name": "package.json", "type": "blob" },
    { "name": "packages", "type": "tree" },
    { "name": "tsconfig.base.json", "type": "blob" },
    { "name": "tsconfig.json", "type": "blob" },
    { "name": "workflows", "type": "tree" },
    { "name": "yarn.config.cjs", "type": "blob" },
    { "name": "yarn.lock", "type": "blob" }
  ]
}

```

### Testing Performed
local