### PR TITLE
frontend: Set workflow layout title as either route or workflow display names

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -218,7 +218,7 @@ const ClutchApp = ({
 
                             const workflowLayoutProps: LayoutProps = {
                               workflow,
-                              title: heading,
+                              title: route.displayName || workflow.displayName,
                               subtitle: route.description,
                               variant:
                                 route.layoutProps?.variant === null ||


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

-  Sets workflow layout title as either route or workflow display names

### Testing Performed

Manual