### PR TITLE
frontend: Improve breadcrumbs UX

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -217,7 +217,7 @@ const ClutchApp = ({
                               : workflow.displayName;
 
                             const workflowLayoutProps: LayoutProps = {
-                              workflow,
+                              workflowsInPath: workflows.filter(w => w.path === workflow.path),
                               title: heading,
                               subtitle: route.description,
                               variant:

--- a/frontend/packages/core/src/AppProvider/workflow.tsx
+++ b/frontend/packages/core/src/AppProvider/workflow.tsx
@@ -55,7 +55,7 @@ interface WorkflowLayoutConfiguration {
   /**
    * (Optional) property to pass the defined layout properties to all of its defined routes
    */
-  defaultLayoutProps?: Omit<LayoutProps, "workflow" | "title" | "subtitle">;
+  defaultLayoutProps?: Omit<LayoutProps, "workflowsInPath" | "title" | "subtitle">;
 }
 
 export interface Workflow
@@ -105,7 +105,7 @@ export interface Route {
   /**
    * (Optional) property to define layout properties for a single route
    */
-  layoutProps?: Omit<LayoutProps, "workflow" | "title" | "subtitle">;
+  layoutProps?: Omit<LayoutProps, "workflowsInPath" | "title" | "subtitle">;
 }
 
 export interface ConfiguredRoute extends Route {

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { matchPath, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import type { Interpolation } from "@emotion/styled";
 import type { CSSObject, Theme } from "@mui/material";
 import { alpha } from "@mui/material";
@@ -14,7 +14,7 @@ import { generateBreadcrumbsEntries } from "../utils";
 export type LayoutVariant = "standard" | "wizard";
 
 export type LayoutProps = {
-  workflow: Workflow;
+  workflowsInPath: Array<Workflow>;
   variant?: LayoutVariant | null;
   title?: string | ((params: Record<string, string>) => string);
   subtitle?: string;
@@ -88,7 +88,7 @@ const Subtitle = styled(Typography)(({ theme }: { theme: Theme }) => ({
 }));
 
 const WorkflowLayout = ({
-  workflow,
+  workflowsInPath,
   variant = null,
   title = null,
   subtitle = null,
@@ -99,22 +99,18 @@ const WorkflowLayout = ({
   const params = useParams();
   const location = useLocation();
 
+  const entries = generateBreadcrumbsEntries(workflowsInPath, location);
+
   if (variant === null) {
     return <>{children}</>;
   }
-
-  const workflowPaths = workflow.routes.map(({ path }) => `/${workflow.path}/${path}`);
-  const breadcrumbsEntries = generateBreadcrumbsEntries(
-    location,
-    url => !!workflowPaths.find(path => !!matchPath({ path }, url))
-  );
 
   return (
     <LayoutContainer $variant={variant}>
       {!hideHeader && (
         <PageHeader $variant={variant}>
           <PageHeaderBreadcrumbsWrapper>
-            <Breadcrumbs entries={breadcrumbsEntries} />
+            <Breadcrumbs entries={entries} />
           </PageHeaderBreadcrumbsWrapper>
           {!breadcrumbsOnly && (title || subtitle) && (
             <PageHeaderMainContainer>

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { useParams } from "react-router-dom";
 import type { Interpolation } from "@emotion/styled";
 import type { CSSObject, Theme } from "@mui/material";
 import { alpha } from "@mui/material";
 
 import type { Workflow } from "../AppProvider/workflow";
 import Breadcrumbs from "../Breadcrumbs";
-import { useLocation } from "../navigation";
+import { useLocation, useParams } from "../navigation";
 import styled from "../styled";
 import { Typography } from "../typography";
 import { generateBreadcrumbsEntries } from "../utils";

--- a/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
+++ b/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
@@ -6,34 +6,51 @@ import type { BreadcrumbEntry } from "../Breadcrumbs";
 const HOME_ENTRY = { label: "Home", url: "/" };
 
 const generateBreadcrumbsEntries = (workflowsInPath: Array<Workflow>, location: Location) => {
+  // The first workflow in the will contain
+  // the same path and displayName as the others
   const firstWorkflow = workflowsInPath[0];
+
+  if (!firstWorkflow) {
+    return [HOME_ENTRY];
+  }
+
+  // Get a single level list of the routes available
   const allRoutes = workflowsInPath.flatMap(w => w.routes);
+
+  // Add to every item in the routes list the workflow path prefix
   const fullPaths = allRoutes.map(({ path }) => `/${firstWorkflow.path}/${path}`);
 
-  const labels = decodeURIComponent(location.pathname)
+  // Generate a list of path segments from the location
+  const pathSegments = decodeURIComponent(location.pathname)
     .split("/")
-    .slice(1, location.pathname.endsWith("/") ? -1 : undefined);
+    .slice(1, location.pathname.endsWith("/") ? -1 : undefined); // in case of a trailing `/`
 
   const entries: Array<BreadcrumbEntry> = [HOME_ENTRY].concat(
-    labels.map((defaultLabel, index) => {
+    pathSegments.map((segment, index) => {
       const nextIndex = index + 1;
-      const url = `/${labels.slice(0, nextIndex).join("/")}`;
+      const url = `/${pathSegments.slice(0, nextIndex).join("/")}`;
 
       const path = fullPaths.find(p => !!matchPath(p, url));
+
+      // If there is a matched path, it's used to find the route that contains its displayName
       const route = path
         ? allRoutes.find(r =>
             r.path.startsWith("/")
               ? r.path
-              : `/${r.path}` === `/${path.split("/").slice(2).join("/")}`
+              : // Done in case of an empty path or missing a facing `/`
+                `/${r.path}` === `/${path.split("/").slice(2).join("/")}`
           )
         : null;
 
       return {
+        // For the label:
+        // - Prioritize the display name
+        // - Handle the case of a single route with an unusual long name
+        // - Default to the path segment
         label:
-          route?.displayName ||
-          (allRoutes.length === 1 && firstWorkflow.displayName) ||
-          defaultLabel,
-        url: !!path && labels.length !== nextIndex ? url : null,
+          route?.displayName || (allRoutes.length === 1 && firstWorkflow.displayName) || segment,
+        // Set a null url if there is no path or for the last segment
+        url: !!path && pathSegments.length !== nextIndex ? url : null,
       };
     })
   );

--- a/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
+++ b/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
@@ -1,23 +1,39 @@
-import type { Location } from "react-router-dom";
+import { Location, matchPath } from "react-router-dom";
 
+import type { Workflow } from "../AppProvider/workflow";
 import type { BreadcrumbEntry } from "../Breadcrumbs";
 
-const generateBreadcrumbsEntries = (location: Location, validateUrl: (url: string) => boolean) => {
+const HOME_ENTRY = { label: "Home", url: "/" };
+
+const generateBreadcrumbsEntries = (workflowsInPath: Array<Workflow>, location: Location) => {
+  const firstWorkflow = workflowsInPath[0];
+  const allRoutes = workflowsInPath.flatMap(w => w.routes);
+  const fullPaths = allRoutes.map(({ path }) => `/${firstWorkflow.path}/${path}`);
+
   const labels = decodeURIComponent(location.pathname)
     .split("/")
     .slice(1, location.pathname.endsWith("/") ? -1 : undefined);
 
-  const entries: Array<BreadcrumbEntry> = [{ label: "Home", url: "/" }].concat(
-    labels.map((label, index) => {
-      let url = `/${labels.slice(0, index + 1).join("/")}`;
+  const entries: Array<BreadcrumbEntry> = [HOME_ENTRY].concat(
+    labels.map((defaultLabel, index) => {
+      const nextIndex = index + 1;
+      const url = `/${labels.slice(0, nextIndex).join("/")}`;
 
-      if (!validateUrl(url)) {
-        url = undefined;
-      }
+      const path = fullPaths.find(p => !!matchPath(p, url));
+      const route = path
+        ? allRoutes.find(r =>
+            r.path.startsWith("/")
+              ? r.path
+              : `/${r.path}` === `/${path.split("/").slice(2).join("/")}`
+          )
+        : null;
 
       return {
-        label,
-        url,
+        label:
+          route?.displayName ||
+          (allRoutes.length === 1 && firstWorkflow.displayName) ||
+          defaultLabel,
+        url: !!path && labels.length !== nextIndex ? url : null,
       };
     })
   );

--- a/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
+++ b/frontend/packages/core/src/utils/generateBreadcrumbsEntries.tsx
@@ -37,7 +37,7 @@ const generateBreadcrumbsEntries = (workflowsInPath: Array<Workflow>, location: 
         ? allRoutes.find(r =>
             r.path.startsWith("/")
               ? r.path
-              : // Done in case of an empty path or missing a facing `/`
+              : // Done in case of an empty path or missing a leading `/`
                 `/${r.path}` === `/${path.split("/").slice(2).join("/")}`
           )
         : null;


### PR DESCRIPTION
<!--- TITLE FORMAT: "component: short description", e.g. "k8s: add pod log reader" -->

### Description

- Sets current path breadcrumb entry as plain text
- Grabs better entry labels from workflow config
- Fixes issue with fragmented workflow groups where not all routes were present

### Screenshots

#### Before

<img width="460" alt="Screenshot 2024-11-13 at 5 50 38 p m" src="https://github.com/user-attachments/assets/fb510e6e-5957-45e1-95e6-1ee3c644a0b6">

#### After

<img width="540" alt="Screenshot 2024-11-13 at 5 50 01 p m" src="https://github.com/user-attachments/assets/4e47f575-023c-44ba-b348-44a050c9b595">

### Testing Performed

Manual