### PR TITLE
frontend: Refactor workflows to use new layout and spacing units

### DIFF
--- a/frontend/packages/app/src/index.jsx
+++ b/frontend/packages/app/src/index.jsx
@@ -9,10 +9,6 @@ import "./index.css";
 const config = require("./clutch.config");
 
 ReactDOM.render(
-  <ClutchApp
-    availableWorkflows={registeredWorkflows}
-    configuration={config}
-    appConfiguration={{ enableWorkflowLayout: true }}
-  />,
+  <ClutchApp availableWorkflows={registeredWorkflows} configuration={config} />,
   document.getElementById("root")
 );

--- a/frontend/packages/app/src/index.jsx
+++ b/frontend/packages/app/src/index.jsx
@@ -9,6 +9,10 @@ import "./index.css";
 const config = require("./clutch.config");
 
 ReactDOM.render(
-  <ClutchApp availableWorkflows={registeredWorkflows} configuration={config} />,
+  <ClutchApp
+    availableWorkflows={registeredWorkflows}
+    configuration={config}
+    appConfiguration={{ enableWorkflowLayout: true }}
+  />,
   document.getElementById("root")
 );

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -216,10 +216,9 @@ const ClutchApp = ({
                               ? `${workflow.displayName}: ${route.displayName}`
                               : workflow.displayName;
 
-                            // We define these props in order to avoid UI changes before refactoring
                             const workflowLayoutProps: LayoutProps = {
                               ...route.layoutProps,
-                              heading: route.layoutProps?.heading || heading,
+                              title: route.layoutProps?.title || heading,
                               workflow,
                             };
 

--- a/frontend/packages/core/src/Breadcrumbs/index.tsx
+++ b/frontend/packages/core/src/Breadcrumbs/index.tsx
@@ -12,7 +12,6 @@ interface BreadcrumbsProps {
 }
 
 const StyledBreadcrumbs = styled(MuiBreadcrumbs)(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(theme.clutch.spacing.sm, theme.clutch.spacing.none),
   "& .MuiBreadcrumbs-separator": {
     color: alpha(theme.colors.neutral[900], 0.6),
   },

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -112,7 +112,7 @@ const WorkflowLayout = ({
   );
 
   if (variant === "custom") {
-    return children;
+    return <>{children}</>;
   }
 
   return (

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -19,7 +19,7 @@ export type LayoutProps = {
   variant?: LayoutVariant;
   title?: string | ((params: Params) => string);
   subtitle?: string;
-  onlyBreadcrumbs?: boolean;
+  breadcrumbsOnly?: boolean;
   hideHeader?: boolean;
 };
 
@@ -97,7 +97,7 @@ const WorkflowLayout = ({
   variant = "standard",
   title = null,
   subtitle = null,
-  onlyBreadcrumbs = false,
+  breadcrumbsOnly = false,
   hideHeader = false,
   children,
 }: React.PropsWithChildren<LayoutProps>) => {
@@ -120,10 +120,10 @@ const WorkflowLayout = ({
     <LayoutContainer $variant={variant}>
       {!hideHeader && (
         <PageHeader $variant={variant}>
-          <PageHeaderBreadcrumbsWrapper $onlyBreadcrumbs={onlyBreadcrumbs}>
+          <PageHeaderBreadcrumbsWrapper>
             <Breadcrumbs entries={breadcrumbsEntries} />
           </PageHeaderBreadcrumbsWrapper>
-          {!onlyBreadcrumbs && (
+          {!breadcrumbsOnly && (title || subtitle) && (
             <PageHeaderMainContainer>
               <PageHeaderInformation>
                 {title && (

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -13,7 +13,7 @@ import { generateBreadcrumbsEntries } from "../utils";
 export type LayoutVariant = "standard" | "wizard" | "custom";
 
 export type LayoutProps = {
-  workflow: Workflow;
+  workflow?: Workflow;
   variant?: LayoutVariant;
   heading?: string | React.ReactElement;
   hideHeader?: boolean;
@@ -56,13 +56,20 @@ const LayoutContainer = styled("div")(
 
 const PageHeader = styled("div")(({ $variant, theme }: StyledVariantComponentProps) => ({
   padding: theme.spacing(
-    theme.clutch.spacing.base,
+    theme.clutch.spacing.none,
     $variant === "wizard" ? theme.clutch.spacing.md : theme.clutch.spacing.none
   ),
+  paddingBottom: theme.spacing(theme.clutch.spacing.base),
   width: "100%",
 }));
 
-const HeaderTitle = styled(Typography)({
+const PageHeaderMainContainer = styled("div")({
+  display: "flex",
+  alignItems: "center",
+  height: "70px",
+});
+
+const Heading = styled(Typography)({
   lineHeight: 1,
 });
 
@@ -74,11 +81,11 @@ const WorkflowLayout = ({
   children,
 }: React.PropsWithChildren<LayoutProps>) => {
   const location = useLocation();
-  const workflowPaths = workflow.routes.map(({ path }) => `/${workflow.path}/${path}`);
+  const workflowPaths = workflow?.routes.map(({ path }) => `/${workflow?.path}/${path}`);
   const breadcrumbsEntries = generateBreadcrumbsEntries(
     location,
     (url: string) =>
-      `/${workflow.path}` !== url &&
+      `/${workflow?.path}` !== url &&
       !workflowPaths.includes(url) &&
       !workflowPaths.find(path => !!matchPath({ path }, url))
   );
@@ -88,15 +95,17 @@ const WorkflowLayout = ({
       {!hideHeader && (
         <PageHeader $variant={variant}>
           <Breadcrumbs entries={breadcrumbsEntries} />
-          {heading && (
-            <>
-              {React.isValidElement(heading) ? (
-                heading
-              ) : (
-                <HeaderTitle variant="h2">{heading}</HeaderTitle>
-              )}
-            </>
-          )}
+          <PageHeaderMainContainer>
+            {heading && (
+              <>
+                {React.isValidElement(heading) ? (
+                  heading
+                ) : (
+                  <Heading variant="h2">{heading}</Heading>
+                )}
+              </>
+            )}
+          </PageHeaderMainContainer>
         </PageHeader>
       )}
       {children}

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { matchPath } from "react-router";
+import { matchPath, Params, useParams } from "react-router";
 import type { Interpolation } from "@emotion/styled";
 import type { CSSObject, Theme } from "@mui/material";
+import { alpha } from "@mui/system";
 
 import type { Workflow } from "../AppProvider/workflow";
 import Breadcrumbs from "../Breadcrumbs";
@@ -12,10 +13,13 @@ import { generateBreadcrumbsEntries } from "../utils";
 
 export type LayoutVariant = "standard" | "wizard" | "custom";
 
+// TODO: Define valid type variants
 export type LayoutProps = {
   workflow?: Workflow;
   variant?: LayoutVariant;
-  heading?: string | React.ReactElement;
+  title?: string | ((params: Params) => string);
+  subtitle?: string;
+  onlyBreadcrumbs?: boolean;
   hideHeader?: boolean;
 };
 
@@ -43,8 +47,7 @@ const getContainerVariantStyles = (variant: LayoutVariant, theme: Theme) => {
       padding: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
       margin: theme.spacing(theme.clutch.spacing.none, "auto"),
     },
-    // No styles
-    custom: {},
+    custom: {}, // No styles,
   };
   return layoutVariantStylesMap[variant];
 };
@@ -59,27 +62,45 @@ const PageHeader = styled("div")(({ $variant, theme }: StyledVariantComponentPro
     theme.clutch.spacing.none,
     $variant === "wizard" ? theme.clutch.spacing.md : theme.clutch.spacing.none
   ),
-  paddingBottom: theme.spacing(theme.clutch.spacing.base),
   width: "100%",
 }));
 
-const PageHeaderMainContainer = styled("div")({
+const PageHeaderBreadcrumbsWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
+  marginBottom: theme.spacing(theme.clutch.spacing.xs),
+}));
+
+const PageHeaderMainContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   alignItems: "center",
   height: "70px",
+  marginBottom: theme.spacing(theme.clutch.spacing.sm),
+}));
+
+const PageHeaderInformation = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-evenly",
+  height: "100%",
 });
 
-const Heading = styled(Typography)({
+const Title = styled(Typography)({
   lineHeight: 1,
 });
+
+const Subtitle = styled(Typography)(({ theme }: { theme: Theme }) => ({
+  color: alpha(theme.colors.neutral[900], 0.45),
+}));
 
 const WorkflowLayout = ({
   workflow,
   variant = "standard",
-  heading = null,
+  title = null,
+  subtitle = null,
+  onlyBreadcrumbs = false,
   hideHeader = false,
   children,
 }: React.PropsWithChildren<LayoutProps>) => {
+  const params = useParams();
   const location = useLocation();
   const workflowPaths = workflow?.routes.map(({ path }) => `/${workflow?.path}/${path}`);
   const breadcrumbsEntries = generateBreadcrumbsEntries(
@@ -90,22 +111,29 @@ const WorkflowLayout = ({
       !workflowPaths.find(path => !!matchPath({ path }, url))
   );
 
+  if (variant === "custom") {
+    return children;
+  }
+
   return (
     <LayoutContainer $variant={variant}>
       {!hideHeader && (
         <PageHeader $variant={variant}>
-          <Breadcrumbs entries={breadcrumbsEntries} />
-          <PageHeaderMainContainer>
-            {heading && (
-              <>
-                {React.isValidElement(heading) ? (
-                  heading
-                ) : (
-                  <Heading variant="h2">{heading}</Heading>
+          <PageHeaderBreadcrumbsWrapper $onlyBreadcrumbs={onlyBreadcrumbs}>
+            <Breadcrumbs entries={breadcrumbsEntries} />
+          </PageHeaderBreadcrumbsWrapper>
+          {!onlyBreadcrumbs && (
+            <PageHeaderMainContainer>
+              <PageHeaderInformation>
+                {title && (
+                  <Title variant="h2" textTransform="capitalize">
+                    {typeof title === "function" ? title(params) : title}
+                  </Title>
                 )}
-              </>
-            )}
-          </PageHeaderMainContainer>
+                {subtitle && <Subtitle variant="subtitle2">{subtitle}</Subtitle>}
+              </PageHeaderInformation>
+            </PageHeaderMainContainer>
+          )}
         </PageHeader>
       )}
       {children}

--- a/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
+++ b/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
@@ -3,7 +3,7 @@ import type { Location } from "history";
 import type { BreadcrumbEntry } from "../Breadcrumbs";
 
 const generateBreadcrumbsEntries = (location: Location, validateUrl: (url: string) => boolean) => {
-  const labels = location.pathname
+  const labels = decodeURIComponent(location.pathname)
     .split("/")
     .slice(1, location.pathname.endsWith("/") ? -1 : undefined);
 

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -72,7 +72,6 @@ const Header = styled(Grid)<{ $orientation: MuiStepperProps["orientation"] }>(
 
 const Container = styled(MuiContainer)<{ $width: ContainerProps["width"] }>(
   {
-    paddingBlock: "24px 32px",
     height: "calc(100% - 56px)",
   },
   props => ({

--- a/frontend/workflows/audit/src/audit-event.tsx
+++ b/frontend/workflows/audit/src/audit-event.tsx
@@ -8,7 +8,7 @@ import type { WorkflowProps } from ".";
 
 const ENDPOINT = "/v1/audit/getEvent";
 
-const AuditEvent: React.FC<WorkflowProps> = ({ heading }) => {
+const AuditEvent: React.FC<WorkflowProps> = () => {
   const params = useParams();
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
   const [event, setEvent] = React.useState<IClutch.audit.v1.IEvent>();

--- a/frontend/workflows/audit/src/audit-event.tsx
+++ b/frontend/workflows/audit/src/audit-event.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactJson from "react-json-view";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { client, ClutchError, Error, Loadable, Typography, useParams } from "@clutch-sh/core";
+import { client, ClutchError, Error, Loadable, useParams } from "@clutch-sh/core";
 import { Stack } from "@mui/material";
 
 import type { WorkflowProps } from ".";

--- a/frontend/workflows/audit/src/audit-event.tsx
+++ b/frontend/workflows/audit/src/audit-event.tsx
@@ -37,8 +37,7 @@ const AuditEvent: React.FC<WorkflowProps> = ({ heading }) => {
   React.useEffect(() => fetch(), []);
 
   return (
-    <Stack spacing={2} direction="column" style={{ padding: "32px" }}>
-      <Typography variant="h2">{heading}</Typography>
+    <Stack spacing={2} direction="column">
       <Loadable isLoading={isLoading}>
         {error && <Error subject={error} />}
         <ReactJson

--- a/frontend/workflows/audit/src/index.tsx
+++ b/frontend/workflows/audit/src/index.tsx
@@ -25,6 +25,9 @@ const register = (): WorkflowConfiguration => {
         displayName: "Logs",
         description: "View audit log",
         component: AuditLog,
+        layoutProps: {
+          variant: "standard",
+        },
       },
       event: {
         path: "/event/:id",
@@ -32,6 +35,9 @@ const register = (): WorkflowConfiguration => {
         description: "View audit event",
         component: AuditEvent,
         hideNav: true,
+        layoutProps: {
+          variant: "standard",
+        },
       },
     },
   };

--- a/frontend/workflows/audit/src/logs/event-row.tsx
+++ b/frontend/workflows/audit/src/logs/event-row.tsx
@@ -18,7 +18,7 @@ const ENDPOINT = "/v1/audit/getEvents";
 const COLUMN_COUNT = 6;
 const MonospaceText = styled("div")(({ theme }: { theme: Theme }) => ({
   fontFamily: "monospace",
-  padding: "8px",
+  padding: theme.spacing(theme.clutch.spacing.sm),
   border: "1px solid lightgray",
   borderRadius: "8px",
   background: theme.palette.secondary[200],
@@ -26,6 +26,10 @@ const MonospaceText = styled("div")(({ theme }: { theme: Theme }) => ({
   textOverflow: "ellipsis",
   whiteSpace: "pre",
   maxWidth: "400px",
+}));
+
+const ReactJsonWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
+  padding: theme.spacing(theme.clutch.spacing.sm),
 }));
 
 interface EventRowAction {
@@ -125,14 +129,15 @@ const EventRow = ({ event, detailsPathPrefix, downloadPrefix }: EventRowProps) =
       </TableRow>
       {open && (
         <TableRow colSpan={COLUMN_COUNT}>
-          <ReactJson
-            src={event}
-            name={null}
-            groupArraysAfterLength={5}
-            displayDataTypes={false}
-            collapsed={2}
-            style={{ padding: "8px" }}
-          />
+          <ReactJsonWrapper>
+            <ReactJson
+              src={event}
+              name={null}
+              groupArraysAfterLength={5}
+              displayDataTypes={false}
+              collapsed={2}
+            />
+          </ReactJsonWrapper>
         </TableRow>
       )}
       <Popper open={showActions} anchorRef={anchorRef} onClickAway={() => setShowActions(false)}>

--- a/frontend/workflows/audit/src/logs/index.tsx
+++ b/frontend/workflows/audit/src/logs/index.tsx
@@ -6,7 +6,6 @@ import {
   IconButton,
   styled,
   Table,
-  Typography,
   useSearchParams,
   useTheme,
 } from "@clutch-sh/core";
@@ -19,7 +18,6 @@ import { DateTimeRangeSelector, QUICK_TIME_OPTIONS } from "./date-selector";
 import EventRows from "./event-row";
 
 const RootContainer = styled(Stack)({
-  padding: "32px",
   height: "100%",
 });
 
@@ -39,7 +37,7 @@ const LoadingSpinner = styled(CircularProgress)(({ theme }: { theme: Theme }) =>
   position: "absolute",
 }));
 
-const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloadPrefix }) => {
+const AuditLog: React.FC<AuditLogProps> = ({ detailsPathPrefix, downloadPrefix }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [now] = React.useState<Date>(new Date());
   const [timeRangeKey, setTimeRangeKey] = React.useState<string>("");
@@ -74,7 +72,6 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
   const genTimeRangeKey = () => `${startTime}-${endTime}-${new Date().toString()}`;
   return (
     <RootContainer spacing={2} direction="column">
-      <Typography variant="h2">{heading}</Typography>
       <Stack direction="column" spacing={2}>
         <Stack
           direction={shrink ? "column" : "row"}

--- a/frontend/workflows/dynamodb/src/index.tsx
+++ b/frontend/workflows/dynamodb/src/index.tsx
@@ -33,6 +33,9 @@ const register = (): WorkflowConfiguration => {
         displayName: "Update Capacity",
         description: "Update the table or GSI provisioned capacity.",
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
     },
   };

--- a/frontend/workflows/dynamodb/src/update-capacity.tsx
+++ b/frontend/workflows/dynamodb/src/update-capacity.tsx
@@ -282,7 +282,7 @@ const UpdateCapacity: React.FC<WorkflowProps> = ({
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <TableIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
       <TableDetails name="Modify" enableOverride={enableOverride} notes={notes} />
       <Confirm name="Results" />

--- a/frontend/workflows/ec2/src/index.tsx
+++ b/frontend/workflows/ec2/src/index.tsx
@@ -33,6 +33,9 @@ const register = (): WorkflowConfiguration => {
         description: "Terminate an EC2 instance.",
         component: TerminateInstance,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
       rebootInstance: {
         path: "instance/reboot",
@@ -40,6 +43,9 @@ const register = (): WorkflowConfiguration => {
         description: "Reboot an EC2 Instance",
         component: RebootInstance,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
       resizeAutoscalingGroup: {
         path: "asg/resize",
@@ -47,6 +53,9 @@ const register = (): WorkflowConfiguration => {
         description: "Resize an autoscaling group.",
         component: ResizeAutoscalingGroup,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
     },
   };

--- a/frontend/workflows/ec2/src/reboot-instance.tsx
+++ b/frontend/workflows/ec2/src/reboot-instance.tsx
@@ -89,7 +89,7 @@ const RebootInstance: React.FC<WorkflowProps> = ({ heading, resolverType, notes 
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Verify" />
       <Confirm name="Result" notes={notes} />

--- a/frontend/workflows/ec2/src/resize-asg.tsx
+++ b/frontend/workflows/ec2/src/resize-asg.tsx
@@ -134,7 +134,7 @@ const ResizeAutoscalingGroup: React.FC<WorkflowProps> = ({ heading, resolverType
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <GroupIdentifier name="Lookup" resolverType={resolverType} />
       <GroupDetails name="Modify" />
       <Confirm name="Result" notes={notes} />

--- a/frontend/workflows/ec2/src/terminate-instance.tsx
+++ b/frontend/workflows/ec2/src/terminate-instance.tsx
@@ -108,7 +108,7 @@ const TerminateInstance: React.FC<WorkflowProps> = ({ heading, resolverType, not
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <InstanceIdentifier name="Lookup" resolverType={resolverType} />
       <InstanceDetails name="Verify" />
       <Confirm name="Result" notes={notes} />

--- a/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/reboot-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1s2y8jy-MuiContainer-root"
+    class="MuiContainer-root css-1so714y-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container css-1yw6yql-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/resize-asg.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1s2y8jy-MuiContainer-root"
+    class="MuiContainer-root css-1so714y-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container css-1yw6yql-MuiGrid-root"

--- a/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
+++ b/frontend/workflows/ec2/src/tests/__snapshots__/terminate-instance.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1s2y8jy-MuiContainer-root"
+    class="MuiContainer-root css-1so714y-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container css-1yw6yql-MuiGrid-root"

--- a/frontend/workflows/envoy/src/index.tsx
+++ b/frontend/workflows/envoy/src/index.tsx
@@ -25,6 +25,9 @@ const register = (): WorkflowConfiguration => {
         component: RemoteTriage,
         displayName: "Remote Triage",
         description: "Triage Envoy configurations.",
+        layoutProps: {
+          variant: "wizard",
+        },
       },
     },
   };

--- a/frontend/workflows/envoy/src/remote-triage/dashboard.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/dashboard.tsx
@@ -93,9 +93,9 @@ const SummariesContainer = styled(Grid)({
   flexBasis: "40%",
 });
 
-const InformationContainer = styled("div")({
-  padding: "16px 0",
-});
+const InformationContainer = styled("div")(({ theme }: { theme: Theme }) => ({
+  padding: theme.spacing(theme.clutch.spacing.base, theme.clutch.spacing.none),
+}));
 
 interface DashboardProps {
   serverInfo: IClutch.envoytriage.v1.IServerInfo;

--- a/frontend/workflows/envoy/src/remote-triage/index.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/index.tsx
@@ -172,7 +172,7 @@ const RemoteTriage: React.FC<WorkflowProps> = ({ heading }) => {
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <TriageIdentifier name="Lookup" host={hostParam} />
       <TriageDetails name="Details" />
     </Wizard>

--- a/frontend/workflows/envoy/src/remote-triage/server-info.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/server-info.tsx
@@ -3,11 +3,11 @@ import type { clutch as IClutch } from "@clutch-sh/api";
 import { MetadataTable, styled } from "@clutch-sh/core";
 import type { Theme } from "@mui/material";
 
-const Container = styled("div")({
+const Container = styled("div")(({ theme }: { theme: Theme }) => ({
   "> *": {
-    padding: "8px 0",
+    padding: theme.spacing(theme.clutch.spacing.sm, theme.clutch.spacing.none),
   },
-});
+}));
 
 const Title = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: "bold",

--- a/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
+++ b/frontend/workflows/envoy/src/tests/__snapshots__/remote-triage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1s2y8jy-MuiContainer-root"
+    class="MuiContainer-root css-1so714y-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container css-1yw6yql-MuiGrid-root"

--- a/frontend/workflows/experimentation/src/core/page-layout.tsx
+++ b/frontend/workflows/experimentation/src/core/page-layout.tsx
@@ -1,36 +1,19 @@
 import React from "react";
 import type { ClutchError } from "@clutch-sh/core";
 import { Error } from "@clutch-sh/core";
-import styled from "@emotion/styled";
-import { Container, Grid, Typography } from "@mui/material";
-
-const PageContainer = styled.div({
-  display: "flex",
-  flex: "1 auto",
-  margin: "30px",
-});
-
-const Heading = styled(Typography)({
-  padding: "16px 0",
-});
+import { Grid } from "@mui/material";
 
 interface PageLayoutProps {
-  heading: string;
   error?: ClutchError;
 }
 
-const PageLayout: React.FC<PageLayoutProps> = ({ heading, error, children }) => {
+const PageLayout: React.FC<PageLayoutProps> = ({ error, children }) => {
   const hasError = error !== undefined && error !== null;
   return (
-    <PageContainer>
-      <Container>
-        <Heading variant="h5">
-          <strong>{heading}</strong>
-        </Heading>
-        {hasError && <Error subject={error} />}
-        <Grid>{children}</Grid>
-      </Container>
-    </PageContainer>
+    <Grid spacing={2}>
+      {hasError && <Error subject={error} />}
+      <Grid>{children}</Grid>
+    </Grid>
   );
 };
 

--- a/frontend/workflows/experimentation/src/index.tsx
+++ b/frontend/workflows/experimentation/src/index.tsx
@@ -20,6 +20,9 @@ const register = (): WorkflowConfiguration => {
         displayName: "Manage Experiments",
         description: "Manage experiments.",
         component: ListExperiments,
+        layoutProps: {
+          variant: "standard",
+        },
       },
       viewExperimentRun: {
         path: "run/:runID",
@@ -27,6 +30,9 @@ const register = (): WorkflowConfiguration => {
         description: "View Experiment Run.",
         hideNav: true,
         component: ViewExperimentRun,
+        layoutProps: {
+          variant: "standard",
+        },
       },
     },
   };

--- a/frontend/workflows/experimentation/src/list-experiments.tsx
+++ b/frontend/workflows/experimentation/src/list-experiments.tsx
@@ -17,7 +17,7 @@ interface ListExperimentsProps extends BaseWorkflowProps {
   links: ExperimentTypeLinkProps[];
 }
 
-const ListExperiments: React.FC<ListExperimentsProps> = ({ heading, columns, links }) => {
+const ListExperiments: React.FC<ListExperimentsProps> = ({ columns, links }) => {
   const [experiments, setExperiments] = useState<
     IClutch.chaos.experimentation.v1.ListViewItem[] | undefined
   >(undefined);
@@ -45,7 +45,7 @@ const ListExperiments: React.FC<ListExperimentsProps> = ({ heading, columns, lin
   ));
 
   return (
-    <PageLayout heading={heading} error={error}>
+    <PageLayout error={error}>
       <ButtonGroup justify="center" border="bottom">
         {buttons}
       </ButtonGroup>

--- a/frontend/workflows/experimentation/src/tests/__snapshots__/list-experiments.test.tsx.snap
+++ b/frontend/workflows/experimentation/src/tests/__snapshots__/list-experiments.test.tsx.snap
@@ -3,165 +3,154 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-hbp9t2"
+    class="MuiGrid-root css-vj1n65-MuiGrid-root"
   >
     <div
-      class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
+      class="MuiGrid-root css-vj1n65-MuiGrid-root"
     >
-      <h5
-        class="MuiTypography-root MuiTypography-h5 css-q2f0a7-MuiTypography-root"
-      >
-        <strong>
-          List Experiments
-        </strong>
-      </h5>
       <div
-        class="MuiGrid-root css-vj1n65-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-container css-n7th3n-MuiGrid-root"
+        data-border="bottom"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
+          palette="[object Object]"
+          tabindex="0"
+          type="button"
+        >
+          button_1
+        </button>
+      </div>
+      <div
+        class="makeStyles-root-1"
       >
         <div
-          class="MuiGrid-root MuiGrid-container css-n7th3n-MuiGrid-root"
-          data-border="bottom"
-        >
-          <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
-            palette="[object Object]"
-            tabindex="0"
-            type="button"
-          >
-            button_1
-          </button>
-        </div>
-        <div
-          class="makeStyles-root-1"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-2 css-7rsy2y-MuiPaper-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 makeStyles-paper-2 css-7rsy2y-MuiPaper-root"
+            class="MuiTableContainer-root css-qv4bde-MuiTableContainer-root"
+          >
+            <table
+              class="MuiTable-root makeStyles-table-3 css-lcoyas-MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head css-1tdc4lx-MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yn1iza-MuiTableCell-root"
+                    scope="col"
+                  >
+                    column 1
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yn1iza-MuiTableCell-root"
+                    scope="col"
+                  >
+                    column 2
+                  </th>
+                </tr>
+              </thead>
+            </table>
+          </div>
+          <div
+            class="MuiTablePagination-root css-65m9ee-MuiTablePagination-root"
           >
             <div
-              class="MuiTableContainer-root css-qv4bde-MuiTableContainer-root"
-            >
-              <table
-                class="MuiTable-root makeStyles-table-3 css-lcoyas-MuiTable-root"
-              >
-                <thead
-                  class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
-                >
-                  <tr
-                    class="MuiTableRow-root MuiTableRow-head css-1tdc4lx-MuiTableRow-root"
-                  >
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yn1iza-MuiTableCell-root"
-                      scope="col"
-                    >
-                      column 1
-                    </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-yn1iza-MuiTableCell-root"
-                      scope="col"
-                    >
-                      column 2
-                    </th>
-                  </tr>
-                </thead>
-              </table>
-            </div>
-            <div
-              class="MuiTablePagination-root css-65m9ee-MuiTablePagination-root"
+              class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
             >
               <div
-                class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+                class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+              />
+              <p
+                class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+                id="mui-2"
+              >
+                Rows per page:
+              </p>
+              <div
+                class="MuiInputBase-root MuiInputBase-colorPrimary css-mc49up-MuiInputBase-root-MuiTablePagination-select"
+                variant="standard"
               >
                 <div
-                  class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  aria-labelledby="mui-2 mui-1"
+                  class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-jok20x-MuiSelect-select-MuiInputBase-input"
+                  id="mui-1"
+                  role="button"
+                  tabindex="0"
+                >
+                  25
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="25"
                 />
-                <p
-                  class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
-                  id="mui-2"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-3d1nhz-MuiSvgIcon-root-MuiSelect-icon"
+                  data-testid="ArrowDropDownIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  Rows per page:
-                </p>
-                <div
-                  class="MuiInputBase-root MuiInputBase-colorPrimary css-mc49up-MuiInputBase-root-MuiTablePagination-select"
-                  variant="standard"
-                >
-                  <div
-                    aria-expanded="false"
-                    aria-haspopup="listbox"
-                    aria-labelledby="mui-2 mui-1"
-                    class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-jok20x-MuiSelect-select-MuiInputBase-input"
-                    id="mui-1"
-                    role="button"
-                    tabindex="0"
-                  >
-                    25
-                  </div>
-                  <input
-                    aria-hidden="true"
-                    class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                    tabindex="-1"
-                    value="25"
+                  <path
+                    d="M7 10l5 5 5-5z"
                   />
+                </svg>
+              </div>
+              <p
+                class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+              >
+                0–0 of 0
+              </p>
+              <div
+                class="MuiTablePagination-actions"
+              >
+                <button
+                  aria-label="Go to previous page"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1slblf2-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  title="Go to previous page"
+                  type="button"
+                >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-3d1nhz-MuiSvgIcon-root-MuiSelect-icon"
-                    data-testid="ArrowDropDownIcon"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowLeftIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
                     <path
-                      d="M7 10l5 5 5-5z"
+                      d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
                     />
                   </svg>
-                </div>
-                <p
-                  class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+                </button>
+                <button
+                  aria-label="Go to next page"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1slblf2-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  title="Go to next page"
+                  type="button"
                 >
-                  0–0 of 0
-                </p>
-                <div
-                  class="MuiTablePagination-actions"
-                >
-                  <button
-                    aria-label="Go to previous page"
-                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1slblf2-MuiButtonBase-root-MuiIconButton-root"
-                    disabled=""
-                    tabindex="-1"
-                    title="Go to previous page"
-                    type="button"
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowLeftIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    aria-label="Go to next page"
-                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1slblf2-MuiButtonBase-root-MuiIconButton-root"
-                    disabled=""
-                    tabindex="-1"
-                    title="Go to next page"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowRightIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                    <path
+                      d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>

--- a/frontend/workflows/experimentation/src/tests/__snapshots__/view-experiment-run.test.tsx.snap
+++ b/frontend/workflows/experimentation/src/tests/__snapshots__/view-experiment-run.test.tsx.snap
@@ -3,23 +3,14 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-hbp9t2"
+    class="MuiGrid-root css-vj1n65-MuiGrid-root"
   >
     <div
-      class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
+      class="MuiGrid-root css-vj1n65-MuiGrid-root"
     >
-      <h5
-        class="MuiTypography-root MuiTypography-h5 css-q2f0a7-MuiTypography-root"
-      >
-        <strong />
-      </h5>
-      <div
-        class="MuiGrid-root css-vj1n65-MuiGrid-root"
-      >
-        <form
-          class="css-1dkqlr9"
-        />
-      </div>
+      <form
+        class="css-1dkqlr9"
+      />
     </div>
   </div>
 </DocumentFragment>

--- a/frontend/workflows/experimentation/src/view-experiment-run.tsx
+++ b/frontend/workflows/experimentation/src/view-experiment-run.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { clutch as IClutch } from "@clutch-sh/api";
 import type { ClutchError } from "@clutch-sh/core";
 import {
-  BaseWorkflowProps,
   Button,
   ButtonGroup,
   client,
@@ -16,7 +15,7 @@ import {
 import PageLayout from "./core/page-layout";
 import { propertyToString } from "./property-helpers";
 
-const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
+const ViewExperimentRun: React.FC = () => {
   const [experiment, setExperiment] = useState<
     IClutch.chaos.experimentation.v1.ExperimentRunDetails | undefined
   >(undefined);
@@ -83,7 +82,7 @@ const ViewExperimentRun: React.FC<BaseWorkflowProps> = ({ heading }) => {
   }
 
   return (
-    <PageLayout heading={heading} error={error}>
+    <PageLayout error={error}>
       <Form>
         {experiment && (
           <>

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -105,7 +105,7 @@ const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <PodIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
       <PodDetails name="Verify" notes={notes} />
       <Confirm name="Result" />

--- a/frontend/workflows/k8s/src/index.tsx
+++ b/frontend/workflows/k8s/src/index.tsx
@@ -38,6 +38,9 @@ const register = (): WorkflowConfiguration => {
         description: "Delete a K8s pod.",
         component: DeletePod,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
       resizeHPA: {
         path: "hpa/resize",
@@ -45,6 +48,9 @@ const register = (): WorkflowConfiguration => {
         description: "Resize a horizontal autoscaler.",
         component: ResizeHPA,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
       scaleResources: {
         path: "resources/scale",
@@ -52,6 +58,9 @@ const register = (): WorkflowConfiguration => {
         description: "Scale CPU and memory requests and limits.",
         component: ScaleResources,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
       kubeDashboard: {
         path: "dashboard",
@@ -59,6 +68,9 @@ const register = (): WorkflowConfiguration => {
         description: "Dashboard for Kubernetes Resources.",
         component: KubeDashboard,
         requiredConfigProps: [],
+        layoutProps: {
+          variant: "standard",
+        },
       },
       cordonNode: {
         path: "node/cordon",
@@ -66,6 +78,9 @@ const register = (): WorkflowConfiguration => {
         description: "Cordon or uncordon a node",
         component: CordonNode,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
       updateLiveness: {
         path: "probe/update",
@@ -73,6 +88,9 @@ const register = (): WorkflowConfiguration => {
         description: "Update Probes on deployments",
         component: UpdateLiveness,
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
     },
   };

--- a/frontend/workflows/k8s/src/k8s-dash-header.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-header.tsx
@@ -8,7 +8,7 @@ const Category = styled("div")(({ theme }: { theme: Theme }) => ({
   lineHeight: "16px",
   color: alpha(theme.palette.secondary[900], 0.38),
   textTransform: "uppercase",
-  paddingBottom: "8px",
+  paddingBottom: theme.spacing(theme.clutch.spacing.sm),
 }));
 
 const HeaderText = styled("div")(({ theme }: { theme: Theme }) => ({

--- a/frontend/workflows/k8s/src/k8s-dash-search.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-search.tsx
@@ -14,20 +14,21 @@ import { useDataLayout } from "@clutch-sh/data-layout";
 import styled from "@emotion/styled";
 import { yupResolver } from "@hookform/resolvers/yup";
 import SearchIcon from "@mui/icons-material/Search";
+import type { Theme } from "@mui/material";
 import * as yup from "yup";
 
-const Container = styled.div({
-  margin: "32px 0",
-});
+const Container = styled.div(({ theme }: { theme: Theme }) => ({
+  margin: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
+}));
 
 const schema = yup.object().shape({
   namespace: yup.string().required("Namespace is required"),
   clientset: yup.string().required("Clientset is required"),
 });
 
-const Content = styled.div({
-  margin: "32px 0",
-});
+const Content = styled.div(({ theme }: { theme: Theme }) => ({
+  margin: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
+}));
 
 const K8sDashSearch = ({ onSubmit }) => {
   const {

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -11,14 +11,12 @@ import { alpha, Theme } from "@mui/material";
 import type { WorkflowProps } from ".";
 import CronTable from "./crons-table";
 import DeploymentTable from "./deployments-table";
-import K8sDashHeader from "./k8s-dash-header";
 import K8sDashSearch from "./k8s-dash-search";
 import PodTable from "./pods-table";
 import StatefulSetTable from "./stateful-sets-table";
 
 const Container = styled("div")({
   flex: 1,
-  margin: "32px",
   display: "flex",
   flexDirection: "column",
   "> *:first-child": {
@@ -177,7 +175,6 @@ const KubeDashboard: React.FC<WorkflowProps> = () => {
   return (
     <DataLayoutContext.Provider value={dataLayoutManager}>
       <Container>
-        <K8sDashHeader />
         <K8sDashSearch onSubmit={(namespace, clientset) => handleSubmit(namespace, clientset)} />
         <Content>
           {error !== undefined ? (

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -15,21 +15,21 @@ import K8sDashSearch from "./k8s-dash-search";
 import PodTable from "./pods-table";
 import StatefulSetTable from "./stateful-sets-table";
 
-const Container = styled("div")({
+const Container = styled("div")(({ theme }: { theme: Theme }) => ({
   flex: 1,
   display: "flex",
   flexDirection: "column",
   "> *:first-child": {
-    margin: "0",
+    margin: theme.spacing(theme.clutch.spacing.none),
   },
-});
+}));
 
-const Content = styled("div")({
-  margin: "32px 0",
-});
+const Content = styled("div")(({ theme }: { theme: Theme }) => ({
+  margin: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
+}));
 
 const PlaceholderTitle = styled("div")(({ theme }: { theme: Theme }) => ({
-  paddingBottom: "16px",
+  paddingBottom: theme.spacing(theme.clutch.spacing.base),
   fontWeight: 700,
   fontSize: "22px",
   lineHeight: "28px",
@@ -43,12 +43,17 @@ const PlaceholderText = styled("div")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.6),
 }));
 
+const PlaceholderWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
+  margin: theme.spacing(theme.clutch.spacing.lg),
+  textAlign: "center",
+}));
+
 const Placeholder = () => (
   <Paper>
-    <div style={{ margin: "32px", textAlign: "center" }}>
+    <PlaceholderWrapper>
       <PlaceholderTitle>There is nothing to display here</PlaceholderTitle>
       <PlaceholderText>Please enter a namespace and clientset to proceed.</PlaceholderText>
-    </div>
+    </PlaceholderWrapper>
   </Paper>
 );
 

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -221,7 +221,7 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
-const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
+const ResizeHPA: React.FC<WorkflowProps> = ({ resolverType, notes = [] }) => {
   const dataLayout = {
     hpaData: {},
     inputData: {},
@@ -254,7 +254,7 @@ const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <HPAIdentifier name="Lookup" resolverType={resolverType} />
       <HPADetails name="Modify" notes={notes} />
       <Confirm name="Result" notes={notes} />

--- a/frontend/workflows/k8s/src/scale-resources.tsx
+++ b/frontend/workflows/k8s/src/scale-resources.tsx
@@ -274,7 +274,7 @@ const ScaleResources: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <DeploymentIdentifier name="Lookup" resolverType={resolverType} />
       <DeploymentDetails name="Modify" />
       <Confirm name="Confirmation" />

--- a/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/delete-pod.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1s2y8jy-MuiContainer-root"
+    class="MuiContainer-root css-1so714y-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container css-1yw6yql-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/resize-hpa.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1s2y8jy-MuiContainer-root"
+    class="MuiContainer-root css-1so714y-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container css-1yw6yql-MuiGrid-root"

--- a/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
+++ b/frontend/workflows/k8s/src/tests/__snapshots__/scale-resources.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiContainer-root css-1s2y8jy-MuiContainer-root"
+    class="MuiContainer-root css-1so714y-MuiContainer-root"
   >
     <div
       class="MuiGrid-root MuiGrid-container css-1yw6yql-MuiGrid-root"

--- a/frontend/workflows/k8s/src/update-probe.tsx
+++ b/frontend/workflows/k8s/src/update-probe.tsx
@@ -324,7 +324,7 @@ const UpdateLiveness: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <DeploymentIdentifier name="Lookup" resolverType={resolverType} />
       <DeploymentDetails name="Modify" />
       <Confirm name="Confirmation" />

--- a/frontend/workflows/kinesis/src/index.tsx
+++ b/frontend/workflows/kinesis/src/index.tsx
@@ -26,6 +26,9 @@ const register = (): WorkflowConfiguration => {
         displayName: "Shard Count",
         description: "Update Kinesis stream shard count.",
         requiredConfigProps: ["resolverType"],
+        layoutProps: {
+          variant: "wizard",
+        },
       },
     },
   };

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -130,7 +130,7 @@ const Confirm: React.FC<WizardChild> = () => {
   );
 };
 
-const UpdateShardCount: React.FC<WorkflowProps> = ({ heading, resolverType }) => {
+const UpdateShardCount: React.FC<WorkflowProps> = ({ resolverType }) => {
   const dataLayout = {
     resourceData: {},
     streamData: {
@@ -152,7 +152,7 @@ const UpdateShardCount: React.FC<WorkflowProps> = ({ heading, resolverType }) =>
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <StreamIdentifier name="Lookup" resolverType={resolverType} />
       <StreamDetails name="Modify" />
       <Confirm name="Result" />

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -17,20 +17,20 @@ import { useDataLayout } from "@clutch-sh/data-layout";
 import type { WizardChild } from "@clutch-sh/wizard";
 import { Wizard, WizardStep } from "@clutch-sh/wizard";
 import styled from "@emotion/styled";
-import { Grid } from "@mui/material";
+import { Grid, Theme } from "@mui/material";
 import _ from "lodash";
 
 import type { ResolverChild, WorkflowProps } from "./index";
 
-const Form = styled.form({
+const Form = styled.form(({ theme }: { theme: Theme }) => ({
   alignItems: "center",
   display: "flex",
   flexDirection: "column",
   justifyItems: "space-evenly",
   "> *": {
-    padding: "8px 0",
+    padding: theme.spacing(theme.clutch.spacing.sm, theme.clutch.spacing.none),
   },
-});
+}));
 
 const StreamIdentifier: React.FC<ResolverChild> = ({ resolverType }) => {
   const { onSubmit } = useWizardContext();
@@ -74,7 +74,7 @@ const StreamDetails: React.FC<WizardChild> = () => {
         <TextField readOnly label="Stream Name" name="streamName" value={stream.streamName} />
         <TextField readOnly label="Region" name="region" value={stream.region} />
         <Grid container alignItems="stretch" wrap="nowrap">
-          <Grid item style={{ flexBasis: "50%", paddingRight: "8px" }}>
+          <Grid item flexBasis="50%" paddingRight={1}>
             <TextField
               readOnly
               label="Current Shard Count"
@@ -83,7 +83,7 @@ const StreamDetails: React.FC<WizardChild> = () => {
               disabled
             />
           </Grid>
-          <Grid item style={{ flexBasis: "50%", paddingLeft: "8px" }}>
+          <Grid item flexBasis="50%" paddingLeft={1}>
             <Select
               label="Target Shard Count"
               name="targetShardCount"

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -9,12 +9,11 @@ import {
   Tooltip,
   Typography,
   useNavigate,
-  useTheme,
 } from "@clutch-sh/core";
 import styled from "@emotion/styled";
 import RestoreIcon from "@mui/icons-material/Restore";
 import SearchIcon from "@mui/icons-material/Search";
-import { alpha, Box, CircularProgress } from "@mui/material";
+import { Box, CircularProgress } from "@mui/material";
 
 import type { WorkflowProps } from "../types";
 
@@ -59,7 +58,6 @@ const autoComplete = async (search: string): Promise<any> => {
 const Form = styled.form({});
 
 const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
-  const theme = useTheme();
   const navigate = useNavigate();
   const [state, dispatch] = React.useReducer(catalogReducer, initialState);
 
@@ -122,20 +120,7 @@ const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
   };
 
   return (
-    <Box style={{ padding: "32px" }}>
-      <div style={{ marginBottom: "8px" }}>
-        <Typography variant="caption2" color={alpha(theme.palette.secondary[900], 0.48)}>
-          Project Catalog
-        </Typography>
-      </div>
-      <div style={{ marginBottom: "32px" }}>
-        <Typography variant="h2">Project Catalog</Typography>
-        <div style={{ marginTop: "8px" }}>
-          <Typography variant="subtitle3" color={alpha(theme.palette.secondary[900], 0.48)}>
-            A catalog of all projects.
-          </Typography>
-        </div>
-      </div>
+    <Box>
       <Paper>
         <div style={{ margin: "16px" }}>
           <Form noValidate onSubmit={handleSubmit(triggerProjectAdd)}>

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -13,7 +13,7 @@ import {
 import styled from "@emotion/styled";
 import RestoreIcon from "@mui/icons-material/Restore";
 import SearchIcon from "@mui/icons-material/Search";
-import { Box, CircularProgress } from "@mui/material";
+import { Box, CircularProgress, Theme } from "@mui/material";
 
 import type { WorkflowProps } from "../types";
 
@@ -30,12 +30,16 @@ const initialState: CatalogState = {
   error: undefined,
 };
 
+const PlaceholderContainer = styled("div")(({ theme }: { theme: Theme }) => ({
+  margin: theme.spacing(theme.clutch.spacing.lg),
+}));
+
 const Placeholder = () => (
   <Paper>
-    <div style={{ margin: "32px", textAlign: "center" }}>
+    <PlaceholderContainer>
       <Typography variant="h5">There is nothing to display here</Typography>
       <Typography variant="body3">Please enter a project to proceed.</Typography>
-    </div>
+    </PlaceholderContainer>
   </Paper>
 );
 
@@ -55,7 +59,22 @@ const autoComplete = async (search: string): Promise<any> => {
   return { results: response?.data?.results || [] };
 };
 
+const FormWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
+  margin: theme.spacing(theme.clutch.spacing.base),
+}));
+
 const Form = styled.form({});
+
+const MainContentWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
+  display: "flex",
+  justifyContent: "space-between",
+  marginBottom: theme.spacing(theme.clutch.spacing.base),
+  marginTop: theme.spacing(theme.clutch.spacing.lg),
+}));
+
+const PlaceholderWrapper = styled(Grid)(({ theme }: { theme: Theme }) => ({
+  paddingTop: theme.spacing(theme.clutch.spacing.lg),
+}));
 
 const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
   const navigate = useNavigate();
@@ -122,7 +141,7 @@ const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
   return (
     <Box>
       <Paper>
-        <div style={{ margin: "16px" }}>
+        <FormWrapper>
           <Form noValidate onSubmit={handleSubmit(triggerProjectAdd)}>
             <TextField
               label="Search"
@@ -135,16 +154,9 @@ const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
               helperText={state?.error}
             />
           </Form>
-        </div>
+        </FormWrapper>
       </Paper>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          marginBottom: "16px",
-          marginTop: "32px",
-        }}
-      >
+      <MainContentWrapper>
         <Typography variant="h3">My Projects</Typography>
         <Tooltip title="Restore to owned projects only">
           <IconButton
@@ -163,7 +175,7 @@ const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
             <RestoreIcon />
           </IconButton>
         </Tooltip>
-      </div>
+      </MainContentWrapper>
       {state.projects.length ? (
         <Grid container direction="row" spacing={3}>
           {state.projects.map(p => (
@@ -173,9 +185,9 @@ const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {
           ))}
         </Grid>
       ) : (
-        <Grid container justifyContent="center" style={{ paddingTop: "35px" }}>
+        <PlaceholderWrapper container justifyContent="center">
           <Placeholder />
-        </Grid>
+        </PlaceholderWrapper>
       )}
     </Box>
   );

--- a/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/project-card.tsx
@@ -55,12 +55,7 @@ const ProjectCard = ({ project, onRemove }: ProjectCardProps) => {
           </Grid>
         </Grid>
       </Grid>
-      <Grid
-        container
-        item
-        style={{ marginTop: "8px", paddingRight: "16px", flex: "1", overflow: "hidden" }}
-        zeroMinWidth
-      >
+      <Grid container item flex={1} marginTop={1} paddingRight={2} overflow="hidden" zeroMinWidth>
         <Typography variant="body2" color={alpha(theme.palette.secondary[900], 0.65)}>
           {project?.data?.description}
         </Typography>

--- a/frontend/workflows/projectCatalog/src/details/components/card.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/card.tsx
@@ -47,19 +47,19 @@ interface BaseCardProps extends CardTitleProps, CardBodyProps {
 
 interface CardProps extends CatalogDetailsCard, BaseCardProps {}
 
-const StyledCard = styled(Card)({
+const StyledCard = styled(Card)(({ theme }: { theme: Theme }) => ({
   width: "100%",
   height: "100%",
-  padding: "16px",
-});
+  padding: theme.spacing(theme.clutch.spacing.base),
+}));
 
 const StyledGrid = styled(Grid)({
   height: "fit-content",
 });
 
 const StyledProgressContainer = styled("div")(({ theme }: { theme: Theme }) => ({
-  marginBottom: "8px",
-  marginTop: "-12px",
+  marginBottom: theme.spacing(theme.clutch.spacing.sm),
+  marginTop: theme.spacing(-theme.clutch.spacing.base),
   height: "4px",
   ".MuiLinearProgress-root": {
     backgroundColor: theme.palette.primary[400],

--- a/frontend/workflows/projectCatalog/src/details/components/layout.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/layout.tsx
@@ -1,30 +1,22 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Grid, QuickLinkGroup, styled, useNavigate, useParams } from "@clutch-sh/core";
+import { Grid, QuickLinkGroup, useNavigate, useParams } from "@clutch-sh/core";
 
 import type { ProjectDetailsWorkflowProps } from "../../types";
 import { ProjectDetailsContext } from "../context";
 import fetchProjectInfo from "../resolver";
 
-import type { BreadCrumbsProps } from "./breadcrumbs";
-import BreadCrumbs from "./breadcrumbs";
 import ProjectHeader, { ProjectHeaderProps } from "./header";
 import QuickLinksAndSettings from "./link-settings";
 
 export interface CatalogLayoutProps
-  extends BreadCrumbsProps,
-    ProjectHeaderProps,
+  extends ProjectHeaderProps,
     Pick<ProjectDetailsWorkflowProps, "configLinks" | "allowDisabled"> {
   children?: React.ReactNode;
   quickLinkSettings?: boolean;
 }
 
-const StyledContainer = styled(Grid)({
-  padding: "8px 24px",
-});
-
 const CatalogLayout = ({
-  routes = [],
   title,
   description,
   configLinks = [],
@@ -65,12 +57,7 @@ const CatalogLayout = ({
 
   return (
     <ProjectDetailsContext.Provider value={projInfo}>
-      <StyledContainer container>
-        <Grid container item direction="column">
-          <Grid item>
-            <BreadCrumbs routes={[{ title: projectId, path: `${projectId}` }, ...routes]} />
-          </Grid>
-        </Grid>
+      <Grid container>
         <Grid container item spacing={1}>
           <Grid
             container
@@ -99,7 +86,7 @@ const CatalogLayout = ({
         <Grid container item spacing={2}>
           {children && children}
         </Grid>
-      </StyledContainer>
+      </Grid>
     </ProjectDetailsContext.Provider>
   );
 };

--- a/frontend/workflows/projectCatalog/src/details/components/layout.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/layout.tsx
@@ -59,13 +59,7 @@ const CatalogLayout = ({
     <ProjectDetailsContext.Provider value={projInfo}>
       <Grid container>
         <Grid container item spacing={1}>
-          <Grid
-            container
-            item
-            justifyContent="space-between"
-            alignItems="center"
-            marginBottom="16px"
-          >
+          <Grid container item justifyContent="space-between" alignItems="center" marginBottom={2}>
             <Grid item>
               <ProjectHeader
                 title={`${projectInfo?.name ?? projectId}${title ? ` ${title}` : ""}`}

--- a/frontend/workflows/projectCatalog/src/details/components/link-settings.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/link-settings.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
 } from "@clutch-sh/core";
 import SettingsIcon from "@mui/icons-material/Settings";
+import { Theme } from "@mui/material";
 import { isEmpty } from "lodash";
 
 import type { ProjectConfigLink } from "../../types";
@@ -23,17 +24,17 @@ interface QuickLinksAndSettingsProps {
   showSettings: boolean;
 }
 
-const StyledPopperItem = styled(PopperItem)({
+const StyledPopperItem = styled(PopperItem)(({ theme }: { theme: Theme }) => ({
   "&&&": {
     height: "auto",
   },
   "& span.MuiTypography-root": {
-    padding: "0",
+    padding: theme.spacing(theme.clutch.spacing.none),
   },
   "& a.MuiTypography-root": {
-    padding: "4px 16px",
+    padding: theme.spacing(theme.clutch.spacing.xs, theme.clutch.spacing.base),
   },
-});
+}));
 
 const QuickLinksAndSettings = ({
   linkGroups,
@@ -66,9 +67,7 @@ const QuickLinksAndSettings = ({
       alignItems="center"
       justifyContent="flex-end"
       spacing={1}
-      style={{
-        padding: "8px 0px 0px 0px",
-      }}
+      paddingTop={1}
     >
       {!isEmpty(linkGroups) && (
         <Grid item>

--- a/frontend/workflows/projectCatalog/src/details/components/link-settings.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/link-settings.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from "@clutch-sh/core";
 import SettingsIcon from "@mui/icons-material/Settings";
-import { Theme } from "@mui/material";
+import type { Theme } from "@mui/material";
 import { isEmpty } from "lodash";
 
 import type { ProjectConfigLink } from "../../types";

--- a/frontend/workflows/projectCatalog/src/details/config/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/config/index.tsx
@@ -117,13 +117,10 @@ const CatalogConfigPage = ({
   description = "",
   ...props
 }: ProjectDetailsConfigWorkflowProps) => {
-  const { configType = defaultRoute } = useParams();
-
   return (
     <CatalogLayout
       title="Configuration"
       description={description}
-      routes={[{ title: "Configuration" }, { title: configType || defaultRoute }]}
       allowDisabled={false}
       quickLinkSettings={false}
       configLinks={[]}

--- a/frontend/workflows/projectCatalog/src/details/info/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/info/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { Grid, styled } from "@clutch-sh/core";
+import { Theme } from "@mui/material";
 
 import type { ProjectInfoChip } from "./chipsRow";
 import ChipsRow from "./chipsRow";
@@ -13,11 +14,11 @@ interface ProjectInfoProps {
   addtlChips?: ProjectInfoChip[];
 }
 
-const StyledRow = styled(Grid)({
-  marginBottom: "16px",
+const StyledRow = styled(Grid)(({ theme }: { theme: Theme }) => ({
+  marginBottom: theme.spacing(theme.clutch.spacing.base),
   whiteSpace: "nowrap",
   width: "100%",
-});
+}));
 
 const ProjectInfoCard = ({ projectData, addtlChips }: ProjectInfoProps) => {
   const [chips, setChips] = React.useState<ProjectInfoChip[]>([]);

--- a/frontend/workflows/projectCatalog/src/details/info/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/info/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
 import { Grid, styled } from "@clutch-sh/core";
-import { Theme } from "@mui/material";
+import type { Theme } from "@mui/material";
 
 import type { ProjectInfoChip } from "./chipsRow";
 import ChipsRow from "./chipsRow";

--- a/frontend/workflows/projectCatalog/src/index.tsx
+++ b/frontend/workflows/projectCatalog/src/index.tsx
@@ -20,24 +20,41 @@ const register = (): WorkflowConfiguration => {
         description: "A searchable catalog of services",
         component: Catalog,
         featureFlag: "projectCatalog",
+        layoutProps: {
+          variant: "standard",
+          title: "Project Catalog",
+          subtitle: "A catalog of all projects.",
+        },
       },
       details: {
         path: "/:projectId",
         description: "Service Detail View",
         component: Details,
         featureFlag: "projectCatalog",
+        layoutProps: {
+          variant: "standard",
+          onlyBreadcrumbs: true,
+        },
       },
       configLanding: {
         path: "/:projectId/config",
         description: "Project Configuration Landing",
         component: Config,
         featureFlag: "projectCatalog",
+        layoutProps: {
+          variant: "standard",
+          onlyBreadcrumbs: true,
+        },
       },
       configPage: {
         path: "/:projectId/config/:configType",
         description: "Project Configuration Page",
         component: Config,
         featureFlag: "projectCatalog",
+        layoutProps: {
+          variant: "standard",
+          onlyBreadcrumbs: true,
+        },
       },
     },
   };

--- a/frontend/workflows/projectCatalog/src/index.tsx
+++ b/frontend/workflows/projectCatalog/src/index.tsx
@@ -33,7 +33,7 @@ const register = (): WorkflowConfiguration => {
         featureFlag: "projectCatalog",
         layoutProps: {
           variant: "standard",
-          onlyBreadcrumbs: true,
+          breadcrumbsOnly: true,
         },
       },
       configLanding: {
@@ -43,7 +43,7 @@ const register = (): WorkflowConfiguration => {
         featureFlag: "projectCatalog",
         layoutProps: {
           variant: "standard",
-          onlyBreadcrumbs: true,
+          breadcrumbsOnly: true,
         },
       },
       configPage: {
@@ -53,7 +53,7 @@ const register = (): WorkflowConfiguration => {
         featureFlag: "projectCatalog",
         layoutProps: {
           variant: "standard",
-          onlyBreadcrumbs: true,
+          breadcrumbsOnly: true,
         },
       },
     },

--- a/frontend/workflows/projectSelector/src/index.tsx
+++ b/frontend/workflows/projectSelector/src/index.tsx
@@ -29,6 +29,9 @@ const register = (): WorkflowConfiguration => {
         displayName: "Dash",
         description: "Display helpful information for multiple services.",
         component: Dash,
+        layoutProps: {
+          variant: "custom",
+        },
       },
     },
   };

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -10,17 +10,17 @@ import { deriveSwitchStatus, useDispatch, useReducerState } from "./helpers";
 import ProjectLinks from "./project-links";
 import type { Group } from "./types";
 
-const StyledGroup = styled("div")({
+const StyledGroup = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: 500,
-  marginLeft: "4px",
-  marginTop: "9px",
+  marginLeft: theme.spacing(theme.clutch.spacing.xs),
+  marginTop: theme.spacing(theme.clutch.spacing.sm),
   display: "block",
-});
+}));
 
-const StyledGroupTitle = styled("span")({
-  marginRight: "4px",
+const StyledGroupTitle = styled("span")(({ theme }: { theme: Theme }) => ({
+  marginRight: theme.spacing(theme.clutch.spacing.xs),
   display: "inline-block",
-});
+}));
 
 const StyledCount = styled("span")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.6),
@@ -29,10 +29,10 @@ const StyledCount = styled("span")(({ theme }: { theme: Theme }) => ({
   borderRadius: "4px",
   fontWeight: "bold",
   fontSize: "12px",
-  padding: "1px 4px",
-  marginRight: "4px",
-  marginBottom: "10px",
-  marginTop: "2px",
+  padding: theme.spacing(theme.clutch.spacing.none, theme.clutch.spacing.xs),
+  marginRight: theme.spacing(theme.clutch.spacing.xs),
+  marginBottom: theme.spacing(theme.clutch.spacing.sm),
+  marginTop: theme.spacing(theme.clutch.spacing.xs),
   display: "inline-block",
 }));
 
@@ -50,14 +50,14 @@ const StyledMenuItem = styled("div")(({ theme }: { theme: Theme }) => ({
   },
 }));
 
-const StyledProjectHeader = styled("div")({
+const StyledProjectHeader = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   maxWidth: "100%",
   alignItems: "flex-start",
   justifyContent: "space-between",
   minHeight: "40px",
-  padding: "0 12px",
-});
+  padding: theme.spacing(theme.clutch.spacing.none, theme.clutch.spacing.base),
+}));
 
 const StyledHeaderColumn = styled("div")((props: { grow?: boolean }) => ({
   display: "flex",
@@ -70,27 +70,27 @@ const StyledNoProjectsText = styled("div")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.38),
   textAlign: "center",
   fontSize: "12px",
-  marginBottom: "16px",
+  marginBottom: theme.spacing(theme.clutch.spacing.base),
 }));
 
 const StyledAllText = styled("div")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.38),
 }));
 
-const StyledMenuItemName = styled("span")({
+const StyledMenuItemName = styled("span")(({ theme }: { theme: Theme }) => ({
   flexGrow: 1,
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
   overflow: "hidden",
-  marginLeft: "4px",
-  marginRight: "0px",
+  marginLeft: theme.spacing(theme.clutch.spacing.xs),
+  marginRight: theme.spacing(theme.clutch.spacing.none),
   display: "block",
   maxWidth: "160px",
-});
+}));
 
 const StyledClearIcon = styled("span")(({ theme }: { theme: Theme }) => ({
   ".MuiIconButton-root": {
-    padding: "6px",
+    padding: theme.spacing(theme.clutch.spacing.sm),
     color: alpha(theme.palette.secondary[900], 0.38),
   },
   ".MuiIconButton-root:hover": {
@@ -106,8 +106,8 @@ const StyledOnlyButton = styled("button")(({ theme }: { theme: Theme }) => ({
   cursor: "pointer",
   borderRadius: "4px",
   fontSize: "14px",
-  padding: "5px",
-  marginRight: "4px",
+  padding: theme.spacing(theme.clutch.spacing.xs),
+  marginRight: theme.spacing(theme.clutch.spacing.xs),
   color: alpha(theme.palette.primary[600], 1),
   backgroundColor: "unset",
   fontFamily: "inherit",

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -14,7 +14,7 @@ const ICON_SIZE = "16px";
 
 const StyledMoreVertIcon = styled("span")(({ theme }: { theme: Theme }) => ({
   ".MuiIconButton-root": {
-    padding: "6px",
+    padding: theme.spacing(theme.clutch.spacing.sm),
     color: alpha(theme.palette.secondary[900], 0.38),
   },
   ".MuiIconButton-root:hover": {
@@ -25,30 +25,30 @@ const StyledMoreVertIcon = styled("span")(({ theme }: { theme: Theme }) => ({
   },
 }));
 
-const StyledLinkTitle = styled(Typography)({
-  padding: "7px 0px",
-});
+const StyledLinkTitle = styled(Typography)(({ theme }: { theme: Theme }) => ({
+  padding: theme.spacing(theme.clutch.spacing.sm, theme.clutch.spacing.none),
+}));
 
 const StyledLinkBox = styled("div")({
   borderRadius: "4px",
   width: "160px",
 });
 
-const StyledMultilinkImage = styled("div")({
+const StyledMultilinkImage = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
-  padding: "8px",
-});
+  padding: theme.spacing(theme.clutch.spacing.sm),
+}));
 
 const StyledMultilinkHeader = styled("div")({
   display: "flex",
   alignItems: "center",
 });
 
-const StyledCenterImgSpan = styled("span")({
+const StyledCenterImgSpan = styled("span")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   alignItems: "center",
-  padding: "8px",
-});
+  padding: theme.spacing(theme.clutch.spacing.sm),
+}));
 interface QuickLinkGroupProps extends LinkGroupProps {
   links: IClutch.core.project.v1.ILink[];
 }
@@ -70,9 +70,9 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
 
   const StyledSubLink = styled("div")({
     ...itemHoverStyle,
-    paddingBottom: "8px",
-    paddingTop: "8px",
-    paddingLeft: "40px",
+    paddingBottom: theme.spacing(theme.clutch.spacing.sm),
+    paddingTop: theme.spacing(theme.clutch.spacing.sm),
+    paddingLeft: theme.spacing(theme.clutch.spacing.xl),
   });
 
   const [validLinks, setValidLinks] = React.useState<IClutch.core.project.v1.ILink[]>([]);

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -74,24 +74,34 @@ const StyledSelectorContainer = styled("div")(({ theme }: { theme: Theme }) => (
   maxHeight: "100%",
 }));
 
-const StyledWorkflowHeader = styled("div")({
-  margin: "16px 16px 12px 16px",
+const StyledWorkflowHeader = styled("div")(({ theme }: { theme: Theme }) => ({
+  margin: theme.spacing(
+    theme.clutch.spacing.base,
+    theme.clutch.spacing.base,
+    theme.clutch.spacing.sm,
+    theme.clutch.spacing.base
+  ),
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
   height: "24px",
-});
+}));
 
-const StyledWorkflowTitle = styled("span")({
+const StyledWorkflowTitle = styled("span")(({ theme }: { theme: Theme }) => ({
   fontWeight: "bold",
   fontSize: "20px",
   lineHeight: "24px",
-  margin: "0px 8px",
-});
+  margin: theme.spacing(theme.clutch.spacing.none, theme.clutch.spacing.base),
+}));
 
-const StyledProjectTextField = styled(TextField)({
-  padding: "16px 16px 8px 16px",
-});
+const StyledProjectTextField = styled(TextField)(({ theme }: { theme: Theme }) => ({
+  padding: theme.spacing(
+    theme.clutch.spacing.base,
+    theme.clutch.spacing.base,
+    theme.clutch.spacing.sm,
+    theme.clutch.spacing.base
+  ),
+}));
 
 const StyledProgressContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   height: "4px",

--- a/frontend/workflows/redisexperimentation/src/index.tsx
+++ b/frontend/workflows/redisexperimentation/src/index.tsx
@@ -19,6 +19,9 @@ const register = (): WorkflowConfiguration => {
         displayName: "Start Experiment",
         description: "Start Redis Experiment.",
         component: StartExperiment,
+        layoutProps: {
+          variant: "standard",
+        },
       },
     },
   };

--- a/frontend/workflows/redisexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/redisexperimentation/src/start-experiment.tsx
@@ -157,7 +157,6 @@ interface StartExperimentProps extends BaseWorkflowProps {
 }
 
 const StartExperiment: React.FC<StartExperimentProps> = ({
-  heading,
   upstreamRedisClusterTemplate,
   downstreamClusterTemplate,
   environments,
@@ -231,7 +230,7 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
   };
 
   return (
-    <PageLayout heading={heading} error={error}>
+    <PageLayout error={error}>
       <ExperimentDetails
         environments={environments ?? []}
         onStart={experimentDetails => setExperimentData(experimentDetails)}

--- a/frontend/workflows/redisexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
+++ b/frontend/workflows/redisexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
@@ -3,214 +3,203 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-hbp9t2"
+    class="MuiGrid-root css-vj1n65-MuiGrid-root"
   >
     <div
-      class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
+      class="MuiGrid-root css-vj1n65-MuiGrid-root"
     >
-      <h5
-        class="MuiTypography-root MuiTypography-h5 css-q2f0a7-MuiTypography-root"
+      <form
+        class="css-1dkqlr9"
       >
-        <strong>
-          testing
-        </strong>
-      </h5>
-      <div
-        class="MuiGrid-root css-vj1n65-MuiGrid-root"
-      >
-        <form
-          class="css-1dkqlr9"
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
         >
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-1"
+            id="mui-1-label"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-1"
-              id="mui-1-label"
+            Downstream Cluster
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-1"
+              name="downstreamCluster"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Downstream Cluster
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-1"
-                name="downstreamCluster"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Downstream Cluster
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Downstream Cluster
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-2"
+            id="mui-2-label"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-2"
-              id="mui-2-label"
+            Upstream Redis Cluster
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-2"
+              name="upstreamRedisCluster"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Upstream Redis Cluster
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-2"
-                name="upstreamRedisCluster"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Upstream Redis Cluster
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Upstream Redis Cluster
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-3"
+            id="mui-3-label"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-3"
-              id="mui-3-label"
+            Percent
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-3"
+              name="percentage"
+              type="number"
+              value="0"
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Percent
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-3"
-                name="percentage"
-                type="number"
-                value="0"
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Percent
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Percent
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
-            id="faultType"
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+          id="faultType"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-            >
-              Fault Type
-            </label>
+            Fault Type
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+          >
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-            >
-              <div
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="faultType-select"
-                class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                id="faultType-select"
-                role="button"
-                tabindex="0"
-              >
-                Error
-              </div>
-              <input
-                aria-hidden="true"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                tabindex="-1"
-                value="Error"
-              />
-              <div
-                class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
-                  data-testid="ExpandMoreIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </div>
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Fault Type
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container css-mgb5sa-MuiGrid-root"
-            data-border="top"
-          >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-ofve1n-MuiButtonBase-root-MuiButton-root"
-              palette="[object Object]"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="faultType-select"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="faultType-select"
+              role="button"
               tabindex="0"
-              type="button"
             >
-              Cancel
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
-              palette="[object Object]"
-              tabindex="0"
-              type="submit"
+              Error
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="Error"
+            />
+            <div
+              class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
             >
-              Start
-            </button>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
+                data-testid="ExpandMoreIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-t08j42"
+              >
+                <span>
+                  Fault Type
+                </span>
+              </legend>
+            </fieldset>
           </div>
-        </form>
-      </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container css-mgb5sa-MuiGrid-root"
+          data-border="top"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-ofve1n-MuiButtonBase-root-MuiButton-root"
+            palette="[object Object]"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
+            palette="[object Object]"
+            tabindex="0"
+            type="submit"
+          >
+            Start
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 </DocumentFragment>

--- a/frontend/workflows/serverexperimentation/src/index.tsx
+++ b/frontend/workflows/serverexperimentation/src/index.tsx
@@ -17,6 +17,9 @@ const register = (): WorkflowConfiguration => {
         displayName: "Start Experiment",
         description: "Start Server Experiment.",
         component: StartExperiment,
+        layoutProps: {
+          variant: "standard",
+        },
       },
     },
   };

--- a/frontend/workflows/serverexperimentation/src/start-experiment.tsx
+++ b/frontend/workflows/serverexperimentation/src/start-experiment.tsx
@@ -244,7 +244,6 @@ interface StartExperimentProps extends BaseWorkflowProps {
 }
 
 const StartExperiment: React.FC<StartExperimentProps> = ({
-  heading,
   upstreamClusterTemplates,
   downstreamClusterTemplate,
   upstreamClusterTypeSelectionEnabled,
@@ -338,7 +337,7 @@ const StartExperiment: React.FC<StartExperimentProps> = ({
   };
 
   return (
-    <PageLayout heading={heading} error={error}>
+    <PageLayout error={error}>
       <ExperimentDetails
         upstreamClusterTypeSelectionEnabled={upstreamClusterTypeSelectionEnabled ?? false}
         environments={environments ?? []}

--- a/frontend/workflows/serverexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
+++ b/frontend/workflows/serverexperimentation/src/tests/__snapshots__/start-experiment.test.tsx.snap
@@ -3,260 +3,249 @@
 exports[`renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-hbp9t2"
+    class="MuiGrid-root css-vj1n65-MuiGrid-root"
   >
     <div
-      class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
+      class="MuiGrid-root css-vj1n65-MuiGrid-root"
     >
-      <h5
-        class="MuiTypography-root MuiTypography-h5 css-q2f0a7-MuiTypography-root"
+      <form
+        class="css-1dkqlr9"
       >
-        <strong>
-          Start Experiment
-        </strong>
-      </h5>
-      <div
-        class="MuiGrid-root css-vj1n65-MuiGrid-root"
-      >
-        <form
-          class="css-1dkqlr9"
+        <h3
+          style="text-align: center;"
         >
-          <h3
-            style="text-align: center;"
+          Cluster Pair
+        </h3>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-1"
+            id="mui-1-label"
           >
-            Cluster Pair
-          </h3>
+            Downstream Cluster
+          </label>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-1"
-              id="mui-1-label"
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-1"
+              name="downstreamCluster"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Downstream Cluster
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-1"
-                name="downstreamCluster"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Downstream Cluster
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Downstream Cluster
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-2"
+            id="mui-2-label"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-2"
-              id="mui-2-label"
+            Upstream Cluster
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-2"
+              name="upstreamCluster"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Upstream Cluster
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-2"
-                name="upstreamCluster"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Upstream Cluster
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Upstream Cluster
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-3"
+            id="mui-3-label"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-3"
-              id="mui-3-label"
+            Percentage of Requests Served by All Hosts
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-3"
+              name="requestsPercentage"
+              type="number"
+              value="0"
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Percentage of Requests Served by All Hosts
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-3"
-                name="requestsPercentage"
-                type="number"
-                value="0"
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Percentage of Requests Served by All Hosts
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Percentage of Requests Served by All Hosts
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <h3
-            style="text-align: center;"
+        </div>
+        <h3
+          style="text-align: center;"
+        >
+          Faults
+        </h3>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+          id="faultType"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
           >
-            Faults
-          </h3>
+            Fault Type
+          </label>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
-            id="faultType"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-            >
-              Fault Type
-            </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-            >
-              <div
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="faultType-select"
-                class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                id="faultType-select"
-                role="button"
-                tabindex="0"
-              >
-                Abort
-              </div>
-              <input
-                aria-hidden="true"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                tabindex="-1"
-                value="Abort"
-              />
-              <div
-                class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
-                  data-testid="ExpandMoreIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </div>
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Fault Type
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-4"
-              id="mui-4-label"
-            >
-              HTTP Status
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-4"
-                name="httpStatus"
-                type="number"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    HTTP Status
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container css-mgb5sa-MuiGrid-root"
-            data-border="top"
-          >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-ofve1n-MuiButtonBase-root-MuiButton-root"
-              palette="[object Object]"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="faultType-select"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="faultType-select"
+              role="button"
               tabindex="0"
-              type="button"
             >
-              Cancel
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
-              palette="[object Object]"
-              tabindex="0"
-              type="submit"
+              Abort
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="Abort"
+            />
+            <div
+              class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
             >
-              Start
-            </button>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
+                data-testid="ExpandMoreIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-t08j42"
+              >
+                <span>
+                  Fault Type
+                </span>
+              </legend>
+            </fieldset>
           </div>
-        </form>
-      </div>
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-4"
+            id="mui-4-label"
+          >
+            HTTP Status
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-4"
+              name="httpStatus"
+              type="number"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-t08j42"
+              >
+                <span>
+                  HTTP Status
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container css-mgb5sa-MuiGrid-root"
+          data-border="top"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-ofve1n-MuiButtonBase-root-MuiButton-root"
+            palette="[object Object]"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
+            palette="[object Object]"
+            tabindex="0"
+            type="submit"
+          >
+            Start
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 </DocumentFragment>
@@ -265,319 +254,308 @@ exports[`renders correctly 1`] = `
 exports[`renders correctly with upstream cluster type selection enabled 1`] = `
 <DocumentFragment>
   <div
-    class="css-hbp9t2"
+    class="MuiGrid-root css-vj1n65-MuiGrid-root"
   >
     <div
-      class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
+      class="MuiGrid-root css-vj1n65-MuiGrid-root"
     >
-      <h5
-        class="MuiTypography-root MuiTypography-h5 css-q2f0a7-MuiTypography-root"
+      <form
+        class="css-1dkqlr9"
       >
-        <strong>
-          Start Experiment
-        </strong>
-      </h5>
-      <div
-        class="MuiGrid-root css-vj1n65-MuiGrid-root"
-      >
-        <form
-          class="css-1dkqlr9"
+        <h3
+          style="text-align: center;"
         >
-          <h3
-            style="text-align: center;"
+          Cluster Pair
+        </h3>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-6"
+            id="mui-6-label"
           >
-            Cluster Pair
-          </h3>
+            Downstream Cluster
+          </label>
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-6"
-              id="mui-6-label"
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-6"
+              name="downstreamCluster"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Downstream Cluster
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-6"
-                name="downstreamCluster"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Downstream Cluster
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Downstream Cluster
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-7"
+            id="mui-7-label"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-7"
-              id="mui-7-label"
+            Upstream Cluster
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-7"
+              name="upstreamCluster"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
             >
-              Upstream Cluster
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-7"
-                name="upstreamCluster"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <legend
+                class="css-t08j42"
               >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Upstream Cluster
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
+                <span>
+                  Upstream Cluster
+                </span>
+              </legend>
+            </fieldset>
           </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
-            id="upstreamClusterType"
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+          id="upstreamClusterType"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
           >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-            >
-              Upstream Cluster Type
-            </label>
+            Upstream Cluster Type
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+          >
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-            >
-              <div
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="upstreamClusterType-select"
-                class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                id="upstreamClusterType-select"
-                role="button"
-                tabindex="0"
-              >
-                Internal
-              </div>
-              <input
-                aria-hidden="true"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                tabindex="-1"
-                value="internal"
-              />
-              <div
-                class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
-                  data-testid="ExpandMoreIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </div>
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Upstream Cluster Type
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-8"
-              id="mui-8-label"
-            >
-              Percentage of Requests Served by All Hosts
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-8"
-                name="requestsPercentage"
-                type="number"
-                value="0"
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Percentage of Requests Served by All Hosts
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </div>
-          <h3
-            style="text-align: center;"
-          >
-            Faults
-          </h3>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
-            id="faultType"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-            >
-              Fault Type
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-            >
-              <div
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="faultType-select"
-                class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                id="faultType-select"
-                role="button"
-                tabindex="0"
-              >
-                Abort
-              </div>
-              <input
-                aria-hidden="true"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                tabindex="-1"
-                value="Abort"
-              />
-              <div
-                class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
-                  data-testid="ExpandMoreIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </div>
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    Fault Type
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </div>
-          <div
-            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
-          >
-            <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="true"
-              for="mui-9"
-              id="mui-9-label"
-            >
-              HTTP Status
-            </label>
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
-            >
-              <input
-                aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
-                id="mui-9"
-                name="httpStatus"
-                type="number"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-t08j42"
-                >
-                  <span>
-                    HTTP Status
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container css-mgb5sa-MuiGrid-root"
-            data-border="top"
-          >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-ofve1n-MuiButtonBase-root-MuiButton-root"
-              palette="[object Object]"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="upstreamClusterType-select"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="upstreamClusterType-select"
+              role="button"
               tabindex="0"
-              type="button"
             >
-              Cancel
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
-              palette="[object Object]"
-              tabindex="0"
-              type="submit"
+              Internal
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="internal"
+            />
+            <div
+              class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
             >
-              Start
-            </button>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
+                data-testid="ExpandMoreIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-t08j42"
+              >
+                <span>
+                  Upstream Cluster Type
+                </span>
+              </legend>
+            </fieldset>
           </div>
-        </form>
-      </div>
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-8"
+            id="mui-8-label"
+          >
+            Percentage of Requests Served by All Hosts
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-8"
+              name="requestsPercentage"
+              type="number"
+              value="0"
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-t08j42"
+              >
+                <span>
+                  Percentage of Requests Served by All Hosts
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <h3
+          style="text-align: center;"
+        >
+          Faults
+        </h3>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+          id="faultType"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled css-re9ma3-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+          >
+            Fault Type
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-mzhcmf-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="faultType-select"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-7atx2b-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="faultType-select"
+              role="button"
+              tabindex="0"
+            >
+              Abort
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="Abort"
+            />
+            <div
+              class="MuiSelect-icon MuiSelect-iconOutlined css-11bgdin-MuiSelect-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pwosc9-MuiSvgIcon-root"
+                data-testid="ExpandMoreIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                />
+              </svg>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-t08j42"
+              >
+                <span>
+                  Fault Type
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wvyz87-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary css-1eup1al-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for="mui-9"
+            id="mui-9-label"
+          >
+            HTTP Status
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-nq81ol-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1tmw4j-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-9"
+              name="httpStatus"
+              type="number"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-t08j42"
+              >
+                <span>
+                  HTTP Status
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container css-mgb5sa-MuiGrid-root"
+          data-border="top"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-ofve1n-MuiButtonBase-root-MuiButton-root"
+            palette="[object Object]"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-61rao6-MuiButtonBase-root-MuiButton-root"
+            palette="[object Object]"
+            tabindex="0"
+            type="submit"
+          >
+            Start
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 </DocumentFragment>

--- a/frontend/workflows/sourcecontrol/src/create-repository.tsx
+++ b/frontend/workflows/sourcecontrol/src/create-repository.tsx
@@ -116,7 +116,7 @@ const Confirm: React.FC<WizardChild> = () => {
   );
 };
 
-const CreateRepository: React.FC<WorkflowProps> = ({ heading }) => {
+const CreateRepository: React.FC<WorkflowProps> = () => {
   const dataLayout = {
     repositoryData: {
       cache: false,
@@ -139,7 +139,7 @@ const CreateRepository: React.FC<WorkflowProps> = ({ heading }) => {
   };
 
   return (
-    <Wizard dataLayout={dataLayout} heading={heading}>
+    <Wizard dataLayout={dataLayout}>
       <RepositoryDetails name="Repository Details" />
       <Confirm name="Result" />
     </Wizard>

--- a/frontend/workflows/sourcecontrol/src/index.tsx
+++ b/frontend/workflows/sourcecontrol/src/index.tsx
@@ -27,6 +27,9 @@ const register = (): WorkflowConfiguration => {
         component: CreateRepository,
         displayName: "Create Repository",
         description: "Create a new repository.",
+        layoutProps: {
+          variant: "wizard",
+        },
       },
     },
   };


### PR DESCRIPTION
### Description

- Modified the configuration and component of all routes of every workflow to use new layout and spacing units

### Screenshots

#### Standard Layout

##### Before

![clutch lyft net_catalog_ (1)](https://github.com/user-attachments/assets/44b927ff-b6e2-4cc3-9a92-22c61dd9ec83)

##### After

![localhost_3000_ec2_asg_resize (2)](https://github.com/user-attachments/assets/274eaa34-a4c8-4363-aea1-bec3d3b462bd)

> [!NOTE]
> New props were added to the layout to display only the breadcrumbs and preserve previous route component header

#### Wizard Layout

##### Before

![clutch lyft net_dash_ (1)](https://github.com/user-attachments/assets/7cf1ffe9-0553-4b5b-b297-4f7c2d7af2b6)

##### After

![379093432-227ce42a-f890-4889-8860-e7c6c27c929f](https://github.com/user-attachments/assets/13360229-554d-4c63-ae66-9d2ff712ac24)

#### Custom Layout

##### Before

![clutch lyft net_dash_](https://github.com/user-attachments/assets/a3fd2caf-9450-4d84-8d54-b22fd2496407)

##### After

![localhost_3000_dash](https://github.com/user-attachments/assets/7b2a864b-7d15-4aef-9b19-7322013fbb78)

### Testing Performed

Manual

### TODO

- [x] Change the application of spacing units to rely on the Clutch spacing