### PR TITLE
backend: Add get query count to sourcegraph

### DIFF
--- a/api/sourcegraph/v1/sourcegraph.proto
+++ b/api/sourcegraph/v1/sourcegraph.proto
@@ -22,3 +22,11 @@ message Commit {
   string message = 3;
   string display_name = 4;
 }
+
+message GetQueryResultsCountRequest {
+  string query = 1 [ (validate.rules).string = {min_bytes : 1, ignore_empty : true} ];
+}
+
+message GetQueryResultsCountResponse {
+  uint32 count = 1;
+}

--- a/backend/api/sourcegraph/v1/sourcegraph.pb.go
+++ b/backend/api/sourcegraph/v1/sourcegraph.pb.go
@@ -202,6 +202,100 @@ func (x *Commit) GetDisplayName() string {
 	return ""
 }
 
+type GetQueryResultsCountRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Query string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+}
+
+func (x *GetQueryResultsCountRequest) Reset() {
+	*x = GetQueryResultsCountRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_sourcegraph_v1_sourcegraph_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *GetQueryResultsCountRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetQueryResultsCountRequest) ProtoMessage() {}
+
+func (x *GetQueryResultsCountRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sourcegraph_v1_sourcegraph_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetQueryResultsCountRequest.ProtoReflect.Descriptor instead.
+func (*GetQueryResultsCountRequest) Descriptor() ([]byte, []int) {
+	return file_sourcegraph_v1_sourcegraph_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *GetQueryResultsCountRequest) GetQuery() string {
+	if x != nil {
+		return x.Query
+	}
+	return ""
+}
+
+type GetQueryResultsCountResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Count uint32 `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`
+}
+
+func (x *GetQueryResultsCountResponse) Reset() {
+	*x = GetQueryResultsCountResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_sourcegraph_v1_sourcegraph_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *GetQueryResultsCountResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetQueryResultsCountResponse) ProtoMessage() {}
+
+func (x *GetQueryResultsCountResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sourcegraph_v1_sourcegraph_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetQueryResultsCountResponse.ProtoReflect.Descriptor instead.
+func (*GetQueryResultsCountResponse) Descriptor() ([]byte, []int) {
+	return file_sourcegraph_v1_sourcegraph_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetQueryResultsCountResponse) GetCount() uint32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
 var File_sourcegraph_v1_sourcegraph_proto protoreflect.FileDescriptor
 
 var file_sourcegraph_v1_sourcegraph_proto_rawDesc = []byte{
@@ -230,11 +324,19 @@ var file_sourcegraph_v1_sourcegraph_proto_rawDesc = []byte{
 	0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x12, 0x21, 0x0a,
 	0x0c, 0x64, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x04, 0x20,
 	0x01, 0x28, 0x09, 0x52, 0x0b, 0x64, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65,
-	0x42, 0x41, 0x5a, 0x3f, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6c,
-	0x79, 0x66, 0x74, 0x2f, 0x63, 0x6c, 0x75, 0x74, 0x63, 0x68, 0x2f, 0x62, 0x61, 0x63, 0x6b, 0x65,
-	0x6e, 0x64, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x67, 0x72, 0x61,
-	0x70, 0x68, 0x2f, 0x76, 0x31, 0x3b, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x67, 0x72, 0x61, 0x70,
-	0x68, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x22, 0x3f, 0x0a, 0x1b, 0x47, 0x65, 0x74, 0x51, 0x75, 0x65, 0x72, 0x79, 0x52, 0x65, 0x73, 0x75,
+	0x6c, 0x74, 0x73, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
+	0x20, 0x0a, 0x05, 0x71, 0x75, 0x65, 0x72, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x42, 0x0a,
+	0xfa, 0x42, 0x07, 0x72, 0x05, 0x20, 0x01, 0xd0, 0x01, 0x01, 0x52, 0x05, 0x71, 0x75, 0x65, 0x72,
+	0x79, 0x22, 0x34, 0x0a, 0x1c, 0x47, 0x65, 0x74, 0x51, 0x75, 0x65, 0x72, 0x79, 0x52, 0x65, 0x73,
+	0x75, 0x6c, 0x74, 0x73, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x12, 0x14, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d,
+	0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x41, 0x5a, 0x3f, 0x67, 0x69, 0x74, 0x68, 0x75,
+	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6c, 0x79, 0x66, 0x74, 0x2f, 0x63, 0x6c, 0x75, 0x74, 0x63,
+	0x68, 0x2f, 0x62, 0x61, 0x63, 0x6b, 0x65, 0x6e, 0x64, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x73, 0x6f,
+	0x75, 0x72, 0x63, 0x65, 0x67, 0x72, 0x61, 0x70, 0x68, 0x2f, 0x76, 0x31, 0x3b, 0x73, 0x6f, 0x75,
+	0x72, 0x63, 0x65, 0x67, 0x72, 0x61, 0x70, 0x68, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
+	0x6f, 0x33,
 }
 
 var (
@@ -249,11 +351,13 @@ func file_sourcegraph_v1_sourcegraph_proto_rawDescGZIP() []byte {
 	return file_sourcegraph_v1_sourcegraph_proto_rawDescData
 }
 
-var file_sourcegraph_v1_sourcegraph_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_sourcegraph_v1_sourcegraph_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_sourcegraph_v1_sourcegraph_proto_goTypes = []interface{}{
-	(*CompareCommitsRequest)(nil),  // 0: clutch.sourcegraph.v1.CompareCommitsRequest
-	(*CompareCommitsResponse)(nil), // 1: clutch.sourcegraph.v1.CompareCommitsResponse
-	(*Commit)(nil),                 // 2: clutch.sourcegraph.v1.Commit
+	(*CompareCommitsRequest)(nil),        // 0: clutch.sourcegraph.v1.CompareCommitsRequest
+	(*CompareCommitsResponse)(nil),       // 1: clutch.sourcegraph.v1.CompareCommitsResponse
+	(*Commit)(nil),                       // 2: clutch.sourcegraph.v1.Commit
+	(*GetQueryResultsCountRequest)(nil),  // 3: clutch.sourcegraph.v1.GetQueryResultsCountRequest
+	(*GetQueryResultsCountResponse)(nil), // 4: clutch.sourcegraph.v1.GetQueryResultsCountResponse
 }
 var file_sourcegraph_v1_sourcegraph_proto_depIdxs = []int32{
 	2, // 0: clutch.sourcegraph.v1.CompareCommitsResponse.commits:type_name -> clutch.sourcegraph.v1.Commit
@@ -306,6 +410,30 @@ func file_sourcegraph_v1_sourcegraph_proto_init() {
 				return nil
 			}
 		}
+		file_sourcegraph_v1_sourcegraph_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GetQueryResultsCountRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_sourcegraph_v1_sourcegraph_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GetQueryResultsCountResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -313,7 +441,7 @@ func file_sourcegraph_v1_sourcegraph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_sourcegraph_v1_sourcegraph_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/backend/api/sourcegraph/v1/sourcegraph.pb.validate.go
+++ b/backend/api/sourcegraph/v1/sourcegraph.pb.validate.go
@@ -411,3 +411,226 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = CommitValidationError{}
+
+// Validate checks the field values on GetQueryResultsCountRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *GetQueryResultsCountRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetQueryResultsCountRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// GetQueryResultsCountRequestMultiError, or nil if none found.
+func (m *GetQueryResultsCountRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetQueryResultsCountRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if m.GetQuery() != "" {
+
+		if len(m.GetQuery()) < 1 {
+			err := GetQueryResultsCountRequestValidationError{
+				field:  "Query",
+				reason: "value length must be at least 1 bytes",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return GetQueryResultsCountRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetQueryResultsCountRequestMultiError is an error wrapping multiple
+// validation errors returned by GetQueryResultsCountRequest.ValidateAll() if
+// the designated constraints aren't met.
+type GetQueryResultsCountRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetQueryResultsCountRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetQueryResultsCountRequestMultiError) AllErrors() []error { return m }
+
+// GetQueryResultsCountRequestValidationError is the validation error returned
+// by GetQueryResultsCountRequest.Validate if the designated constraints
+// aren't met.
+type GetQueryResultsCountRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetQueryResultsCountRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetQueryResultsCountRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetQueryResultsCountRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetQueryResultsCountRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetQueryResultsCountRequestValidationError) ErrorName() string {
+	return "GetQueryResultsCountRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetQueryResultsCountRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetQueryResultsCountRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetQueryResultsCountRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetQueryResultsCountRequestValidationError{}
+
+// Validate checks the field values on GetQueryResultsCountResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *GetQueryResultsCountResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetQueryResultsCountResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// GetQueryResultsCountResponseMultiError, or nil if none found.
+func (m *GetQueryResultsCountResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetQueryResultsCountResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Count
+
+	if len(errors) > 0 {
+		return GetQueryResultsCountResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetQueryResultsCountResponseMultiError is an error wrapping multiple
+// validation errors returned by GetQueryResultsCountResponse.ValidateAll() if
+// the designated constraints aren't met.
+type GetQueryResultsCountResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetQueryResultsCountResponseMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetQueryResultsCountResponseMultiError) AllErrors() []error { return m }
+
+// GetQueryResultsCountResponseValidationError is the validation error returned
+// by GetQueryResultsCountResponse.Validate if the designated constraints
+// aren't met.
+type GetQueryResultsCountResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetQueryResultsCountResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetQueryResultsCountResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetQueryResultsCountResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetQueryResultsCountResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetQueryResultsCountResponseValidationError) ErrorName() string {
+	return "GetQueryResultsCountResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetQueryResultsCountResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetQueryResultsCountResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetQueryResultsCountResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetQueryResultsCountResponseValidationError{}

--- a/frontend/api/src/index.d.ts
+++ b/frontend/api/src/index.d.ts
@@ -25804,6 +25804,102 @@ export namespace clutch {
                  */
                 public toJSON(): { [k: string]: any };
             }
+
+            /** Properties of a GetQueryResultsCountRequest. */
+            interface IGetQueryResultsCountRequest {
+
+                /** GetQueryResultsCountRequest query */
+                query?: (string|null);
+            }
+
+            /** Represents a GetQueryResultsCountRequest. */
+            class GetQueryResultsCountRequest implements IGetQueryResultsCountRequest {
+
+                /**
+                 * Constructs a new GetQueryResultsCountRequest.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: clutch.sourcegraph.v1.IGetQueryResultsCountRequest);
+
+                /** GetQueryResultsCountRequest query. */
+                public query: string;
+
+                /**
+                 * Verifies a GetQueryResultsCountRequest message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a GetQueryResultsCountRequest message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns GetQueryResultsCountRequest
+                 */
+                public static fromObject(object: { [k: string]: any }): clutch.sourcegraph.v1.GetQueryResultsCountRequest;
+
+                /**
+                 * Creates a plain object from a GetQueryResultsCountRequest message. Also converts values to other types if specified.
+                 * @param message GetQueryResultsCountRequest
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: clutch.sourcegraph.v1.GetQueryResultsCountRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this GetQueryResultsCountRequest to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            /** Properties of a GetQueryResultsCountResponse. */
+            interface IGetQueryResultsCountResponse {
+
+                /** GetQueryResultsCountResponse count */
+                count?: (number|null);
+            }
+
+            /** Represents a GetQueryResultsCountResponse. */
+            class GetQueryResultsCountResponse implements IGetQueryResultsCountResponse {
+
+                /**
+                 * Constructs a new GetQueryResultsCountResponse.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: clutch.sourcegraph.v1.IGetQueryResultsCountResponse);
+
+                /** GetQueryResultsCountResponse count. */
+                public count: number;
+
+                /**
+                 * Verifies a GetQueryResultsCountResponse message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a GetQueryResultsCountResponse message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns GetQueryResultsCountResponse
+                 */
+                public static fromObject(object: { [k: string]: any }): clutch.sourcegraph.v1.GetQueryResultsCountResponse;
+
+                /**
+                 * Creates a plain object from a GetQueryResultsCountResponse message. Also converts values to other types if specified.
+                 * @param message GetQueryResultsCountResponse
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: clutch.sourcegraph.v1.GetQueryResultsCountResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this GetQueryResultsCountResponse to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
         }
     }
 

--- a/frontend/api/src/index.js
+++ b/frontend/api/src/index.js
@@ -61975,6 +61975,206 @@ export const clutch = $root.clutch = (() => {
                 return Commit;
             })();
 
+            v1.GetQueryResultsCountRequest = (function() {
+
+                /**
+                 * Properties of a GetQueryResultsCountRequest.
+                 * @memberof clutch.sourcegraph.v1
+                 * @interface IGetQueryResultsCountRequest
+                 * @property {string|null} [query] GetQueryResultsCountRequest query
+                 */
+
+                /**
+                 * Constructs a new GetQueryResultsCountRequest.
+                 * @memberof clutch.sourcegraph.v1
+                 * @classdesc Represents a GetQueryResultsCountRequest.
+                 * @implements IGetQueryResultsCountRequest
+                 * @constructor
+                 * @param {clutch.sourcegraph.v1.IGetQueryResultsCountRequest=} [properties] Properties to set
+                 */
+                function GetQueryResultsCountRequest(properties) {
+                    if (properties)
+                        for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * GetQueryResultsCountRequest query.
+                 * @member {string} query
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountRequest
+                 * @instance
+                 */
+                GetQueryResultsCountRequest.prototype.query = "";
+
+                /**
+                 * Verifies a GetQueryResultsCountRequest message.
+                 * @function verify
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountRequest
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                GetQueryResultsCountRequest.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.query != null && message.hasOwnProperty("query"))
+                        if (!$util.isString(message.query))
+                            return "query: string expected";
+                    return null;
+                };
+
+                /**
+                 * Creates a GetQueryResultsCountRequest message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountRequest
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {clutch.sourcegraph.v1.GetQueryResultsCountRequest} GetQueryResultsCountRequest
+                 */
+                GetQueryResultsCountRequest.fromObject = function fromObject(object) {
+                    if (object instanceof $root.clutch.sourcegraph.v1.GetQueryResultsCountRequest)
+                        return object;
+                    let message = new $root.clutch.sourcegraph.v1.GetQueryResultsCountRequest();
+                    if (object.query != null)
+                        message.query = String(object.query);
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a GetQueryResultsCountRequest message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountRequest
+                 * @static
+                 * @param {clutch.sourcegraph.v1.GetQueryResultsCountRequest} message GetQueryResultsCountRequest
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                GetQueryResultsCountRequest.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    let object = {};
+                    if (options.defaults)
+                        object.query = "";
+                    if (message.query != null && message.hasOwnProperty("query"))
+                        object.query = message.query;
+                    return object;
+                };
+
+                /**
+                 * Converts this GetQueryResultsCountRequest to JSON.
+                 * @function toJSON
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountRequest
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                GetQueryResultsCountRequest.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return GetQueryResultsCountRequest;
+            })();
+
+            v1.GetQueryResultsCountResponse = (function() {
+
+                /**
+                 * Properties of a GetQueryResultsCountResponse.
+                 * @memberof clutch.sourcegraph.v1
+                 * @interface IGetQueryResultsCountResponse
+                 * @property {number|null} [count] GetQueryResultsCountResponse count
+                 */
+
+                /**
+                 * Constructs a new GetQueryResultsCountResponse.
+                 * @memberof clutch.sourcegraph.v1
+                 * @classdesc Represents a GetQueryResultsCountResponse.
+                 * @implements IGetQueryResultsCountResponse
+                 * @constructor
+                 * @param {clutch.sourcegraph.v1.IGetQueryResultsCountResponse=} [properties] Properties to set
+                 */
+                function GetQueryResultsCountResponse(properties) {
+                    if (properties)
+                        for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * GetQueryResultsCountResponse count.
+                 * @member {number} count
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountResponse
+                 * @instance
+                 */
+                GetQueryResultsCountResponse.prototype.count = 0;
+
+                /**
+                 * Verifies a GetQueryResultsCountResponse message.
+                 * @function verify
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountResponse
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                GetQueryResultsCountResponse.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.count != null && message.hasOwnProperty("count"))
+                        if (!$util.isInteger(message.count))
+                            return "count: integer expected";
+                    return null;
+                };
+
+                /**
+                 * Creates a GetQueryResultsCountResponse message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountResponse
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {clutch.sourcegraph.v1.GetQueryResultsCountResponse} GetQueryResultsCountResponse
+                 */
+                GetQueryResultsCountResponse.fromObject = function fromObject(object) {
+                    if (object instanceof $root.clutch.sourcegraph.v1.GetQueryResultsCountResponse)
+                        return object;
+                    let message = new $root.clutch.sourcegraph.v1.GetQueryResultsCountResponse();
+                    if (object.count != null)
+                        message.count = object.count >>> 0;
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a GetQueryResultsCountResponse message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountResponse
+                 * @static
+                 * @param {clutch.sourcegraph.v1.GetQueryResultsCountResponse} message GetQueryResultsCountResponse
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                GetQueryResultsCountResponse.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    let object = {};
+                    if (options.defaults)
+                        object.count = 0;
+                    if (message.count != null && message.hasOwnProperty("count"))
+                        object.count = message.count;
+                    return object;
+                };
+
+                /**
+                 * Converts this GetQueryResultsCountResponse to JSON.
+                 * @function toJSON
+                 * @memberof clutch.sourcegraph.v1.GetQueryResultsCountResponse
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                GetQueryResultsCountResponse.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                return GetQueryResultsCountResponse;
+            })();
+
             return v1;
         })();
 


### PR DESCRIPTION
### Description

- Add method to Sourcegraph service to get count from the results of a query
 
### Testing Performed

manual
