### PR TITLE
frontend: Implement a theme switcher input to select from multiple themes

### DIFF
--- a/frontend/packages/core/src/AppLayout/header.tsx
+++ b/frontend/packages/core/src/AppLayout/header.tsx
@@ -11,6 +11,7 @@ import Logo from "./logo";
 import Notifications from "./notifications";
 import SearchField from "./search";
 import ShortLinker from "./shortLinker";
+import ThemeSwitcher from "./theme-switcher";
 import { UserInformation } from "./user";
 
 export const APP_BAR_HEIGHT = "64px";
@@ -115,7 +116,11 @@ const Header: React.FC<HeaderProps> = ({
               </>
             )}
             {children && children}
-            {userInfo && <UserInformation />}
+            {userInfo && (
+              <UserInformation>
+                <ThemeSwitcher />
+              </UserInformation>
+            )}
           </Grid>
         </Toolbar>
       </AppBar>

--- a/frontend/packages/core/src/AppLayout/theme-switcher.tsx
+++ b/frontend/packages/core/src/AppLayout/theme-switcher.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import { Grid } from "@mui/material";
+import get from "lodash/get";
+
+import { useUserPreferences } from "../Contexts";
+import { Select } from "../Input";
+import { THEME_VARIANTS } from "../Theme/colors";
+
+const ThemeSwitcher = () => {
+  const { preferences, dispatch } = useUserPreferences();
+
+  const options = [
+    {
+      label: THEME_VARIANTS.light,
+      startAdornment: <LightModeIcon />,
+    },
+    {
+      label: THEME_VARIANTS.dark,
+      startAdornment: <DarkModeIcon />,
+    },
+  ];
+
+  const handleOnChange = (value: string) => {
+    dispatch({
+      type: "SetPref",
+      payload: { key: "theme", value },
+    });
+  };
+
+  return (
+    <Grid container alignItems="center" justifyContent="space-between">
+      <Grid item>Theme</Grid>
+      <Grid item>
+        <Select
+          name="theme-switcher"
+          label=""
+          options={options}
+          onChange={handleOnChange}
+          defaultOption={get(preferences, "theme")}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ThemeSwitcher;

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -160,10 +160,10 @@ const ClutchApp = ({
 
   return (
     <Router>
-      <Theme>
-        <div id="App">
-          <ApplicationContext.Provider value={appContextValue}>
-            <UserPreferencesProvider>
+      <UserPreferencesProvider>
+        <Theme>
+          <div id="App">
+            <ApplicationContext.Provider value={appContextValue}>
               <ShortLinkContext.Provider value={shortLinkProviderProps}>
                 {hydrateError && (
                   <Toast onClose={() => setHydrateError(null)}>
@@ -238,10 +238,10 @@ const ClutchApp = ({
                   </Route>
                 </Routes>
               </ShortLinkContext.Provider>
-            </UserPreferencesProvider>
-          </ApplicationContext.Provider>
-        </div>
-      </Theme>
+            </ApplicationContext.Provider>
+          </div>
+        </Theme>
+      </UserPreferencesProvider>
     </Router>
   );
 };

--- a/frontend/packages/core/src/AppProvider/themes.tsx
+++ b/frontend/packages/core/src/AppProvider/themes.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { useTheme as useMuiTheme } from "@mui/material";
 import type { Theme as MuiTheme } from "@mui/material/styles";
+import get from "lodash/get";
+import isEmpty from "lodash/isEmpty";
 
+import { useUserPreferences } from "../Contexts";
 import { ThemeProvider } from "../Theme";
-import { THEME_VARIANTS } from "../Theme/colors";
 import type { ClutchColors } from "../Theme/types";
+import { THEME_VARIANTS } from "../Theme/types";
 
 declare module "@mui/material/styles" {
   interface Theme {
@@ -23,16 +26,20 @@ declare module "@mui/material/styles" {
 const useTheme = () => useMuiTheme() as MuiTheme;
 
 const Theme: React.FC = ({ children }) => {
-  // Uncomment to use dark mode
-  // Detect system color mode
+  const { preferences } = useUserPreferences();
+
   const prefersDarkMode =
     window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
 
-  return (
-    <ThemeProvider variant={prefersDarkMode ? THEME_VARIANTS.dark : THEME_VARIANTS.light}>
-      {children}
-    </ThemeProvider>
-  );
+  const themeVariant = get(preferences, "theme");
+
+  const variant = isEmpty(themeVariant)
+    ? prefersDarkMode
+      ? THEME_VARIANTS.dark
+      : THEME_VARIANTS.light
+    : themeVariant;
+
+  return <ThemeProvider variant={variant}>{children}</ThemeProvider>;
 };
 
 export { Theme, useTheme };

--- a/frontend/packages/core/src/Contexts/preferences-context.tsx
+++ b/frontend/packages/core/src/Contexts/preferences-context.tsx
@@ -9,6 +9,7 @@ type Dispatch = (action: Action) => void;
 type UserPreferencesProviderProps = { children: React.ReactNode };
 const DEFAULT_PREFERENCES: State = {
   timeFormat: "UTC",
+  theme: "",
 } as any;
 interface ContextProps {
   preferences: State;


### PR DESCRIPTION
Added theme option to user preferences:

<img width="314" alt="Screenshot 2024-06-11 at 4 28 08 p m" src="https://github.com/lyft/clutch/assets/25833665/71b27cfc-54d7-410f-aa8e-dad609508f82">


<img width="305" alt="Screenshot 2024-06-11 at 4 28 47 p m" src="https://github.com/lyft/clutch/assets/25833665/c198409f-ee2e-493a-b15b-f096cda8e9e1">
