### PR TITLE
frontend: Add style prop to table component

### DIFF
--- a/frontend/packages/core/src/Table/components/TableCell.tsx
+++ b/frontend/packages/core/src/Table/components/TableCell.tsx
@@ -8,7 +8,6 @@ import type { TableProps } from "../types";
 interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
   action?: boolean;
   border?: boolean;
-  maxWidth?: number;
 }
 
 const StyledTableCell = styled(MuiTableCell)<{

--- a/frontend/packages/core/src/Table/components/TableCell.tsx
+++ b/frontend/packages/core/src/Table/components/TableCell.tsx
@@ -5,14 +5,9 @@ import { TableCell as MuiTableCell } from "@mui/material";
 import styled from "../../styled";
 import type { TableProps } from "../types";
 
-export enum TableCellType {
-  TABLE_CELL = "TableCell",
-}
-
 interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
   action?: boolean;
   border?: boolean;
-  type?: string;
 }
 
 const StyledTableCell = styled(MuiTableCell)<{
@@ -36,10 +31,10 @@ const StyledTableCell = styled(MuiTableCell)<{
   })
 );
 
-const BaseTableCell = ({ action, border, responsive, ...props }: TableCellProps) => (
+const TableCell = ({ action, border, responsive, ...props }: TableCellProps) => (
   <StyledTableCell $action={action} $border={border} $responsive={responsive} {...props} />
 );
 
-const TableCell = props => <BaseTableCell type={TableCellType.TABLE_CELL} {...props} />;
+TableCell.displayName = "ClutchTableCell";
 
 export default TableCell;

--- a/frontend/packages/core/src/Table/components/TableCell.tsx
+++ b/frontend/packages/core/src/Table/components/TableCell.tsx
@@ -8,6 +8,7 @@ import type { TableProps } from "../types";
 interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
   action?: boolean;
   border?: boolean;
+  maxWidth?: number;
 }
 
 const StyledTableCell = styled(MuiTableCell)<{
@@ -31,8 +32,14 @@ const StyledTableCell = styled(MuiTableCell)<{
   })
 );
 
-const TableCell = ({ action, border, responsive, ...props }: TableCellProps) => (
-  <StyledTableCell $action={action} $border={border} $responsive={responsive} {...props} />
+const TableCell = ({ action, border, responsive, style = {}, ...props }: TableCellProps) => (
+  <StyledTableCell
+    $action={action}
+    $border={border}
+    $responsive={responsive}
+    {...props}
+    sx={style}
+  />
 );
 
 export default TableCell;

--- a/frontend/packages/core/src/Table/components/TableCell.tsx
+++ b/frontend/packages/core/src/Table/components/TableCell.tsx
@@ -5,6 +5,10 @@ import { TableCell as MuiTableCell } from "@mui/material";
 import styled from "../../styled";
 import type { TableProps } from "../types";
 
+export enum TableCellType {
+  TABLE_CELL = "TableCell",
+}
+
 interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
   action?: boolean;
   border?: boolean;
@@ -32,8 +36,10 @@ const StyledTableCell = styled(MuiTableCell)<{
   })
 );
 
-const TableCell = ({ action, border, responsive, ...props }: TableCellProps) => (
+const BaseTableCell = ({ action, border, responsive, ...props }: TableCellProps) => (
   <StyledTableCell $action={action} $border={border} $responsive={responsive} {...props} />
 );
+
+const TableCell = props => <BaseTableCell type={TableCellType.TABLE_CELL} {...props} />;
 
 export default TableCell;

--- a/frontend/packages/core/src/Table/components/TableCell.tsx
+++ b/frontend/packages/core/src/Table/components/TableCell.tsx
@@ -8,6 +8,7 @@ import type { TableProps } from "../types";
 interface TableCellProps extends MuiTableCellProps, Pick<TableProps, "responsive"> {
   action?: boolean;
   border?: boolean;
+  type?: string;
 }
 
 const StyledTableCell = styled(MuiTableCell)<{
@@ -31,14 +32,8 @@ const StyledTableCell = styled(MuiTableCell)<{
   })
 );
 
