### PR TITLE
frontend: Adjust current palette for accessibility / look for components where the switch between light/dark/else affects readability

### DIFF
--- a/frontend/packages/core/src/AppLayout/search.tsx
+++ b/frontend/packages/core/src/AppLayout/search.tsx
@@ -80,7 +80,7 @@ const ResultLabel = styled(Typography)(({ theme }: { theme: Theme }) => ({
 
 // main search icon on header
 const SearchIconButton = styled(IconButton)(({ theme }: { theme: Theme }) => ({
-  color: theme.palette.contrastColor,
+  color: theme.palette.common.white,
   fontSize: "24px",
   padding: "12px",
   marginRight: "8px",

--- a/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
+++ b/frontend/packages/core/src/AppLayout/stories/searchfield.stories.tsx
@@ -5,6 +5,7 @@ import { Box, Grid as MuiGrid, Theme } from "@mui/material";
 import type { Meta } from "@storybook/react";
 
 import { ApplicationContext } from "../../Contexts/app-context";
+import { THEME_VARIANTS } from "../../Theme/colors";
 import SearchFieldComponent from "../search";
 
 export default {
@@ -62,7 +63,10 @@ export default {
 
 const Grid = styled(MuiGrid)(({ theme }: { theme: Theme }) => ({
   height: "64px",
-  backgroundColor: theme.palette.primary[900],
+  backgroundColor:
+    theme.palette.mode === THEME_VARIANTS.light
+      ? theme.palette.primary[900]
+      : theme.palette.headerGradient,
 }));
 
 const Template = () => (

--- a/frontend/packages/core/src/Input/stories/date-time.stories.tsx
+++ b/frontend/packages/core/src/Input/stories/date-time.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type { Meta } from "@storybook/react";
+import dayjs from "dayjs";
 
 import type { DateTimePickerProps } from "../date-time";
 import DateTimePicker from "../date-time";
@@ -46,19 +47,19 @@ WithError.args = {
   ...PrimaryDemo.args,
   error: true,
   helperText: "error in the field",
-  onChange: (newValue: unknown) => null,
+  onChange: (_newValue: unknown) => null,
 } as DateTimePickerProps;
 
 export const WithMinDate = Template.bind({});
 WithMinDate.args = {
   ...PrimaryDemo.args,
-  minDate: new Date(),
+  minDate: dayjs(new Date()),
   onChange: (newValue: unknown) => null,
 } as DateTimePickerProps;
 
 export const WithMaxDate = Template.bind({});
 WithMaxDate.args = {
   ...PrimaryDemo.args,
-  maxDate: new Date(),
-  onChange: (newValue: unknown) => null,
+  maxDate: dayjs(new Date()),
+  onChange: (_newValue: unknown) => null,
 } as DateTimePickerProps;

--- a/frontend/packages/core/src/horizontal-rule.tsx
+++ b/frontend/packages/core/src/horizontal-rule.tsx
@@ -32,14 +32,14 @@ const StyledHorizontalRule = styled(HorizontalRuleBase)(({ theme }: { theme: The
 
   ".line > span": {
     display: "block",
-    borderTop: `1px solid ${alpha(theme.palette.secondary[900], 0.12)}`,
+    borderTop: `1px solid ${alpha(theme.palette.secondary[900], 0.38)}`,
   },
 
   ".content": {
     padding: "0 16px",
     fontWeight: "bold",
     fontSize: "14px",
-    color: alpha(theme.palette.secondary[900], 0.38),
+    color: alpha(theme.palette.secondary[900], 0.6),
     textTransform: "uppercase",
     display: "inline-flex",
     alignItems: "center",

--- a/frontend/packages/core/src/stepper.tsx
+++ b/frontend/packages/core/src/stepper.tsx
@@ -56,7 +56,7 @@ const StepContainer = styled("div")<{ $orientation: StepperOrientation }>(
     ".MuiStepLabel-label": {
       fontWeight: 500,
       fontSize: "14px",
-      color: alpha(theme.palette.secondary[900], 0.38),
+      color: alpha(theme.palette.secondary[900], 0.5),
     },
     ".MuiStepLabel-label.Mui-active": {
       color: theme.palette.secondary[900],


### PR DESCRIPTION
**Search Icon Button:** in both light and dark mode the background where this component is used is dark, so there is no need to use the contrastColor value here:

<img width="678" alt="Screenshot 2024-06-11 at 2 04 36 p m" src="https://github.com/lyft/clutch/assets/25833665/5b77032d-e555-44ba-b57b-dcb88049c617">

<img width="681" alt="Screenshot 2024-06-11 at 2 04 46 p m" src="https://github.com/lyft/clutch/assets/25833665/9bac1163-dba2-4486-b092-0a7a80462c91">

**Horizontal Rule:** Opacity was too low:

<img width="679" alt="Screenshot 2024-06-11 at 2 05 05 p m" src="https://github.com/lyft/clutch/assets/25833665/6a5a9510-ad98-464e-aebe-55583ccb0aa5">

<img width="681" alt="Screenshot 2024-06-11 at 2 05 13 p m" src="https://github.com/lyft/clutch/assets/25833665/2e44fc32-c2b7-4e18-bfef-4cdf07899a11">

**Stepper:** Inactive options opacity was too low:

<img width="680" alt="Screenshot 2024-06-11 at 2 05 35 p m" src="https://github.com/lyft/clutch/assets/25833665/e386b359-8702-4ba2-9509-bc0d565fc909">

<img width="678" alt="Screenshot 2024-06-11 at 2 05 44 p m" src="https://github.com/lyft/clutch/assets/25833665/3ad81fe3-6d72-4acf-8bf3-d2d6c9c20a13">

