### PR TITLE
aws: Handle Moved Permanently error while calling HEAD Bucket

### DIFF
--- a/backend/service/aws/cache.go
+++ b/backend/service/aws/cache.go
@@ -329,22 +329,22 @@ func (c *client) processAllS3AccessPoints(ctx context.Context, account string, c
 		return
 	}
 	for _, accessPoint := range output.AccessPointList {
-		bucketLogger := funcLogger.With(zap.String("access_point", *accessPoint.Name))
+		accessPointLogger := funcLogger.With(zap.String("access_point", *accessPoint.Name))
 		v1AccessPoint, err := c.S3GetAccessPoint(ctx, account, client.region, *accessPoint.Name, *accountId)
 		if err != nil {
-			bucketLogger.Error("unable to describe s3 access point", zap.Error(err))
+			accessPointLogger.Error("unable to describe s3 access point", zap.Error(err))
 			continue
 		}
 
 		protoAccessPoint, err := anypb.New(v1AccessPoint)
 		if err != nil {
-			bucketLogger.Error("unable to marshal s3 access point", zap.Error(err))
+			accessPointLogger.Error("unable to marshal s3 access point", zap.Error(err))
 			continue
 		}
 
 		patternId, err := meta.HydratedPatternForProto(v1AccessPoint)
 		if err != nil {
-			bucketLogger.Error("unable to get proto id from pattern", zap.Error(err))
+			accessPointLogger.Error("unable to get proto id from pattern", zap.Error(err))
 			continue
 		}
 


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
<!-- Describe your change below. -->

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->
This PRs handles Moved Permanently error while calling HEAD Bucket

- List Buckets API returns all buckets in an account regardless of region client used for request. However, the subsequent Head bucket request works for buckets in the same account and returns 301 Moved Permanently error for buckets in different regions.
- This PR ensures we are not logging an error when bucket is in a different region. 

### Testing Performed
<!-- Describe how you tested this change below. -->
Tested changes locally