### PR TITLE
frontend: add confirm action component via context

### DIFF
--- a/frontend/packages/core/src/AppLayout/index.tsx
+++ b/frontend/packages/core/src/AppLayout/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
-import styled from "@emotion/styled";
 import { Grid as MuiGrid } from "@mui/material";
 
 import Loadable from "../loading";
+import styled from "../styled";
 import type { AppConfiguration } from "../Types";
 
 import Drawer from "./drawer";
@@ -22,7 +22,7 @@ const ContentGrid = styled(MuiGrid)<{ $isFullScreen: boolean }>(
   })
 );
 
-const MainContent = styled.div({ overflowY: "auto", width: "100%" });
+const MainContent = styled("div")({ overflowY: "auto", width: "100%" });
 
 interface AppLayoutProps {
   isLoading?: boolean;

--- a/frontend/packages/core/src/Contexts/index.tsx
+++ b/frontend/packages/core/src/Contexts/index.tsx
@@ -1,7 +1,7 @@
 export { ApplicationContext, useAppContext } from "./app-context";
 export { ShortLinkContext, useShortLinkContext } from "./short-link-context";
 export { WizardContext, useWizardContext } from "./wizard-context";
-export type { WizardNavigationProps } from "./wizard-context";
+export type { WizardNavigationProps, ConfirmActionProps } from "./wizard-context";
 export { WorkflowStorageContext, useWorkflowStorageContext } from "./workflow-storage-context";
 export type {
   WorkflowRemoveDataFn,

--- a/frontend/packages/core/src/Contexts/wizard-context.tsx
+++ b/frontend/packages/core/src/Contexts/wizard-context.tsx
@@ -22,7 +22,7 @@ export interface ContextProps {
   setIsLoading: (isLoading: boolean) => void;
   setHasError: (hasError: boolean) => void;
   setIsComplete?: (isComplete: boolean) => void;
-  showConfirmAction: (props: ConfirmActionProps) => void;
+  showConfirmAction?: (props: ConfirmActionProps) => void;
 }
 
 const WizardContext = React.createContext<() => ContextProps>(undefined);

--- a/frontend/packages/core/src/Contexts/wizard-context.tsx
+++ b/frontend/packages/core/src/Contexts/wizard-context.tsx
@@ -5,6 +5,13 @@ export interface WizardNavigationProps {
   keepSearch?: boolean;
 }
 
+export interface ConfirmActionProps {
+  title: string;
+  description: string;
+  confirmationText: string;
+  onConfirm: () => void;
+}
+
 export interface ContextProps {
   displayWarnings: (warnings: string[]) => void;
   onBack: (params?: WizardNavigationProps) => void;
@@ -14,6 +21,7 @@ export interface ContextProps {
   setIsLoading: (isLoading: boolean) => void;
   setHasError: (hasError: boolean) => void;
   setIsComplete?: (isComplete: boolean) => void;
+  showConfirmAction: (props: ConfirmActionProps) => void;
 }
 
 const WizardContext = React.createContext<() => ContextProps>(undefined);

--- a/frontend/packages/core/src/Contexts/wizard-context.tsx
+++ b/frontend/packages/core/src/Contexts/wizard-context.tsx
@@ -8,6 +8,7 @@ export interface WizardNavigationProps {
 export interface ConfirmActionProps {
   title: string;
   description: string;
+  actionLabel?: string;
   confirmationText: string;
   onConfirm: () => void;
 }

--- a/frontend/packages/core/src/Contexts/wizard-context.tsx
+++ b/frontend/packages/core/src/Contexts/wizard-context.tsx
@@ -7,7 +7,7 @@ export interface WizardNavigationProps {
 
 export interface ConfirmActionProps {
   title: string;
-  description: string;
+  description: React.ReactNode | string;
   actionLabel?: string;
   confirmationText: string;
   onConfirm: () => void;

--- a/frontend/packages/core/src/index.tsx
+++ b/frontend/packages/core/src/index.tsx
@@ -84,6 +84,7 @@ export type {
   WorkflowRetrieveDataFn,
   WorkflowStoreDataFn,
   WizardNavigationProps,
+  ConfirmActionProps,
 } from "./Contexts";
 export type { ClutchError } from "./Network/errors";
 export type { TypographyProps } from "./typography";

--- a/frontend/packages/wizard/src/confirm-action.tsx
+++ b/frontend/packages/wizard/src/confirm-action.tsx
@@ -34,7 +34,11 @@ const ConfirmAction: React.FC<ConfirmActionDialogProps> = ({
   return (
     <Dialog title={title} open={open} onClose={onCancel}>
       <DialogContent>
-        <Typography variant="body1">{description}</Typography>
+        {typeof description === "string" ? (
+          <Typography variant="body1">{description}</Typography>
+        ) : (
+          description
+        )}
         <TextField
           label="Confirmation"
           value={input}

--- a/frontend/packages/wizard/src/confirm-action.tsx
+++ b/frontend/packages/wizard/src/confirm-action.tsx
@@ -19,6 +19,7 @@ const ConfirmAction: React.FC<ConfirmActionDialogProps> = ({
   title,
   description,
   confirmationText,
+  actionLabel,
   onConfirm,
   onCancel,
 }) => {
@@ -42,9 +43,9 @@ const ConfirmAction: React.FC<ConfirmActionDialogProps> = ({
         />
       </DialogContent>
       <DialogActions>
-        <Button text="Cancel" onClick={onCancel} variant="secondary" />
+        <Button text="Cancel" onClick={onCancel} variant="neutral" />
         <Button
-          text="Confirm"
+          text={actionLabel || "Confirm"}
           onClick={handleConfirm}
           variant="danger"
           disabled={input !== confirmationText}

--- a/frontend/packages/wizard/src/confirm-action.tsx
+++ b/frontend/packages/wizard/src/confirm-action.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   Button,
   ConfirmActionProps,
@@ -23,7 +23,13 @@ const ConfirmAction: React.FC<ConfirmActionDialogProps> = ({
   onConfirm,
   onCancel,
 }) => {
-  const [input, setInput] = useState("");
+  const [input, setInput] = React.useState("");
+
+  React.useEffect(() => {
+    if (open) {
+      setInput("");
+    }
+  }, [open]);
 
   const handleConfirm = () => {
     if (input === confirmationText) {

--- a/frontend/packages/wizard/src/confirm-action.tsx
+++ b/frontend/packages/wizard/src/confirm-action.tsx
@@ -25,11 +25,7 @@ const ConfirmAction: React.FC<ConfirmActionDialogProps> = ({
 }) => {
   const [input, setInput] = React.useState("");
 
-  React.useEffect(() => {
-    if (open) {
-      setInput("");
-    }
-  }, [open]);
+  React.useEffect(() => setInput(""), []);
 
   const handleConfirm = () => {
     if (input === confirmationText) {

--- a/frontend/packages/wizard/src/confirm-action.tsx
+++ b/frontend/packages/wizard/src/confirm-action.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  TextField,
+  Typography,
+} from "@clutch-sh/core";
+
+interface ConfirmActionProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmationText: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmAction: React.FC<ConfirmActionProps> = ({
+  open,
+  title,
+  description,
+  confirmationText,
+  onConfirm,
+  onCancel,
+}) => {
+  const [input, setInput] = useState("");
+
+  const handleConfirm = () => {
+    if (input === confirmationText) {
+      onConfirm();
+    }
+  };
+
+  return (
+    <Dialog title={title} open={open} onClose={onCancel}>
+      <DialogContent>
+        <Typography variant="body1">{description}</Typography>
+        <TextField
+          label="Confirmation"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          fullWidth
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button text="Cancel" onClick={onCancel} variant="secondary" />
+        <Button
+          text="Confirm"
+          onClick={handleConfirm}
+          variant="danger"
+          disabled={input !== confirmationText}
+        />
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmAction;

--- a/frontend/packages/wizard/src/confirm-action.tsx
+++ b/frontend/packages/wizard/src/confirm-action.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import {
   Button,
+  ConfirmActionProps,
   Dialog,
   DialogActions,
   DialogContent,
@@ -8,16 +9,12 @@ import {
   Typography,
 } from "@clutch-sh/core";
 
-interface ConfirmActionProps {
+interface ConfirmActionDialogProps extends ConfirmActionProps {
   open: boolean;
-  title: string;
-  description: string;
-  confirmationText: string;
-  onConfirm: () => void;
   onCancel: () => void;
 }
 
-const ConfirmAction: React.FC<ConfirmActionProps> = ({
+const ConfirmAction: React.FC<ConfirmActionDialogProps> = ({
   open,
   title,
   description,

--- a/frontend/packages/wizard/src/confirm-action.tsx
+++ b/frontend/packages/wizard/src/confirm-action.tsx
@@ -25,7 +25,7 @@ const ConfirmAction: React.FC<ConfirmActionDialogProps> = ({
 }) => {
   const [input, setInput] = React.useState("");
 
-  React.useEffect(() => setInput(""), []);
+  React.useEffect(() => setInput(""), [open]);
 
   const handleConfirm = () => {
     if (input === confirmationText) {

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import type { WizardNavigationProps } from "@clutch-sh/core";
 import {
   Button,
@@ -27,6 +27,7 @@ import type {
 } from "@mui/material";
 import { alpha, Container as MuiContainer, Theme } from "@mui/material";
 
+import ConfirmAction from "./confirm-action";
 import { useWizardState, WizardActionType } from "./state";
 import type { WizardStepProps } from "./step";
 
@@ -124,6 +125,13 @@ const Wizard = ({
   const [state, dispatch] = useWizardState();
   const [wizardStepData, setWizardStepData] = React.useState<WizardStepData>({});
   const [globalWarnings, setGlobalWarnings] = React.useState<string[]>([]);
+  const [confirmActionOpen, setConfirmActionOpen] = useState(false);
+  const [confirmActionConfig, setConfirmActionConfig] = useState({
+    title: "",
+    description: "",
+    confirmationText: "",
+    onConfirm: () => {},
+  });
   const dataLayoutManager = useDataLayoutManager(dataLayout);
   const [, setSearchParams] = useSearchParams();
   const locationState = useLocation().state as { origin?: string };
@@ -185,6 +193,15 @@ const Wizard = ({
       },
       onNext: (params: WizardNavigationProps) => {
         handleNavigation(params, WizardActionType.NEXT);
+      },
+      showConfirmAction: (
+        title: string,
+        description: string,
+        confirmationText: string,
+        onConfirm: () => void
+      ) => {
+        setConfirmActionConfig({ title, description, confirmationText, onConfirm });
+        setConfirmActionOpen(true);
       },
     };
   };
@@ -299,6 +316,17 @@ const Wizard = ({
           {error}
         </Toast>
       ))}
+      <ConfirmAction
+        open={confirmActionOpen}
+        title={confirmActionConfig.title}
+        description={confirmActionConfig.description}
+        confirmationText={confirmActionConfig.confirmationText}
+        onConfirm={() => {
+          setConfirmActionOpen(false);
+          confirmActionConfig.onConfirm();
+        }}
+        onCancel={() => setConfirmActionOpen(false)}
+      />
     </Container>
   );
 };

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -131,7 +131,7 @@ const Wizard = ({
     description: "",
     confirmationText: "",
     onConfirm: () => {},
-  });
+  } as ConfirmActionProps);
   const dataLayoutManager = useDataLayoutManager(dataLayout);
   const [, setSearchParams] = useSearchParams();
   const locationState = useLocation().state as { origin?: string };

--- a/frontend/packages/wizard/src/wizard.tsx
+++ b/frontend/packages/wizard/src/wizard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import type { WizardNavigationProps } from "@clutch-sh/core";
+import type { ConfirmActionProps, WizardNavigationProps } from "@clutch-sh/core";
 import {
   Button,
   ButtonGroup,
@@ -194,13 +194,8 @@ const Wizard = ({
       onNext: (params: WizardNavigationProps) => {
         handleNavigation(params, WizardActionType.NEXT);
       },
-      showConfirmAction: (
-        title: string,
-        description: string,
-        confirmationText: string,
-        onConfirm: () => void
-      ) => {
-        setConfirmActionConfig({ title, description, confirmationText, onConfirm });
+      showConfirmAction: (props: ConfirmActionProps) => {
+        setConfirmActionConfig(props);
         setConfirmActionOpen(true);
       },
     };


### PR DESCRIPTION
This pull request introduces a confirmation dialog component and integrates it into the existing wizard component. The main changes include the creation of the `ConfirmAction` component and the necessary modifications to the `Wizard` component to utilize this new dialog.

<img width="721" alt="image" src="https://github.com/user-attachments/assets/4cd0187e-d3fc-490b-aa48-74e21d1359d7" />

### Addition of Confirmation Dialog:

* [`frontend/packages/wizard/src/confirm-action.tsx`](diffhunk://#diff-7d0b18d7ce5b6739fcd64ef9cc8fec33957b46bd0aabc0ebc4a41e7938f12473R1-R60): Created a new `ConfirmAction` component that displays a dialog with a confirmation text input and confirm/cancel buttons.

### Integration with Wizard Component:

* `frontend/packages/wizard/src/wizard.tsx`: 
  - Imported `useState` and the new `ConfirmAction` component. [[1]](diffhunk://#diff-fb5a2ff0894b9e7ddb45ec4d09e32f61843c333aff5fbc7ebf30371eaeefa373L1-R1) [[2]](diffhunk://#diff-fb5a2ff0894b9e7ddb45ec4d09e32f61843c333aff5fbc7ebf30371eaeefa373R30)
  - Added state variables to manage the dialog's open state and configuration.
  - Added a function `showConfirmAction` to configure and open the `ConfirmAction` dialog.
  - Integrated the `ConfirmAction` component into the `Wizard` component's JSX, passing the necessary props and handling the confirm and cancel actions.