-const TableCell = ({ action, border, responsive, style = {}, ...props }: TableCellProps) => (
-  <StyledTableCell
-    $action={action}
-    $border={border}
-    $responsive={responsive}
-    {...props}
-    sx={style}
-  />
+const TableCell = ({ action, border, responsive, ...props }: TableCellProps) => (
+  <StyledTableCell $action={action} $border={border} $responsive={responsive} {...props} />
 );
 
 export default TableCell;

--- a/frontend/packages/core/src/Table/stories/table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/table.stories.tsx
@@ -4,7 +4,8 @@ import FilterListIcon from "@mui/icons-material/FilterList";
 import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
-import { Table, TableRow, TableRowAction, TableRowActions } from "../table";
+import TableCell from "../components/TableCell";
+import { Table, TableCellType, TableRow, TableRowAction, TableRowActions } from "../table";
 import type { TableProps, TableRowProps } from "../types";
 
 export default {
@@ -45,43 +46,29 @@ const PrimaryTableRow = (props: TableRowProps) => (
 );
 
 const SecondaryTableRow = (props: TableRowProps) => (
-  <TableRow
-    {...props}
-    style={[
-      {
-        width: "100px",
-        maxWidth: "100px",
-      },
-      {
-        width: "100px",
-        maxWidth: "100px",
-      },
-      {
-        width: "100px",
-        maxWidth: "100px",
-      },
-      {
-        width: "300px",
-        maxWidth: "300px",
-      },
-      {
-        width: "100px",
-        maxWidth: "100px",
-      },
-    ]}
-  >
-    <div>Value 1</div>
-    <div>Value 2</div>
-    <div>Value 3</div>
-    <div>
-      Long description Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-      reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-      occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-      laborum.
-    </div>
-    <div>Value 5</div>
+  <TableRow {...props}>
+    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+      <div>Value 1</div>
+    </TableCell>
+    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+      <div>Value 2</div>
+    </TableCell>
+    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+      <div>Value 3</div>
+    </TableCell>
+    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "300px", maxWidth: "300px" }}>
+      <div>
+        Long description Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+        exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+        in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
+      </div>
+    </TableCell>
+    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+      <div>Value 5</div>
+    </TableCell>
   </TableRow>
 );
 

--- a/frontend/packages/core/src/Table/stories/table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/table.stories.tsx
@@ -5,7 +5,7 @@ import { action } from "@storybook/addon-actions";
 import type { Meta } from "@storybook/react";
 
 import TableCell from "../components/TableCell";
