### PR TITLE
frontend: date time picker range TypeScript fix

### DIFF
--- a/frontend/packages/core/src/Input/date-time.tsx
+++ b/frontend/packages/core/src/Input/date-time.tsx
@@ -19,13 +19,12 @@ const PaddedTextField = styled(TextField)({
 });
 
 export interface DateTimePickerProps
-  extends Pick<
-    MuiDateTimePickerProps<Date, Date>,
-    "disabled" | "value" | "onChange" | "label" | "minDate" | "maxDate"
-  > {
+  extends Pick<MuiDateTimePickerProps<Date, Date>, "disabled" | "value" | "onChange" | "label"> {
   allowEmpty?: boolean;
   error?: boolean;
   helperText?: string;
+  minDate?: Dayjs;
+  maxDate?: Dayjs;
 }
 
 const DateTimePicker = ({
@@ -33,8 +32,6 @@ const DateTimePicker = ({
   allowEmpty = false,
   error = false,
   helperText = "",
-  minDate = null,
-  maxDate = null,
   ...props
 }: DateTimePickerProps) => (
   <LocalizationProvider dateAdapter={AdapterDayjs}>


### PR DESCRIPTION
Typescript fix so that the date time picker from MUI has the correct typing for minDate and maxDate