### PR TITLE
network: Create `proxyClient` to handle errors on API calls done via the proxy API

### DIFF
--- a/frontend/packages/core/src/Network/errors.ts
+++ b/frontend/packages/core/src/Network/errors.ts
@@ -296,6 +296,10 @@ const HTTP_CODE_MAPPING = {
   504: "Gateway Timeout",
 };
 
+const httpCodeToText = (code: number): string => {
+  return HTTP_CODE_MAPPING[code] || "Unknown";
+};
+
 /* eslint-disable no-underscore-dangle */
 const isHelpDetails = (details: ErrorDetails): details is Help => {
   return details._type === "types.googleapis.com/google.rpc.Help";
@@ -306,4 +310,4 @@ const isClutchErrorDetails = (details: ErrorDetails): details is IClutch.api.v1.
 };
 /* eslint-enable */
 
-export { grpcResponseToError, isClutchErrorDetails, isHelpDetails, HTTP_CODE_MAPPING };
+export { grpcResponseToError, httpCodeToText, isClutchErrorDetails, isHelpDetails };

--- a/frontend/packages/core/src/Network/errors.ts
+++ b/frontend/packages/core/src/Network/errors.ts
@@ -281,6 +281,21 @@ const grpcResponseToError = (clientError: AxiosError): ClutchError => {
   return error;
 };
 
+const HTTP_CODE_MAPPING = {
+  200: "OK",
+  400: "Failed Precondition",
+  401: "Unauthenticated",
+  403: "Permission Denied",
+  404: "Not Found",
+  409: "Already Exists",
+  429: "Resource Exhausted",
+  499: "Cancelled",
+  500: "Internal Server Error",
+  501: "Not Implemented",
+  503: "Service Unavailable",
+  504: "Gateway Timeout",
+};
+
 /* eslint-disable no-underscore-dangle */
 const isHelpDetails = (details: ErrorDetails): details is Help => {
   return details._type === "types.googleapis.com/google.rpc.Help";
@@ -291,4 +306,4 @@ const isClutchErrorDetails = (details: ErrorDetails): details is IClutch.api.v1.
 };
 /* eslint-enable */
 
-export { grpcResponseToError, isClutchErrorDetails, isHelpDetails };
+export { grpcResponseToError, isClutchErrorDetails, isHelpDetails, HTTP_CODE_MAPPING };

--- a/frontend/packages/core/src/Network/index.ts
+++ b/frontend/packages/core/src/Network/index.ts
@@ -2,7 +2,7 @@ import type { AxiosError, AxiosResponse } from "axios";
 import axios from "axios";
 
 import type { ClutchError } from "./errors";
-import { grpcResponseToError, HTTP_CODE_MAPPING } from "./errors";
+import { grpcResponseToError, httpCodeToText } from "./errors";
 
 /**
  * HTTP response status.
@@ -31,7 +31,7 @@ const successProxyInterceptor = (response: AxiosResponse) => {
     const error = {
       status: {
         code: response.data.httpStatus,
-        text: HTTP_CODE_MAPPING[response.data.httpStatus] || "Unknown",
+        text: httpCodeToText(response.data.httpStatus),
       },
       message: response.data.response.message,
       data: response.data,

--- a/frontend/packages/core/src/Network/tests/index.test.ts
+++ b/frontend/packages/core/src/Network/tests/index.test.ts
@@ -153,7 +153,7 @@ describe("axios client", () => {
 });
 
 describe("axios success proxy interceptor", () => {
-  it("returns an error if the proxy call returns response.data.httpStatus >= 400", () => {
+  it("returns an error if the proxy call returns response.data.httpStatus >= 400", async () => {
     const response = {
       status: 200,
       statusText: "Not Found",
@@ -177,6 +177,6 @@ describe("axios success proxy interceptor", () => {
       data: response.data,
     } as ClutchError;
 
-    expect(successProxyInterceptor(response)).rejects.toEqual(err);
+    await expect(successProxyInterceptor(response)).rejects.toEqual(err);
   });
 });

--- a/frontend/packages/core/src/Network/tests/index.test.ts
+++ b/frontend/packages/core/src/Network/tests/index.test.ts
@@ -1,7 +1,7 @@
-import type { AxiosError } from "axios";
+import type { AxiosError, AxiosResponse } from "axios";
 
 import type { ClutchError } from "../errors";
-import { client, errorInterceptor } from "../index";
+import { client, errorInterceptor, successProxyInterceptor } from "../index";
 
 describe("error interceptor", () => {
   describe("on axios error", () => {
@@ -149,5 +149,34 @@ describe("axios client", () => {
 
   it("treats status codes < 400 as success", () => {
     expect(client.defaults.validateStatus(399)).toBe(true);
+  });
+});
+
+describe("axios success proxy interceptor", () => {
+  it("returns an error if the proxy call returns response.data.httpStatus >= 400", () => {
+    const response = {
+      status: 200,
+      statusText: "Not Found",
+      data: {
+        httpStatus: 404,
+        headers: {
+          "Cache-Control": ["no-cache"],
+        },
+        response: {
+          message: "Item not found",
+        },
+      },
+    } as AxiosResponse;
+
+    const err = {
+      status: {
+        code: 404,
+        text: "Not Found",
+      },
+      message: "Item not found",
+      data: response.data,
+    } as ClutchError;
+
+    expect(successProxyInterceptor(response)).rejects.toEqual(err);
   });
 });

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -35,7 +35,7 @@ export {
   useParams,
   useSearchParams,
 } from "./navigation";
-export { client } from "./Network";
+export { client, proxyClient } from "./Network";
 export * from "./NPS";
 export { default as ExpansionPanel } from "./panel";
 export { default as Paper } from "./paper";


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
API calls done via the proxy API always return 200 unless there's a 5XX error. There's a `httpStatus` property that's returned inside the `data` property on Axios calls which contains the actual HTTP status.

The new `proxyClient` now will be able to handle those errors correctly.

<!-- Reference previous related pull requests below. -->

<!-- [OPTIONAL] Include screenshots below for frontend changes. -->

### Testing Performed
Unit testing and tested on internal UI.
