### PR TITLE
backend: Create GetFileContents method in GitHub service

### DIFF
--- a/backend/mock/service/githubmock/githubmock.go
+++ b/backend/mock/service/githubmock/githubmock.go
@@ -128,6 +128,15 @@ func (s *svc) SearchCode(ctx context.Context, query string, opts *githubv3.Searc
 	}, nil
 }
 
+func (s *svc) GetFileContents(ctx context.Context, ref *github.RemoteRef, path string) (*githubv3.RepositoryContent, error) {
+	return &githubv3.RepositoryContent{
+		Name:     githubv3.String("README.md"),
+		Path:     githubv3.String("README.md"),
+		Content:  githubv3.String("# Hello World"),
+		Encoding: githubv3.String(""),
+	}, nil
+}
+
 func NewAsService(*any.Any, *zap.Logger, tally.Scope) (service.Service, error) {
 	return New(), nil
 }

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -46,7 +46,7 @@ const (
 )
 
 // RegEx only for Repositories.GetContents
-// must match something like `/repos/lyft/clutch-private/contents/manifest.yaml`
+// must match something like `/repos/lyft/clutch/contents/README.md`
 var getRepositoryContentRegex = regexp.MustCompile(`^\/repos\/[\w-]+\/[\w-]+\/contents\/[\w-.\/]+$`)
 
 type FileMap map[string]io.ReadCloser
@@ -407,7 +407,6 @@ func commitOptionsFromClaims(ctx context.Context, commitTime time.Time) *git.Com
 
 // Creates a new branch with a commit containing files and pushes it to the remote.
 func (s *svc) CreateBranch(ctx context.Context, req *CreateBranchRequest) error {
-	println("\n\n\n\n>>>>> CreateBranch service")
 	_, err := s.createWorktreeCommit(ctx, req.Ref, req.CommitMessage, req.Files, &req.BranchName, &req.SingleBranch)
 	if err != nil {
 		return err

--- a/backend/service/github/github.go
+++ b/backend/service/github/github.go
@@ -53,7 +53,7 @@ type StatsRoundTripper struct {
 
 func (st *StatsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if st.AcceptRaw && GetRepositoryContentRegex.Match([]byte(req.URL.Path)) {
-		req.Header.Set("accept", AcceptRawMediaTypeGithub)
+		req.Header.Set("accept", AcceptGithubRawMediaType)
 	}
 
 	resp, err := st.Wrapped.RoundTrip(req)

--- a/backend/service/github/helpers.go
+++ b/backend/service/github/helpers.go
@@ -1,0 +1,66 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	githubv3 "github.com/google/go-github/v54/github"
+)
+
+const (
+	// From https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#media-types
+	// and https://docs2.lfe.io/v3/media/
+	AcceptRawMediaTypeGithub = "application/vnd.github.v3.raw+json"
+	// From https://cs.opensource.google/go/go/+/master:src/encoding/json/scanner.go;l=593?q=scanner.go&ss=go%2Fgo
+	JSONSyntaxErrorPrefix = "invalid character"
+)
+
+// RegEx only for `Repositories.GetContents` must match something like `/repos/lyft/clutch/contents/README.md`
+var GetRepositoryContentRegex = regexp.MustCompile(`^\/repos\/[\w-]+\/[\w-]+\/contents\/[\w-.\/]+$`)
+
+// `Repositories.GetContents“ method cannot process a raw response, so we intercept it
+func InterceptGetRepositoryContentResponse(res *http.Response) error {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	var fileContentBytes []byte
+	var fileContent *githubv3.RepositoryContent
+
+	// Sometimes we get a githubv3.RepositoryContent body and we have to check
+	err = json.Unmarshal(body, &fileContent)
+	switch {
+	case fileContent != nil &&
+		fileContent.Content != nil &&
+		fileContent.Encoding != nil &&
+		fileContent.Path != nil &&
+		fileContent.GitURL != nil:
+		fileContentBytes = body
+	case err != nil:
+		if !strings.HasPrefix(err.Error(), JSONSyntaxErrorPrefix) {
+			return err
+		}
+		fallthrough
+	default:
+		// Set the body as a `githubv3.RepositoryContent`
+		fileContentBytes, err = json.Marshal(&githubv3.RepositoryContent{
+			Content:  githubv3.String(string(body)),
+			Encoding: githubv3.String(""), // The content is not encoded
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Recreate the response body
+	res.Body = io.NopCloser(bytes.NewReader(fileContentBytes))
+	res.ContentLength = int64(len(fileContentBytes))
+
+	return nil
+}

--- a/backend/service/github/helpers.go
+++ b/backend/service/github/helpers.go
@@ -14,7 +14,7 @@ import (
 const (
 	// From https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#media-types
 	// and https://docs2.lfe.io/v3/media/
-	AcceptRawMediaTypeGithub = "application/vnd.github.v3.raw+json"
+	AcceptGithubRawMediaType = "application/vnd.github.v3.raw+json"
 	// From https://cs.opensource.google/go/go/+/master:src/encoding/json/scanner.go;l=593?q=scanner.go&ss=go%2Fgo
 	JSONSyntaxErrorPrefix = "invalid character"
 )


### PR DESCRIPTION
### Description

- Created GetFileContents method in GitHub service

This method behaves similarly to `getFile` but is able to retry the request if the file is larger than 1MB. See [Get repository content](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content).

### Testing Performed

Manual and mocks