-import { Table, TableCellType, TableRow, TableRowAction, TableRowActions } from "../table";
+import { Table, TableRow, TableRowAction, TableRowActions } from "../table";
 import type { TableProps, TableRowProps } from "../types";
 
 export default {
@@ -47,16 +47,16 @@ const PrimaryTableRow = (props: TableRowProps) => (
 
 const SecondaryTableRow = (props: TableRowProps) => (
   <TableRow {...props}>
-    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+    <TableCell sx={{ width: "100px", maxWidth: "100px" }}>
       <div>Value 1</div>
     </TableCell>
-    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+    <TableCell sx={{ width: "100px", maxWidth: "100px" }}>
       <div>Value 2</div>
     </TableCell>
-    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+    <TableCell sx={{ width: "100px", maxWidth: "100px" }}>
       <div>Value 3</div>
     </TableCell>
-    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "300px", maxWidth: "300px" }}>
+    <TableCell sx={{ width: "300px", maxWidth: "300px" }}>
       <div>
         Long description Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -66,7 +66,7 @@ const SecondaryTableRow = (props: TableRowProps) => (
         laborum.
       </div>
     </TableCell>
-    <TableCell type={TableCellType.TABLE_CELL} sx={{ width: "100px", maxWidth: "100px" }}>
+    <TableCell sx={{ width: "100px", maxWidth: "100px" }}>
       <div>Value 5</div>
     </TableCell>
   </TableRow>

--- a/frontend/packages/core/src/Table/stories/table.stories.tsx
+++ b/frontend/packages/core/src/Table/stories/table.stories.tsx
@@ -44,6 +44,47 @@ const PrimaryTableRow = (props: TableRowProps) => (
   </TableRow>
 );
 
+const SecondaryTableRow = (props: TableRowProps) => (
+  <TableRow
+    {...props}
+    style={[
+      {
+        width: "100px",
+        maxWidth: "100px",
+      },
+      {
+        width: "100px",
+        maxWidth: "100px",
+      },
+      {
+        width: "100px",
+        maxWidth: "100px",
+      },
+      {
+        width: "300px",
+        maxWidth: "300px",
+      },
+      {
+        width: "100px",
+        maxWidth: "100px",
+      },
+    ]}
+  >
+    <div>Value 1</div>
+    <div>Value 2</div>
+    <div>Value 3</div>
+    <div>
+      Long description Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+      reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+      occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+      laborum.
+    </div>
+    <div>Value 5</div>
+  </TableRow>
+);
+
 const IncompleteTableRow = (props: TableRowProps) => {
   let data;
   return (
@@ -135,5 +176,5 @@ SortFilterOptions.args = {
       options: <FilterListIcon fontSize="medium" />,
     },
   ],
-  row: <PrimaryTableRow />,
+  row: <SecondaryTableRow />,
 };

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -13,8 +13,9 @@ import {
 
 import { Popper, PopperItem } from "../popper";
 import styled from "../styled";
+import { getDisplayName } from "../utils";
 
-import TableCell, { TableCellType } from "./components/TableCell";
+import TableCell from "./components/TableCell";
 import TableHeader from "./components/TableHeader";
 import type { TableContainerProps, TableProps, TableRowProps } from "./types";
 
@@ -148,10 +149,8 @@ const TableRow = ({
       );
 
       if (React.isValidElement(child)) {
-        const { type } = child?.props || {};
-
-        switch (type) {
-          case TableCellType.TABLE_CELL:
+        switch (getDisplayName(child)) {
+          case "ClutchTableCell":
             return child;
           default:
             return withTableCellWrapper;

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -14,7 +14,7 @@ import {
 import { Popper, PopperItem } from "../popper";
 import styled from "../styled";
 
-import TableCell from "./components/TableCell";
+import TableCell, { TableCellType } from "./components/TableCell";
 import TableHeader from "./components/TableHeader";
 import type { TableContainerProps, TableProps, TableRowProps } from "./types";
 
@@ -125,10 +125,6 @@ const Table: React.FC<TableProps> = React.forwardRef(
     );
   }
 );
-
-export enum TableCellType {
-  TABLE_CELL = "TableCell",
-}
 
 const TableRow = ({
   children = [],

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -132,12 +132,13 @@ const TableRow = ({
   cellDefault,
   responsive = false,
   colSpan,
+  style = [],
   ...props
 }: TableRowProps) => (
   <StyledTableRow onClick={onClick} $responsive={responsive} {...props}>
     {React.Children.map(children, (value, index) => (
       // eslint-disable-next-line react/no-array-index-key
-      <TableCell key={index} responsive={responsive} colSpan={colSpan}>
+      <TableCell key={index} responsive={responsive} colSpan={colSpan} style={style?.[index]}>
         {value === null && cellDefault !== undefined ? cellDefault : value}
       </TableCell>
     ))}

--- a/frontend/packages/core/src/Table/table.tsx
+++ b/frontend/packages/core/src/Table/table.tsx
@@ -126,22 +126,43 @@ const Table: React.FC<TableProps> = React.forwardRef(
   }
 );
 
+export enum TableCellType {
+  TABLE_CELL = "TableCell",
+}
+
 const TableRow = ({
   children = [],
   onClick,
   cellDefault,
   responsive = false,
   colSpan,
-  style = [],
   ...props
 }: TableRowProps) => (
   <StyledTableRow onClick={onClick} $responsive={responsive} {...props}>
-    {React.Children.map(children, (value, index) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <TableCell key={index} responsive={responsive} colSpan={colSpan} style={style?.[index]}>
-        {value === null && cellDefault !== undefined ? cellDefault : value}
-      </TableCell>
-    ))}
+    {React.Children.map(children, (child, index) => {
+      const withTableCellWrapper = (
+        <TableCell
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          responsive={responsive}
+          colSpan={colSpan}
+        >
+          {child === null && cellDefault !== undefined ? cellDefault : child}
+        </TableCell>
+      );
+
+      if (React.isValidElement(child)) {
+        const { type } = child?.props || {};
+
+        switch (type) {
+          case TableCellType.TABLE_CELL:
+            return child;
+          default:
+            return withTableCellWrapper;
+        }
+      }
+      return withTableCellWrapper;
+    })}
   </StyledTableRow>
 );
 

--- a/frontend/packages/core/src/Table/types.tsx
+++ b/frontend/packages/core/src/Table/types.tsx
@@ -20,6 +20,7 @@ interface TableRowProps
    * should set the responsive prop on the table.
    */
   responsive?: boolean;
+  style?: {};
 }
 
 interface TableColumn {

--- a/frontend/packages/core/src/Table/types.tsx
+++ b/frontend/packages/core/src/Table/types.tsx
@@ -20,7 +20,6 @@ interface TableRowProps
    * should set the responsive prop on the table.
    */
   responsive?: boolean;
-  style?: {};
 }
 
 interface TableColumn {

--- a/frontend/packages/core/src/utils/getDisplayName.ts
+++ b/frontend/packages/core/src/utils/getDisplayName.ts
@@ -1,0 +1,18 @@
+/**
+ * Context: https://stackoverflow.com/questions/65793723/i-cant-find-the-matching-typescript-type-for-displayname-as-a-prop-of-type
+ * @param Component the component to fetch the displayName from
+ * @returns the displayName of the component
+ */
+const getDisplayName = (element: React.ReactElement<any>) => {
+  const node = element as React.ReactElement<React.ComponentType<any>>;
+  const { type } = (node as unknown) as React.ReactElement<React.FunctionComponent>;
+  const displayName =
+    typeof type === "function"
+      ? (type as React.FunctionComponent).displayName ||
+        (type as React.FunctionComponent).name ||
+        "Unknown"
+      : type;
+  return displayName;
+};
+
+export default getDisplayName;

--- a/frontend/packages/core/src/utils/index.ts
+++ b/frontend/packages/core/src/utils/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as getDisplayName } from "./getDisplayName";


### PR DESCRIPTION
Scope: Add style prop to _TableRow_ so that styling can be dynamic for _TableCell_ components in body

Table with default column width
<img width="1489" alt="Screenshot 2024-07-24 at 3 55 29 p m" src="https://github.com/user-attachments/assets/400f61c5-ff1e-454a-8e2e-69f5e965aec1">

Table with set column width
<img width="1476" alt="Screenshot 2024-07-24 at 3 57 03 p m" src="https://github.com/user-attachments/assets/e3a8b850-c3ce-416b-9c2b-f1a32ac6f670">

