### PR TITLE
frontend: Add options to the table header component

### DIFF
--- a/frontend/packages/core/src/Table/accordion-table.tsx
+++ b/frontend/packages/core/src/Table/accordion-table.tsx
@@ -5,8 +5,8 @@ import { IconButton as MuiIconButton, TableRow, Theme } from "@mui/material";
 
 import styled from "../styled";
 
-import type { TableRowProps } from "./table";
-import { TableCell } from "./table";
+import TableCell from "./components/TableCell";
+import type { TableRowProps } from "./types";
 
 const IconButton = styled(MuiIconButton)(({ theme }: { theme: Theme }) => ({
   padding: "0",

--- a/frontend/packages/core/src/Table/components/TableCell.tsx
+++ b/frontend/packages/core/src/Table/components/TableCell.tsx
@@ -1,9 +1,14 @@
 import React from "react";
-import type { Theme } from "@mui/material";
+import type { TableCellProps as MuiTableCellProps, Theme } from "@mui/material";
 import { TableCell as MuiTableCell } from "@mui/material";
 
 import styled from "../../styled";
-import type { TableCellProps } from "../types";
+import type { TableProps } from "../types";
+
+interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
+  action?: boolean;
+  border?: boolean;
+}
 
 const StyledTableCell = styled(MuiTableCell)<{
   $border?: TableCellProps["border"];

--- a/frontend/packages/core/src/Table/components/TableCell.tsx
+++ b/frontend/packages/core/src/Table/components/TableCell.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import type { Theme } from "@mui/material";
+import { TableCell as MuiTableCell } from "@mui/material";
+
+import styled from "../../styled";
+import type { TableCellProps } from "../types";
+
+const StyledTableCell = styled(MuiTableCell)<{
+  $border?: TableCellProps["border"];
+  $responsive?: TableCellProps["responsive"];
+  $action?: TableCellProps["action"];
+}>(
+  ({ theme }: { theme: Theme }) => ({
+    alignItems: "center",
+    fontSize: "14px",
+    padding: "15px 16px",
+    color: theme.palette.secondary[900],
+    overflow: "hidden",
+    background: "inherit",
+    minHeight: "100%",
+  }),
+  props => ({ theme }: { theme: Theme }) => ({
+    borderBottom: props?.$border ? `1px solid ${theme.palette.secondary[200]}` : "0",
+    display: props.$responsive ? "flex" : "",
+    width: !props.$responsive && props.$action ? "80px" : "",
+  })
+);
+
+const TableCell = ({ action, border, responsive, ...props }: TableCellProps) => (
+  <StyledTableCell $action={action} $border={border} $responsive={responsive} {...props} />
+);
+
+export default TableCell;

--- a/frontend/packages/core/src/Table/components/TableHeader.tsx
+++ b/frontend/packages/core/src/Table/components/TableHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Theme } from "@mui/material";
+import type { TableSortLabelProps as MuiTableSortLabelProps, Theme } from "@mui/material";
 import {
   TableHead as MuiTableHead,
   TableRow as MuiTableRow,
@@ -8,7 +8,7 @@ import {
 
 import styled from "../../styled";
 import { Typography } from "../../typography";
-import type { TableColumn, TableHeaderProps } from "../types";
+import type { Column, TableColumn } from "../types";
 
 import TableCell from "./TableCell";
 
@@ -22,6 +22,15 @@ const HeaderCell = styled("div")({
   alignItems: "center",
   justifyContent: "space-between",
 });
+
+interface TableHeaderProps {
+  columns: Column[];
+  responsive?: boolean;
+  defaultSort?: [string, MuiTableSortLabelProps["direction"]];
+  onRequestSort?: (event: React.MouseEvent<unknown>, property: string) => void;
+  actionsColumn?: boolean;
+  compress?: boolean;
+}
 
 const TableHeader = ({
   columns,
@@ -77,12 +86,12 @@ const TableHeader = ({
                   >
                     <Typography variant="subtitle3">{h?.title}</Typography>
                   </MuiTableSortLabel>
-                  {h?.filter && h?.filterRender}
+                  {h?.options}
                 </HeaderCell>
               ) : (
                 <HeaderCell>
                   <Typography variant="subtitle3">{h?.title || h?.render}</Typography>
-                  {h?.filter && h?.filterRender}
+                  {h?.options}
                 </HeaderCell>
               )}
             </TableCell>

--- a/frontend/packages/core/src/Table/components/TableHeader.tsx
+++ b/frontend/packages/core/src/Table/components/TableHeader.tsx
@@ -35,7 +35,7 @@ interface TableHeaderProps {
 const TableHeader = ({
   columns,
   responsive,
-  defaultSort,
+  defaultSort: [sortKey, sortDir],
   onRequestSort,
   actionsColumn,
   compress,
@@ -75,13 +75,13 @@ const TableHeader = ({
               key={h?.id}
               responsive={responsive}
               align="left"
-              sortDirection={h?.sortable && defaultSort?.[0] === h?.id ? defaultSort[1] : false}
+              sortDirection={h?.sortable && sortKey === h?.id ? sortDir : false}
             >
               {h?.sortable ? (
                 <HeaderCell>
                   <MuiTableSortLabel
-                    active={defaultSort[0] === h?.id}
-                    direction={defaultSort[0] === h?.id ? defaultSort[1] : "asc"}
+                    active={sortKey === h?.id}
+                    direction={sortKey === h?.id ? sortDir : "asc"}
                     onClick={createSortHandler(h?.id)}
                   >
                     <Typography variant="subtitle3">{h?.title}</Typography>

--- a/frontend/packages/core/src/Table/components/TableHeader.tsx
+++ b/frontend/packages/core/src/Table/components/TableHeader.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import type { Theme } from "@mui/material";
+import {
+  TableHead as MuiTableHead,
+  TableRow as MuiTableRow,
+  TableSortLabel as MuiTableSortLabel,
+} from "@mui/material";
+
+import styled from "../../styled";
+import { Typography } from "../../typography";
+import type { TableColumn, TableHeaderProps } from "../types";
+
+import TableCell from "./TableCell";
+
+const StyledTableHeadRow = styled(MuiTableRow)(({ theme }: { theme: Theme }) => ({
+  display: "contents",
+  backgroundColor: theme.palette.primary[300],
+}));
+
+const HeaderCell = styled("div")({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+});
+
+const TableHeader = ({
+  columns,
+  responsive,
+  defaultSort,
+  onRequestSort,
+  actionsColumn,
+  compress,
+}: TableHeaderProps) => {
+  const createSortHandler = property => (event: React.MouseEvent<unknown>) => {
+    onRequestSort && onRequestSort(event, property);
+  };
+
+  const [managedColumns, setManagedColumns] = React.useState<TableColumn[]>([]);
+
+  React.useEffect(() => {
+    if (columns?.length === 0) {
+      // eslint-disable-next-line no-console
+      console.warn("Table must have at least one column.");
+    } else {
+      setManagedColumns(
+        columns.map((c, i) => {
+          if (React.isValidElement(c)) {
+            return { id: `element${i}`, render: c };
+          }
+          if (typeof c === "string") {
+            return { id: c, title: c };
+          }
+          return c as TableColumn;
+        })
+      );
+    }
+  }, [columns]);
+
+  return (
+    managedColumns?.length !== 0 &&
+    managedColumns.filter(h => h?.title?.length !== 0 || h?.render).length !== 0 && (
+      <MuiTableHead>
+        <StyledTableHeadRow>
+          {managedColumns.map(h => (
+            <TableCell
+              key={h?.id}
+              responsive={responsive}
+              align="left"
+              sortDirection={h?.sortable && defaultSort?.[0] === h?.id ? defaultSort[1] : false}
+            >
+              {h?.sortable ? (
+                <HeaderCell>
+                  <MuiTableSortLabel
+                    active={defaultSort[0] === h?.id}
+                    direction={defaultSort[0] === h?.id ? defaultSort[1] : "asc"}
+                    onClick={createSortHandler(h?.id)}
+                  >
+                    <Typography variant="subtitle3">{h?.title}</Typography>
+                  </MuiTableSortLabel>
+                  {h?.filter && h?.filterRender}
+                </HeaderCell>
+              ) : (
+                <HeaderCell>
+                  <Typography variant="subtitle3">{h?.title || h?.render}</Typography>
+                  {h?.filter && h?.filterRender}
+                </HeaderCell>
+              )}
+            </TableCell>
+          ))}
+          {actionsColumn && !(responsive && compress) && (
+            <TableCell responsive={responsive} action />
+          )}
+        </StyledTableHeadRow>
+      </MuiTableHead>
+    )
+  );
+};
+
+export default TableHeader;

--- a/frontend/packages/core/src/Table/index.tsx
+++ b/frontend/packages/core/src/Table/index.tsx
@@ -1,6 +1,7 @@
+import TableCell from "./components/TableCell";
 import { AccordionRow } from "./accordion-table";
 import { MetadataTable } from "./metadata-table";
-import { Table, TableCell, TableRow, TableRowAction, TableRowActions } from "./table";
+import { Table, TableRow, TableRowAction, TableRowActions } from "./table";
 import TreeTable from "./tree-table";
 
 export {

--- a/frontend/packages/core/src/Table/stories/table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/table.stories.tsx
@@ -3,14 +3,8 @@ import EmojiPeopleIcon from "@mui/icons-material/EmojiPeople";
 import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
-import {
-  Table,
-  TableProps,
-  TableRow,
-  TableRowAction,
-  TableRowActions,
-  TableRowProps,
-} from "../table";
+import { Table, TableRow, TableRowAction, TableRowActions } from "../table";
+import type { TableProps, TableRowProps } from "../types";
 
 export default {
   title: "Core/Table/Table",

--- a/frontend/packages/core/src/Table/stories/table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/table.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import EmojiPeopleIcon from "@mui/icons-material/EmojiPeople";
+import FilterListIcon from "@mui/icons-material/FilterList";
 import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
@@ -14,6 +15,17 @@ export default {
 const Template = ({ row, ...props }: TableProps & { row: React.ReactElement }) => (
   <div style={{ maxHeight: "300px", display: "flex" }}>
     <Table {...props} columns={["Column 1", "Column 2", "Column 3", "Column 4", "Column 5"]}>
+      {Array(10)
+        .fill(null)
+        // eslint-disable-next-line react/no-array-index-key
+        .map((_, index: number) => React.cloneElement(row, { key: index }))}
+    </Table>
+  </div>
+);
+
+const Template2 = ({ row, ...props }: TableProps & { row: React.ReactElement }) => (
+  <div style={{ maxHeight: "300px", display: "flex" }}>
+    <Table {...props}>
       {Array(10)
         .fill(null)
         // eslint-disable-next-line react/no-array-index-key
@@ -85,4 +97,43 @@ export const ActionableRows = Template.bind({});
 ActionableRows.args = {
   actionsColumn: true,
   row: <ActionableTableRow />,
+};
+
+export const SortFilterOptions = Template2.bind({});
+SortFilterOptions.args = {
+  defaultSort: ["column1", "asc"],
+  onRequestSort: () => {},
+  columns: [
+    {
+      id: "column1",
+      title: "Column 1",
+      sortable: true,
+      options: <FilterListIcon fontSize="medium" />,
+    },
+    {
+      id: "column2",
+      title: "Column 2",
+      sortable: true,
+      options: <FilterListIcon fontSize="medium" />,
+    },
+    {
+      id: "column3",
+      title: "Column 3",
+      sortable: true,
+      options: <FilterListIcon fontSize="medium" />,
+    },
+    {
+      id: "column4",
+      title: "Column 4",
+      sortable: true,
+      options: <FilterListIcon fontSize="medium" />,
+    },
+    {
+      id: "column5",
+      title: "Column 5",
+      sortable: true,
+      options: <FilterListIcon fontSize="medium" />,
+    },
+  ],
+  row: <PrimaryTableRow />,
 };

--- a/frontend/packages/core/src/Table/types.tsx
+++ b/frontend/packages/core/src/Table/types.tsx
@@ -1,0 +1,81 @@
+import type {
+  TableCellProps as MuiTableCellProps,
+  TableProps as MuiTableProps,
+  TableRowProps as MuiTableRowProps,
+  TableSortLabelProps as MuiTableSortLabelProps,
+} from "@mui/material";
+import type { Breakpoint } from "@mui/material/styles";
+
+interface TableRowProps
+  extends Pick<MuiTableRowProps, "onClick">,
+    Pick<MuiTableCellProps, "colSpan"> {
+  children?: React.ReactNode;
+  /**
+   * The default element to render if children are null. If not present and a child is null
+   * this the child's value will be used.
+   */
+  cellDefault?: React.ReactNode;
+  /**
+   * Make the table row responsive. This is mainly used for internal rendering. Consumers
+   * should set the responsive prop on the table.
+   */
+  responsive?: boolean;
+}
+
+interface TableColumn {
+  id: string;
+  title?: string;
+  sortable?: boolean;
+  render?: JSX.Element;
+  filter?: boolean;
+  filterRender?: JSX.Element;
+}
+
+type Column = string | TableColumn | JSX.Element;
+interface TableProps extends Pick<MuiTableProps, "stickyHeader"> {
+  /** The names of the columns. This must be set (even to empty string) to render the table. */
+  columns: Column[];
+  /** The breakpoint at which to compress the table rows. By default the small breakpoint is used. */
+  compressBreakpoint?: Breakpoint;
+  /** Hide the header. By default this is false. */
+  hideHeader?: boolean;
+  /** Add an actions column. By default this is false. */
+  actionsColumn?: boolean;
+  /** Make table responsive */
+  responsive?: boolean;
+  /** How to handle horizontal overflow */
+  overflow?: "scroll" | "break-word";
+  /** Table rows to render */
+  children?:
+    | (React.ReactElement<TableRowProps> | null | undefined | {})[]
+    | React.ReactElement<TableRowProps>;
+  defaultSort?: [string, MuiTableSortLabelProps["direction"]];
+  onRequestSort?: (event: React.MouseEvent<unknown>, property: string) => void;
+}
+
+interface TableContainerProps {
+  children: React.ReactElement<TableProps>;
+}
+
+interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
+  action?: boolean;
+  border?: boolean;
+}
+
+interface TableHeaderProps {
+  columns: Column[];
+  responsive?: boolean;
+  defaultSort?: [string, MuiTableSortLabelProps["direction"]];
+  onRequestSort?: (event: React.MouseEvent<unknown>, property: string) => void;
+  actionsColumn?: boolean;
+  compress?: boolean;
+}
+
+export type {
+  TableRowProps,
+  TableColumn,
+  TableProps,
+  TableContainerProps,
+  TableCellProps,
+  TableHeaderProps,
+};

--- a/frontend/packages/core/src/Table/types.tsx
+++ b/frontend/packages/core/src/Table/types.tsx
@@ -27,8 +27,7 @@ interface TableColumn {
   title?: string;
   sortable?: boolean;
   render?: JSX.Element;
-  filter?: boolean;
-  filterRender?: JSX.Element;
+  options?: JSX.Element;
 }
 
 type Column = string | TableColumn | JSX.Element;
@@ -57,25 +56,4 @@ interface TableContainerProps {
   children: React.ReactElement<TableProps>;
 }
 
-interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
-  action?: boolean;
-  border?: boolean;
-}
-
-interface TableHeaderProps {
-  columns: Column[];
-  responsive?: boolean;
-  defaultSort?: [string, MuiTableSortLabelProps["direction"]];
-  onRequestSort?: (event: React.MouseEvent<unknown>, property: string) => void;
-  actionsColumn?: boolean;
-  compress?: boolean;
-}
-
-export type {
-  TableRowProps,
-  TableColumn,
-  TableProps,
-  TableContainerProps,
-  TableCellProps,
-  TableHeaderProps,
-};
+export type { Column, TableRowProps, TableColumn, TableProps, TableContainerProps };


### PR DESCRIPTION
Similar to sorting, the user can send attributes (_options?: JSX.Element_) in the columns list to the **Table** component to specify if they want to display options (e.g. filters) while also providing the _component_ that needs to be rendered.

An example could be something like the following:
<img width="675" alt="Screenshot 2024-07-04 at 5 43 42 p m" src="https://github.com/lyft/clutch/assets/25833665/e63e0bf6-4ed3-4c11-9887-3e5e53ec9bd5">

<img width="831" alt="Screenshot 2024-07-08 at 10 28 45 a m" src="https://github.com/lyft/clutch/assets/25833665/0177b440-3faa-4e47-a582-519011bc09f3">

**Filtering logic and UI is 100% responsibility of the father component, table header only renders the component provided** 