### PR TITLE
frontend: Fixing protobufjs Improperly Controlled Modification of Object Prototype Pollution

### DIFF
--- a/tools/scaffolding/templates/gateway/frontend/package.json
+++ b/tools/scaffolding/templates/gateway/frontend/package.json
@@ -18,7 +18,7 @@
     "upgrade": "yarn upgrade"
   },
   "dependencies": {
-    "protobufjs": "6.11.3"
+    "protobufjs": "6.11.4"
   },
   "devDependencies": {
     "@clutch-sh/ec2": "^4.0.0-beta",


### PR DESCRIPTION
A user-controlled protobuf message can be used by an attacker to pollute the prototype of Object.prototype by adding and overwriting its data and functions. Exploitation can involve: (1) using the function parse to parse protobuf messages on the fly, (2) loading .proto files by using load/loadSync functions, or (3) providing untrusted input to the functions ReflectionObject.setParsedOption and util.setProperty. 

### GitHub Issue
#3013
