### PR TITLE
chaos integration test: update docker compose command

### DIFF
--- a/backend/internal/test/integration/chaos/do_integration_test.sh
+++ b/backend/internal/test/integration/chaos/do_integration_test.sh
@@ -29,7 +29,7 @@ run_tests () {
 		popd
   	popd
 
-	docker-compose up --build --abort-on-container-exit
+	docker compose up --build --abort-on-container-exit
 }
 
 run_tests "internal/test/integration/chaos/experimentation/cmd/envoyconfiggen" "module/chaos/experimentation/xds"


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description
The chaos integration test has been failing with `KeyError: 'ContainerConfig'`

Came across https://askubuntu.com/questions/1508129/docker-compose-giving-containerconfig-errors-after-update-today; tldr `docker-compose` is the V1 syntax which has been deprecated in V2. The V2 syntax is `docker compose`.

https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

### Testing Performed
CI run