### PR TITLE
frontend: Add context for workflow layout to support dynamic content

### DIFF
--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -16,6 +16,7 @@ import type { ClutchError } from "../Network/errors";
 import NotFound from "../not-found";
 import type { AppConfiguration } from "../Types";
 import WorkflowLayout, { LayoutProps } from "../WorkflowLayout";
+import { WorkflowLayoutContextProvider } from "../WorkflowLayout/context";
 
 import { registeredWorkflows } from "./registrar";
 import ShortLinkProxy, { ShortLinkBaseRoute } from "./short-link-proxy";
@@ -233,6 +234,10 @@ const ClutchApp = ({
                                 route.layoutProps?.hideHeader ??
                                 workflow.defaultLayoutProps?.hideHeader ??
                                 false,
+                              usesContext:
+                                route.layoutProps?.usesContext ??
+                                workflow.defaultLayoutProps?.usesContext ??
+                                false,
                             };
 
                             const workflowRouteComponent = (
@@ -254,9 +259,11 @@ const ClutchApp = ({
                                 path={`${route.path.replace(/^\/+/, "").replace(/\/+$/, "")}`}
                                 element={
                                   appConfiguration?.useWorkflowLayout ? (
-                                    <WorkflowLayout {...workflowLayoutProps}>
-                                      {workflowRouteComponent}
-                                    </WorkflowLayout>
+                                    <WorkflowLayoutContextProvider>
+                                      <WorkflowLayout {...workflowLayoutProps}>
+                                        {workflowRouteComponent}
+                                      </WorkflowLayout>
+                                    </WorkflowLayoutContextProvider>
                                   ) : (
                                     workflowRouteComponent
                                   )

--- a/frontend/packages/core/src/AppProvider/index.tsx
+++ b/frontend/packages/core/src/AppProvider/index.tsx
@@ -226,10 +226,6 @@ const ClutchApp = ({
                                 route.layoutProps?.variant !== undefined
                                   ? route.layoutProps?.variant
                                   : workflow.defaultLayoutProps?.variant,
-                              breadcrumbsOnly:
-                                route.layoutProps?.breadcrumbsOnly ??
-                                workflow.defaultLayoutProps?.breadcrumbsOnly ??
-                                false,
                               hideHeader:
                                 route.layoutProps?.hideHeader ??
                                 workflow.defaultLayoutProps?.hideHeader ??

--- a/frontend/packages/core/src/WorkflowLayout/context.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/context.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+export interface WorkflowLayoutContextProps {
+  title?: string;
+  subtitle?: string;
+  headerContent?: React.ReactNode;
+  setTitle: (title: string) => void;
+  setSubtitle: (subtitle: string) => void;
+  setHeaderContent: (headerContent: React.ReactNode) => void;
+}
+
+const INITIAL_STATE = {
+  title: null,
+  subtitle: null,
+  headerContent: null,
+  setTitle: () => {},
+  setSubtitle: () => {},
+  setHeaderContent: () => {},
+};
+
+const WorkflowLayoutContext = React.createContext<WorkflowLayoutContextProps>(INITIAL_STATE);
+
+const workflowLayoutContextReducer = (state, action) => {
+  switch (action.type) {
+    case "set_title":
+      return { ...state, title: action.payload };
+    case "set_subtitle":
+      return { ...state, subtitle: action.payload };
+    case "set_content":
+      return { ...state, headerContent: action.payload };
+    default:
+      throw new Error("Unhandled action type");
+  }
+};
+
+const WorkflowLayoutContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const [state, dispatch] = React.useReducer(workflowLayoutContextReducer, INITIAL_STATE);
+
+  const providerValue = React.useMemo(
+    () => ({
+      ...state,
+      setTitle: (title: string) => {
+        dispatch({ type: "set_title", payload: title });
+      },
+      setSubtitle: (subtitle: string) => {
+        dispatch({ type: "set_subtitle", payload: subtitle });
+      },
+      setHeaderContent: (headerContent: string) => {
+        dispatch({ type: "set_content", payload: headerContent });
+      },
+    }),
+    [state]
+  );
+
+  return (
+    <WorkflowLayoutContext.Provider value={providerValue}>
+      {children}
+    </WorkflowLayoutContext.Provider>
+  );
+};
+
+const useWorkflowLayoutContext = () => {
+  const location = useLocation();
+  const context = React.useContext<WorkflowLayoutContextProps>(WorkflowLayoutContext);
+
+  if (!context) {
+    throw new Error("useWorkflowLayoutContext was invoked outside of a valid context");
+  }
+
+  // Reset state on route change
+  React.useEffect(() => {
+    context.setTitle(null);
+    context.setSubtitle(null);
+    context.setHeaderContent(null);
+  }, [location.pathname]);
+
+  return context;
+};
+
+export { WorkflowLayoutContextProvider, useWorkflowLayoutContext };

--- a/frontend/packages/core/src/WorkflowLayout/index.tsx
+++ b/frontend/packages/core/src/WorkflowLayout/index.tsx
@@ -21,7 +21,6 @@ export type LayoutProps = {
   variant?: LayoutVariant | null;
   title?: string;
   subtitle?: string;
-  breadcrumbsOnly?: boolean;
   hideHeader?: boolean;
   usesContext?: boolean;
 };
@@ -106,7 +105,6 @@ const WorkflowLayout = ({
   variant = null,
   title = null,
   subtitle = null,
-  breadcrumbsOnly = false,
   hideHeader = false,
   usesContext = false,
   children,
@@ -143,7 +141,7 @@ const WorkflowLayout = ({
           <PageHeaderBreadcrumbsWrapper>
             <Breadcrumbs entries={breadcrumbsEntries} />
           </PageHeaderBreadcrumbsWrapper>
-          {!breadcrumbsOnly && (headerTitle || headerSubtitle) && (
+          {(headerTitle || headerSubtitle) && (
             <PageHeaderMainContainer>
               <Loadable isLoading={headerLoading}>
                 <PageHeaderInformation>

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -62,7 +62,7 @@ export { default as ClutchApp } from "./AppProvider";
 export { useTheme } from "./AppProvider/themes";
 export { ThemeProvider } from "./Theme";
 export { getDisplayName } from "./utils";
-export { default as WorkflowLayout } from "./WorkflowLayout";
+export { useWorkflowLayoutContext } from "./WorkflowLayout/context";
 export { default as Breadcrumbs } from "./Breadcrumbs";
 
 export { css as EMOTION_CSS, keyframes as EMOTION_KEYFRAMES } from "@emotion/react";

--- a/frontend/workflows/audit/src/index.tsx
+++ b/frontend/workflows/audit/src/index.tsx
@@ -21,6 +21,7 @@ const register = (): WorkflowConfiguration => {
     displayName: "Audit Trail",
     defaultLayoutProps: {
       variant: "standard",
+      usesContext: true,
     },
     routes: {
       landing: {
@@ -35,6 +36,9 @@ const register = (): WorkflowConfiguration => {
         description: "View audit event",
         component: AuditEvent,
         hideNav: true,
+        layoutProps: {
+          usesContext: false,
+        },
       },
     },
   };

--- a/frontend/workflows/audit/src/logs/index.tsx
+++ b/frontend/workflows/audit/src/logs/index.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   useSearchParams,
   useTheme,
+  useWorkflowLayoutContext,
 } from "@clutch-sh/core";
 import SearchIcon from "@mui/icons-material/Search";
 import { CircularProgress, Stack, Theme, useMediaQuery } from "@mui/material";
@@ -69,12 +70,13 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
 
   const theme = useTheme();
   const shrink = useMediaQuery(theme.breakpoints.down("md"));
+  const workflowLayoutContent = useWorkflowLayoutContext();
 
   const genTimeRangeKey = () => `${startTime}-${endTime}-${new Date().toString()}`;
-  return (
-    <RootContainer spacing={2} direction="column" padding={theme.clutch.layout.gutter}>
-      {!theme.clutch.useWorkflowLayout && <Typography variant="h2">{heading}</Typography>}
-      <Stack direction="column" spacing={2}>
+
+  React.useEffect(() => {
+    if (theme.clutch.useWorkflowLayout) {
+      workflowLayoutContent.setHeaderContent(
         <Stack
           direction={shrink ? "column" : "row"}
           spacing={1}
@@ -109,6 +111,50 @@ const AuditLog: React.FC<AuditLogProps> = ({ heading, detailsPathPrefix, downloa
             </IconButton>
           )}
         </Stack>
+      );
+    }
+  }, [isLoading, shrink]);
+
+  return (
+    <RootContainer spacing={2} direction="column" padding={theme.clutch.layout.gutter}>
+      {!theme.clutch.useWorkflowLayout && <Typography variant="h2">{heading}</Typography>}
+      <Stack direction="column" spacing={2}>
+        {!theme.clutch.useWorkflowLayout && (
+          <Stack
+            direction={shrink ? "column" : "row"}
+            spacing={1}
+            sx={{
+              alignSelf: shrink ? "center" : "flex-end",
+              width: shrink ? "100%" : "inherit",
+            }}
+          >
+            {isLoading && (
+              <LoadingContainer>
+                <LoadingSpinner />
+              </LoadingContainer>
+            )}
+            <DateTimeRangeSelector
+              shrink={shrink}
+              disabled={isLoading}
+              start={startTime}
+              end={endTime}
+              onStartChange={setStartTime}
+              onEndChange={setEndTime}
+              onQuickSelect={(start, end) => {
+                setStartTime(start);
+                setEndTime(end);
+                setTimeRangeKey(genTimeRangeKey());
+              }}
+            />
+            {shrink ? (
+              <Button text="Search" onClick={() => setTimeRangeKey(genTimeRangeKey())} />
+            ) : (
+              <IconButton onClick={() => setTimeRangeKey(genTimeRangeKey())}>
+                <SearchIcon />
+              </IconButton>
+            )}
+          </Stack>
+        )}
         {error && <Error subject={error} />}
       </Stack>
       <TableContainer>

--- a/frontend/workflows/projectCatalog/src/details/components/layout.tsx
+++ b/frontend/workflows/projectCatalog/src/details/components/layout.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import type { clutch as IClutch } from "@clutch-sh/api";
-import { Grid, QuickLinkGroup, useNavigate, useParams, useTheme } from "@clutch-sh/core";
+import {
+  Grid,
+  QuickLinkGroup,
+  useNavigate,
+  useParams,
+  useTheme,
+  useWorkflowLayoutContext,
+} from "@clutch-sh/core";
 
 import type { ProjectDetailsWorkflowProps } from "../../types";
 import { ProjectDetailsContext } from "../context";
@@ -35,6 +42,7 @@ const CatalogLayout = ({
   );
   const projInfo = React.useMemo(() => ({ projectId, projectInfo }), [projectId, projectInfo]);
   const theme = useTheme();
+  const workflowLayoutContent = useWorkflowLayoutContext();
 
   const redirectNotFound = () => navigate(`/${projectId}/notFound`, { replace: true });
 
@@ -64,35 +72,63 @@ const CatalogLayout = ({
     return () => {};
   }, [projectId]);
 
+  React.useEffect(() => {
+    if (theme.clutch.useWorkflowLayout) {
+      workflowLayoutContent.setTitle(
+        `${projectInfo?.name ?? projectId}${title ? ` ${title}` : ""}`
+      );
+
+      workflowLayoutContent.setSubtitle(description ?? (projectInfo?.data?.description as string));
+
+      workflowLayoutContent.setHeaderContent(
+        projectInfo ? (
+          <QuickLinksAndSettings
+            linkGroups={(projectInfo.linkGroups as QuickLinkGroup[]) || []}
+            configLinks={configLinks ?? []}
+            showSettings={quickLinkSettings}
+          />
+        ) : null
+      );
+    }
+  }, [description, projectInfo, title]);
+
   return (
     <ProjectDetailsContext.Provider value={projInfo}>
       <Grid container padding={theme.clutch.layout.gutter}>
         {!theme.clutch.useWorkflowLayout && (
-          <Grid container item direction="column">
-            <Grid item>
-              <BreadCrumbs routes={[{ title: projectId, path: `${projectId}` }, ...routes]} />
+          <>
+            <Grid container item direction="column">
+              <Grid item>
+                <BreadCrumbs routes={[{ title: projectId, path: `${projectId}` }, ...routes]} />
+              </Grid>
             </Grid>
-          </Grid>
+            <Grid container item spacing={1}>
+              <Grid
+                container
+                item
+                justifyContent="space-between"
+                alignItems="center"
+                marginBottom={2}
+              >
+                <Grid item>
+                  <ProjectHeader
+                    title={`${projectInfo?.name ?? projectId}${title ? ` ${title}` : ""}`}
+                    description={description ?? (projectInfo?.data?.description as string)}
+                  />
+                </Grid>
+                <Grid item>
+                  {projectInfo && (
+                    <QuickLinksAndSettings
+                      linkGroups={(projectInfo.linkGroups as QuickLinkGroup[]) || []}
+                      configLinks={configLinks ?? []}
+                      showSettings={quickLinkSettings}
+                    />
+                  )}
+                </Grid>
+              </Grid>
+            </Grid>
+          </>
         )}
-        <Grid container item spacing={1}>
-          <Grid container item justifyContent="space-between" alignItems="center" marginBottom={2}>
-            <Grid item>
-              <ProjectHeader
-                title={`${projectInfo?.name ?? projectId}${title ? ` ${title}` : ""}`}
-                description={description ?? (projectInfo?.data?.description as string)}
-              />
-            </Grid>
-            <Grid item>
-              {projectInfo && (
-                <QuickLinksAndSettings
-                  linkGroups={(projectInfo.linkGroups as QuickLinkGroup[]) || []}
-                  configLinks={configLinks ?? []}
-                  showSettings={quickLinkSettings}
-                />
-              )}
-            </Grid>
-          </Grid>
-        </Grid>
         <Grid container item spacing={2}>
           {children && children}
         </Grid>

--- a/frontend/workflows/projectCatalog/src/index.tsx
+++ b/frontend/workflows/projectCatalog/src/index.tsx
@@ -15,7 +15,7 @@ const register = (): WorkflowConfiguration => {
     displayName: "Catalog",
     defaultLayoutProps: {
       variant: "standard",
-      breadcrumbsOnly: true,
+      usesContext: true,
     },
     routes: {
       catalog: {
@@ -24,9 +24,6 @@ const register = (): WorkflowConfiguration => {
         description: "A searchable catalog of services",
         component: Catalog,
         featureFlag: "projectCatalog",
-        layoutProps: {
-          breadcrumbsOnly: false,
-        },
       },
       details: {
         path: "/:projectId",

--- a/frontend/workflows/redisexperimentation/src/index.tsx
+++ b/frontend/workflows/redisexperimentation/src/index.tsx
@@ -13,6 +13,9 @@ const register = (): WorkflowConfiguration => {
     path: "redis-experimentation",
     group: "Chaos Experimentation",
     displayName: "Redis Fault Injection",
+    defaultLayoutProps: {
+      variant: "standard",
+    },
     routes: {
       startExperiment: {
         path: "/start",


### PR DESCRIPTION
### Description

- Added a Context for the Workflow Layout component to support dynamic content
- Removed the breadcrumbsOnly prop
- Refactored workflows that previously had header content

### Screenshots

#### Before 

![localhost_3000_catalog_clutch (1)](https://github.com/user-attachments/assets/eb665e32-78a7-4f0e-b369-00f8c133866d)

#### After

![localhost_3000_catalog_clutch](https://github.com/user-attachments/assets/5dca3cfa-40a0-4ba9-b010-1dd0f444e470)


### Testing Performed

Manual