### PR TITLE
frontend: Refactor theme spacing to allow units as strings

### DIFF
--- a/frontend/packages/core/src/Theme/theme.tsx
+++ b/frontend/packages/core/src/Theme/theme.tsx
@@ -16,18 +16,22 @@ declare module "@emotion/react" {
 }
 
 declare module "@mui/material/styles" {
+  type SpacingUnit = "xs" | "sm" | "base" | "md" | "lg" | "xl";
+
+  // NOTE: `string & {}` allows `SpacingUnit` to be autocompleted
+  type SpacingArg = SpacingUnit | number | (string & {});
+
+  interface Spacing {
+    (value: SpacingArg): string;
+    (topBottom: SpacingArg, rightLeft: SpacingArg): string;
+    (top: SpacingArg, rightLeft: SpacingArg, bottom: SpacingArg): string;
+    (top: SpacingArg, right: SpacingArg, bottom: SpacingArg, left: SpacingArg): string;
+  }
+
   interface Theme {
+    spacing: Spacing;
     clutch: {
       useWorkflowLayout: boolean;
-      spacing: {
-        none: number;
-        xs: number;
-        sm: number;
-        base: number;
-        md: number;
-        lg: number;
-        xl: number;
-      };
       layout: {
         gutter: string;
       };
@@ -36,15 +40,6 @@ declare module "@mui/material/styles" {
   interface ThemeOptions {
     clutch: {
       useWorkflowLayout: boolean;
-      spacing: {
-        none: number;
-        xs: number;
-        sm: number;
-        base: number;
-        md: number;
-        lg: number;
-        xl: number;
-      };
       layout: {
         gutter: string;
       };
@@ -52,25 +47,42 @@ declare module "@mui/material/styles" {
   }
 }
 
+// `8` is the default scaling factor in MUI, so we define and use it
+// to allow predictability using a `number` value
+// https://v5.mui.com/material-ui/customization/spacing/
+const DEFAULT_SCALING_FACTOR = 8;
+
+const CLUTCH_CUSTOM_SPACING = {
+  xs: "4px",
+  sm: "8px",
+  base: "16px",
+  md: "24px",
+  lg: "32px",
+  xl: "40px",
+};
+
 // Create a Material UI theme is propagated to all children.
 const createTheme = (variant: ThemeVariant, useWorkflowLayout: boolean): MuiTheme => {
   return createMuiTheme({
     colors: clutchColors(variant),
     palette: palette(variant),
-    // `8` is the default scaling factor in MUI, we are setting it again to make it explicit
-    // https://v5.mui.com/material-ui/customization/spacing/
-    spacing: 8,
+    spacing: (...args) => {
+      const spacingValues = args.map(value => {
+        if (typeof value === "number") {
+          return `${value * DEFAULT_SCALING_FACTOR}px`;
+        }
+
+        if (typeof value === "string" && CLUTCH_CUSTOM_SPACING[value] !== undefined) {
+          return CLUTCH_CUSTOM_SPACING[value];
+        }
+
+        return value;
+      });
+
+      return spacingValues.join(" ");
+    },
     clutch: {
       useWorkflowLayout,
-      spacing: {
-        none: 0,
-        xs: 0.5,
-        sm: 1,
-        base: 2,
-        md: 3,
-        lg: 4,
-        xl: 5,
-      },
       layout: {
         gutter: useWorkflowLayout ? "0px" : "24px",
       },

--- a/frontend/packages/core/src/Theme/theme.tsx
+++ b/frontend/packages/core/src/Theme/theme.tsx
@@ -11,16 +11,16 @@ import { clutchColors, THEME_VARIANTS } from "./colors";
 import palette from "./palette";
 import type { ThemeVariant } from "./types";
 
+type SpacingUnit = "xs" | "sm" | "base" | "md" | "lg" | "xl";
+
+// NOTE: `string & {}` allows `SpacingUnit` to be autocompleted
+type SpacingArg = SpacingUnit | number | (string & {});
+
 declare module "@emotion/react" {
   export interface Theme extends MuiTheme {}
 }
 
 declare module "@mui/material/styles" {
-  type SpacingUnit = "xs" | "sm" | "base" | "md" | "lg" | "xl";
-
-  // NOTE: `string & {}` allows `SpacingUnit` to be autocompleted
-  type SpacingArg = SpacingUnit | number | (string & {});
-
   interface Spacing {
     (value: SpacingArg): string;
     (topBottom: SpacingArg, rightLeft: SpacingArg): string;
@@ -32,6 +32,7 @@ declare module "@mui/material/styles" {
     spacing: Spacing;
     clutch: {
       useWorkflowLayout: boolean;
+      spacing: Record<SpacingUnit, string>;
       layout: {
         gutter: string;
       };
@@ -40,6 +41,7 @@ declare module "@mui/material/styles" {
   interface ThemeOptions {
     clutch: {
       useWorkflowLayout: boolean;
+      spacing: Record<SpacingUnit, string>;
       layout: {
         gutter: string;
       };
@@ -52,7 +54,7 @@ declare module "@mui/material/styles" {
 // https://v5.mui.com/material-ui/customization/spacing/
 const DEFAULT_SCALING_FACTOR = 8;
 
-const CLUTCH_CUSTOM_SPACING = {
+const CLUTCH_CUSTOM_SPACING: Record<SpacingUnit, string> = {
   xs: "4px",
   sm: "8px",
   base: "16px",
@@ -83,6 +85,7 @@ const createTheme = (variant: ThemeVariant, useWorkflowLayout: boolean): MuiThem
     },
     clutch: {
       useWorkflowLayout,
+      spacing: { ...CLUTCH_CUSTOM_SPACING },
       layout: {
         gutter: useWorkflowLayout ? "0px" : "24px",
       },

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -38,13 +38,13 @@ const getContainerVariantStyles = (variant: LayoutVariant, theme: Theme) => {
   const layoutVariantStylesMap: { [key in LayoutVariant]: CSSObject } = {
     standard: {
       ...BASE_CONTAINER_STYLES,
-      padding: theme.spacing(theme.clutch.spacing.md),
+      padding: theme.spacing("md"),
     },
     wizard: {
       ...BASE_CONTAINER_STYLES,
       width: "800px", // Taken from the Wizard Component default width
-      padding: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
-      margin: theme.spacing(theme.clutch.spacing.none, "auto"),
+      padding: theme.spacing("lg", "none"),
+      margin: theme.spacing("none", "auto"),
     },
   };
   return layoutVariantStylesMap[variant];
@@ -56,23 +56,20 @@ const LayoutContainer = styled("div")(
 );
 
 const PageHeader = styled("div")(({ $variant, theme }: StyledVariantComponentProps) => ({
-  padding: theme.spacing(
-    theme.clutch.spacing.none,
-    $variant === "wizard" ? theme.clutch.spacing.md : theme.clutch.spacing.none
-  ),
-  paddingBottom: theme.spacing(theme.clutch.spacing.base),
+  padding: theme.spacing("none", $variant === "wizard" ? "md" : "none"),
+  paddingBottom: theme.spacing("base"),
   width: "100%",
 }));
 
 const PageHeaderBreadcrumbsWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
-  marginBottom: theme.spacing(theme.clutch.spacing.xs),
+  marginBottom: theme.spacing("xs"),
 }));
 
 const PageHeaderMainContainer = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   alignItems: "center",
   height: "70px",
-  marginBottom: theme.spacing(theme.clutch.spacing.sm),
+  marginBottom: theme.spacing("sm"),
 }));
 
 const PageHeaderInformation = styled("div")({

--- a/frontend/workflows/audit/src/logs/event-row.tsx
+++ b/frontend/workflows/audit/src/logs/event-row.tsx
@@ -18,7 +18,7 @@ const ENDPOINT = "/v1/audit/getEvents";
 const COLUMN_COUNT = 6;
 const MonospaceText = styled("div")(({ theme }: { theme: Theme }) => ({
   fontFamily: "monospace",
-  padding: theme.spacing(theme.clutch.spacing.sm),
+  padding: theme.spacing("sm"),
   border: "1px solid lightgray",
   borderRadius: "8px",
   background: theme.palette.secondary[200],
@@ -29,7 +29,7 @@ const MonospaceText = styled("div")(({ theme }: { theme: Theme }) => ({
 }));
 
 const ReactJsonWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
-  padding: theme.spacing(theme.clutch.spacing.sm),
+  padding: theme.spacing("sm"),
 }));
 
 interface EventRowAction {

--- a/frontend/workflows/envoy/src/remote-triage/dashboard.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/dashboard.tsx
@@ -94,7 +94,7 @@ const SummariesContainer = styled(Grid)({
 });
 
 const InformationContainer = styled("div")(({ theme }: { theme: Theme }) => ({
-  padding: theme.spacing(theme.clutch.spacing.base, theme.clutch.spacing.none),
+  padding: theme.spacing("base", "none"),
 }));
 
 interface DashboardProps {

--- a/frontend/workflows/envoy/src/remote-triage/server-info.tsx
+++ b/frontend/workflows/envoy/src/remote-triage/server-info.tsx
@@ -5,7 +5,7 @@ import type { Theme } from "@mui/material";
 
 const Container = styled("div")(({ theme }: { theme: Theme }) => ({
   "> *": {
-    padding: theme.spacing(theme.clutch.spacing.sm, theme.clutch.spacing.none),
+    padding: theme.spacing("sm", "none"),
   },
 }));
 

--- a/frontend/workflows/k8s/src/k8s-dash-header.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-header.tsx
@@ -8,7 +8,7 @@ const Category = styled("div")(({ theme }: { theme: Theme }) => ({
   lineHeight: "16px",
   color: alpha(theme.palette.secondary[900], 0.38),
   textTransform: "uppercase",
-  paddingBottom: theme.spacing(theme.clutch.spacing.sm),
+  paddingBottom: theme.spacing("sm"),
 }));
 
 const HeaderText = styled("div")(({ theme }: { theme: Theme }) => ({

--- a/frontend/workflows/k8s/src/k8s-dash-search.tsx
+++ b/frontend/workflows/k8s/src/k8s-dash-search.tsx
@@ -18,7 +18,7 @@ import type { Theme } from "@mui/material";
 import * as yup from "yup";
 
 const Container = styled.div(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
+  margin: theme.spacing("lg", "none"),
 }));
 
 const schema = yup.object().shape({
@@ -27,7 +27,7 @@ const schema = yup.object().shape({
 });
 
 const Content = styled.div(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
+  margin: theme.spacing("lg", "none"),
 }));
 
 const K8sDashSearch = ({ onSubmit }) => {

--- a/frontend/workflows/k8s/src/k8s-dashboard.tsx
+++ b/frontend/workflows/k8s/src/k8s-dashboard.tsx
@@ -22,16 +22,16 @@ const Container = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   flexDirection: "column",
   "> *:first-child": {
-    margin: theme.spacing(theme.clutch.spacing.none),
+    margin: theme.spacing("none"),
   },
 }));
 
 const Content = styled("div")(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(theme.clutch.spacing.lg, theme.clutch.spacing.none),
+  margin: theme.spacing("lg", "none"),
 }));
 
 const PlaceholderTitle = styled("div")(({ theme }: { theme: Theme }) => ({
-  paddingBottom: theme.spacing(theme.clutch.spacing.base),
+  paddingBottom: theme.spacing("base"),
   fontWeight: 700,
   fontSize: "22px",
   lineHeight: "28px",
@@ -46,7 +46,7 @@ const PlaceholderText = styled("div")(({ theme }: { theme: Theme }) => ({
 }));
 
 const PlaceholderWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(theme.clutch.spacing.lg),
+  margin: theme.spacing("lg"),
   textAlign: "center",
 }));
 

--- a/frontend/workflows/kinesis/src/update-shard-count.tsx
+++ b/frontend/workflows/kinesis/src/update-shard-count.tsx
@@ -28,7 +28,7 @@ const Form = styled.form(({ theme }: { theme: Theme }) => ({
   flexDirection: "column",
   justifyItems: "space-evenly",
   "> *": {
-    padding: theme.spacing(theme.clutch.spacing.sm, theme.clutch.spacing.none),
+    padding: theme.spacing("sm", "none"),
   },
 }));
 

--- a/frontend/workflows/projectCatalog/src/catalog/index.tsx
+++ b/frontend/workflows/projectCatalog/src/catalog/index.tsx
@@ -32,7 +32,7 @@ const initialState: CatalogState = {
 };
 
 const PlaceholderContainer = styled("div")(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(theme.clutch.spacing.lg),
+  margin: theme.spacing("lg"),
 }));
 
 const Placeholder = () => (
@@ -61,7 +61,7 @@ const autoComplete = async (search: string): Promise<any> => {
 };
 
 const FormWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(theme.clutch.spacing.base),
+  margin: theme.spacing("base"),
 }));
 
 const Form = styled.form({});
@@ -69,12 +69,12 @@ const Form = styled.form({});
 const MainContentWrapper = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   justifyContent: "space-between",
-  marginBottom: theme.spacing(theme.clutch.spacing.base),
-  marginTop: theme.spacing(theme.clutch.spacing.lg),
+  marginBottom: theme.spacing("base"),
+  marginTop: theme.spacing("lg"),
 }));
 
 const PlaceholderWrapper = styled(Grid)(({ theme }: { theme: Theme }) => ({
-  paddingTop: theme.spacing(theme.clutch.spacing.lg),
+  paddingTop: theme.spacing("lg"),
 }));
 
 const Catalog: React.FC<WorkflowProps> = ({ allowDisabled }) => {

--- a/frontend/workflows/projectCatalog/src/details/components/card.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/card.tsx
@@ -50,7 +50,7 @@ interface CardProps extends CatalogDetailsCard, BaseCardProps {}
 const StyledCard = styled(Card)(({ theme }: { theme: Theme }) => ({
   width: "100%",
   height: "100%",
-  padding: theme.spacing(theme.clutch.spacing.base),
+  padding: theme.spacing("base"),
 }));
 
 const StyledGrid = styled(Grid)({
@@ -58,8 +58,8 @@ const StyledGrid = styled(Grid)({
 });
 
 const StyledProgressContainer = styled("div")(({ theme }: { theme: Theme }) => ({
-  marginBottom: theme.spacing(theme.clutch.spacing.sm),
-  marginTop: theme.spacing(-theme.clutch.spacing.base),
+  marginBottom: theme.spacing("sm"),
+  marginTop: theme.spacing("-16px"),
   height: "4px",
   ".MuiLinearProgress-root": {
     backgroundColor: theme.palette.primary[400],

--- a/frontend/workflows/projectCatalog/src/details/components/link-settings.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/link-settings.tsx
@@ -29,10 +29,10 @@ const StyledPopperItem = styled(PopperItem)(({ theme }: { theme: Theme }) => ({
     height: "auto",
   },
   "& span.MuiTypography-root": {
-    padding: theme.spacing(theme.clutch.spacing.none),
+    padding: theme.spacing("none"),
   },
   "& a.MuiTypography-root": {
-    padding: theme.spacing(theme.clutch.spacing.xs, theme.clutch.spacing.base),
+    padding: theme.spacing("xs", "base"),
   },
 }));
 

--- a/frontend/workflows/projectCatalog/src/details/info/index.tsx
+++ b/frontend/workflows/projectCatalog/src/details/info/index.tsx
@@ -15,7 +15,7 @@ interface ProjectInfoProps {
 }
 
 const StyledRow = styled(Grid)(({ theme }: { theme: Theme }) => ({
-  marginBottom: theme.spacing(theme.clutch.spacing.base),
+  marginBottom: theme.spacing("base"),
   whiteSpace: "nowrap",
   width: "100%",
 }));

--- a/frontend/workflows/projectSelector/src/project-group.tsx
+++ b/frontend/workflows/projectSelector/src/project-group.tsx
@@ -12,13 +12,13 @@ import type { Group } from "./types";
 
 const StyledGroup = styled("div")(({ theme }: { theme: Theme }) => ({
   fontWeight: 500,
-  marginLeft: theme.spacing(theme.clutch.spacing.xs),
-  marginTop: theme.spacing(theme.clutch.spacing.sm),
+  marginLeft: theme.spacing("xs"),
+  marginTop: theme.spacing("sm"),
   display: "block",
 }));
 
 const StyledGroupTitle = styled("span")(({ theme }: { theme: Theme }) => ({
-  marginRight: theme.spacing(theme.clutch.spacing.xs),
+  marginRight: theme.spacing("xs"),
   display: "inline-block",
 }));
 
@@ -29,10 +29,10 @@ const StyledCount = styled("span")(({ theme }: { theme: Theme }) => ({
   borderRadius: "4px",
   fontWeight: "bold",
   fontSize: "12px",
-  padding: theme.spacing(theme.clutch.spacing.none, theme.clutch.spacing.xs),
-  marginRight: theme.spacing(theme.clutch.spacing.xs),
-  marginBottom: theme.spacing(theme.clutch.spacing.sm),
-  marginTop: theme.spacing(theme.clutch.spacing.xs),
+  padding: theme.spacing("none", "xs"),
+  marginRight: theme.spacing("xs"),
+  marginBottom: theme.spacing("sm"),
+  marginTop: theme.spacing("xs"),
   display: "inline-block",
 }));
 
@@ -56,7 +56,7 @@ const StyledProjectHeader = styled("div")(({ theme }: { theme: Theme }) => ({
   alignItems: "flex-start",
   justifyContent: "space-between",
   minHeight: "40px",
-  padding: theme.spacing(theme.clutch.spacing.none, theme.clutch.spacing.base),
+  padding: theme.spacing("none", "base"),
 }));
 
 const StyledHeaderColumn = styled("div")((props: { grow?: boolean }) => ({
@@ -70,7 +70,7 @@ const StyledNoProjectsText = styled("div")(({ theme }: { theme: Theme }) => ({
   color: alpha(theme.palette.secondary[900], 0.38),
   textAlign: "center",
   fontSize: "12px",
-  marginBottom: theme.spacing(theme.clutch.spacing.base),
+  marginBottom: theme.spacing("base"),
 }));
 
 const StyledAllText = styled("div")(({ theme }: { theme: Theme }) => ({
@@ -82,15 +82,15 @@ const StyledMenuItemName = styled("span")(({ theme }: { theme: Theme }) => ({
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
   overflow: "hidden",
-  marginLeft: theme.spacing(theme.clutch.spacing.xs),
-  marginRight: theme.spacing(theme.clutch.spacing.none),
+  marginLeft: theme.spacing("xs"),
+  marginRight: theme.spacing("none"),
   display: "block",
   maxWidth: "160px",
 }));
 
 const StyledClearIcon = styled("span")(({ theme }: { theme: Theme }) => ({
   ".MuiIconButton-root": {
-    padding: theme.spacing(theme.clutch.spacing.sm),
+    padding: theme.spacing("sm"),
     color: alpha(theme.palette.secondary[900], 0.38),
   },
   ".MuiIconButton-root:hover": {
@@ -106,8 +106,8 @@ const StyledOnlyButton = styled("button")(({ theme }: { theme: Theme }) => ({
   cursor: "pointer",
   borderRadius: "4px",
   fontSize: "14px",
-  padding: theme.spacing(theme.clutch.spacing.xs),
-  marginRight: theme.spacing(theme.clutch.spacing.xs),
+  padding: theme.spacing("xs"),
+  marginRight: theme.spacing("xs"),
   color: alpha(theme.palette.primary[600], 1),
   backgroundColor: "unset",
   fontFamily: "inherit",

--- a/frontend/workflows/projectSelector/src/project-links.tsx
+++ b/frontend/workflows/projectSelector/src/project-links.tsx
@@ -14,7 +14,7 @@ const ICON_SIZE = "16px";
 
 const StyledMoreVertIcon = styled("span")(({ theme }: { theme: Theme }) => ({
   ".MuiIconButton-root": {
-    padding: theme.spacing(theme.clutch.spacing.sm),
+    padding: theme.spacing("sm"),
     color: alpha(theme.palette.secondary[900], 0.38),
   },
   ".MuiIconButton-root:hover": {
@@ -26,7 +26,7 @@ const StyledMoreVertIcon = styled("span")(({ theme }: { theme: Theme }) => ({
 }));
 
 const StyledLinkTitle = styled(Typography)(({ theme }: { theme: Theme }) => ({
-  padding: theme.spacing(theme.clutch.spacing.sm, theme.clutch.spacing.none),
+  padding: theme.spacing("sm", "none"),
 }));
 
 const StyledLinkBox = styled("div")({
@@ -36,7 +36,7 @@ const StyledLinkBox = styled("div")({
 
 const StyledMultilinkImage = styled("div")(({ theme }: { theme: Theme }) => ({
   display: "flex",
-  padding: theme.spacing(theme.clutch.spacing.sm),
+  padding: theme.spacing("sm"),
 }));
 
 const StyledMultilinkHeader = styled("div")({
@@ -47,7 +47,7 @@ const StyledMultilinkHeader = styled("div")({
 const StyledCenterImgSpan = styled("span")(({ theme }: { theme: Theme }) => ({
   display: "flex",
   alignItems: "center",
-  padding: theme.spacing(theme.clutch.spacing.sm),
+  padding: theme.spacing("sm"),
 }));
 interface QuickLinkGroupProps extends LinkGroupProps {
   links: IClutch.core.project.v1.ILink[];
@@ -70,9 +70,9 @@ const QuickLinkGroup = ({ linkGroupName, linkGroupImage, links }: QuickLinkGroup
 
   const StyledSubLink = styled("div")({
     ...itemHoverStyle,
-    paddingBottom: theme.spacing(theme.clutch.spacing.sm),
-    paddingTop: theme.spacing(theme.clutch.spacing.sm),
-    paddingLeft: theme.spacing(theme.clutch.spacing.xl),
+    paddingBottom: theme.spacing("sm"),
+    paddingTop: theme.spacing("sm"),
+    paddingLeft: theme.spacing("xl"),
   });
 
   const [validLinks, setValidLinks] = React.useState<IClutch.core.project.v1.ILink[]>([]);

--- a/frontend/workflows/projectSelector/src/project-selector.tsx
+++ b/frontend/workflows/projectSelector/src/project-selector.tsx
@@ -75,12 +75,7 @@ const StyledSelectorContainer = styled("div")(({ theme }: { theme: Theme }) => (
 }));
 
 const StyledWorkflowHeader = styled("div")(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(
-    theme.clutch.spacing.base,
-    theme.clutch.spacing.base,
-    theme.clutch.spacing.sm,
-    theme.clutch.spacing.base
-  ),
+  margin: theme.spacing("base", "base", "sm", "base"),
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
@@ -91,16 +86,11 @@ const StyledWorkflowTitle = styled("span")(({ theme }: { theme: Theme }) => ({
   fontWeight: "bold",
   fontSize: "20px",
   lineHeight: "24px",
-  margin: theme.spacing(theme.clutch.spacing.none, theme.clutch.spacing.base),
+  margin: theme.spacing("none", "base"),
 }));
 
 const StyledProjectTextField = styled(TextField)(({ theme }: { theme: Theme }) => ({
-  padding: theme.spacing(
-    theme.clutch.spacing.base,
-    theme.clutch.spacing.base,
-    theme.clutch.spacing.sm,
-    theme.clutch.spacing.base
-  ),
+  padding: theme.spacing("base", "base", "sm", "base"),
 }));
 
 const StyledProgressContainer = styled("div")(({ theme }: { theme: Theme }) => ({


### PR DESCRIPTION
### Description

- Override `theme.spacing` to allow the new spacing units as strings