### PR TITLE
backend: Updating Github Service

### DIFF
--- a/backend/service/github/github_test.go
+++ b/backend/service/github/github_test.go
@@ -104,7 +104,8 @@ func (g *getdirectoryMock) Query(ctx context.Context, query interface{}, variabl
 			struct {
 				Name githubv4.String
 				Type githubv4.String
-			}{Name: githubv4.String(g.entries[0].Name), Type: githubv4.String(g.entries[0].Type)})
+				OID  githubv4.GitObjectID
+			}{Name: githubv4.String(g.entries[0].Name), Type: githubv4.String(g.entries[0].Type), OID: githubv4.GitObjectID(g.entries[0].SHA)})
 	}
 
 	q.Repository.Ref.Commit.History.Nodes = append(
@@ -277,7 +278,7 @@ func TestGetFile(t *testing.T) {
 	}
 }
 
-var directoryEntries = []*Entry{{Name: "foo", Type: "blob"}}
+var directoryEntries = []*Entry{{Name: "foo", Type: "blob", SHA: "abcdef12345"}}
 
 var getDirectoryTests = []struct {
 	name    string
@@ -582,6 +583,7 @@ var getCommitsTests = []struct {
 	authorLogin     string
 	authorAvatarURL string
 	authorID        int64
+	sha             string
 	parentRef       string
 }{
 	{
@@ -596,6 +598,7 @@ var getCommitsTests = []struct {
 		message:         "committing some changes (#1)",
 		authorAvatarURL: "https://foo.bar/baz.png",
 		authorID:        1234,
+		sha:             "test",
 		parentRef:       "test",
 	},
 }
@@ -633,6 +636,9 @@ func TestGetCommit(t *testing.T) {
 			if commit.Author != nil {
 				a.Equal(tt.authorAvatarURL, *commit.Author.AvatarURL)
 				a.Equal(tt.authorID, *commit.Author.ID)
+			}
+			if commit.SHA != "" {
+				a.Equal(tt.sha, commit.SHA)
 			}
 			if commit.ParentRef != "" {
 				a.Equal(tt.parentRef, commit.ParentRef)

--- a/backend/service/github/graphql.go
+++ b/backend/service/github/graphql.go
@@ -59,6 +59,7 @@ type getDirectoryQuery struct {
 				Entries []struct {
 					Name githubv4.String
 					Type githubv4.String
+					OID  githubv4.GitObjectID
 				} `graphql:"entries"`
 			} `graphql:"... on Tree"`
 		} `graphql:"object(expression:$refPath)"`


### PR DESCRIPTION
### Description
Minor adjustments:
- Updated `Entry` struct to have a SHA field
- Updated CreateBranch functionality to add files in worktree to the commit. Currently only existing files were being added when creating the commit
- Returning the SHA from GetCommit since if you search via a tag or a branch you would not have that information available

### Testing Performed
manual
