### PR TITLE
housekeeping: Updating pre-commit to ignore deleted files

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -2,7 +2,7 @@
 
 ROOT_DIR=$(pwd)
 FRONTEND_DIR="${ROOT_DIR}/frontend"
-BASE_GIT_DIFF_CMD="git diff --name-only --staged --relative=frontend"
+BASE_GIT_DIFF_CMD="git diff --name-only --staged --diff-filter=d --relative=frontend"
 
 if [[ $(${BASE_GIT_DIFF_CMD} -- frontend) ]]; then
   echo "Running frontend checks in ${FRONTEND_DIR}..."

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,6 +91,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
+    "eslint": "^8.3.0",
     "jest": "^27.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -106,6 +107,7 @@
     "@storybook/preset-typescript": "^3.0.0",
     "@storybook/react-webpack5": "^7.6.0",
     "@storybook/theming": "^7.6.0",
+    "@types/eslint": "^8",
     "jest": "^27.0.0",
     "license-checker": "^25.0.1",
     "pre-commit": "^1.2.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1899,6 +1899,8 @@ __metadata:
     "@storybook/preset-typescript": "npm:^3.0.0"
     "@storybook/react-webpack5": "npm:^7.6.0"
     "@storybook/theming": "npm:^7.6.0"
+    "@types/eslint": "npm:^8"
+    eslint: "npm:^8.3.0"
     jest: "npm:^27.0.0"
     license-checker: "npm:^25.0.1"
     pre-commit: "npm:^1.2.2"


### PR DESCRIPTION
### Description
Was noticed that when the pre-commit was run with a deleted file it would fail in the linting phase. Since it had been setup to fetch the names only it was unaware of which files were still present. Adding the filter option to filter out deleted files.

#### Before
![Screenshot 2024-05-23 at 12 45 06 PM](https://github.com/lyft/clutch/assets/8338893/99da2acd-bf17-41bf-87e2-c46a5bc89a9a)

#### After
![Screenshot 2024-05-23 at 12 45 48 PM](https://github.com/lyft/clutch/assets/8338893/1d1f2061-80b4-48e4-9eaa-af1af0b25b23)


### Testing Performed
manual
