### PR TITLE
frontend: bypass auth middleware for favicon and icon assets in root

### DIFF
--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
@@ -24,6 +23,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 
 	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
 	"github.com/lyft/clutch/backend/service"

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"golang.org/x/net/http2"
@@ -60,6 +61,19 @@ func copyHTTPResponse(resp *http.Response, w http.ResponseWriter) {
 }
 
 func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasSuffix(r.URL.Path, ".ico") || 
+		strings.HasSuffix(r.URL.Path, ".svg") || 
+		strings.HasSuffix(r.URL.Path, ".webp") {
+		if !strings.Contains(r.URL.Path[1:], "/") {
+			if f, err := a.fileSystem.Open(r.URL.Path); err == nil {
+				defer f.Close()
+				w.Header().Set("Cache-Control", "public, max-age=86400")
+				http.ServeContent(w, r, r.URL.Path, time.Time{}, f)
+				return
+			}
+		}
+	}
+
 	if apiPattern.MatchString(r.URL.Path) || r.URL.Path == "/healthcheck" {
 		// Serve from the embedded API handler.
 		a.next.ServeHTTP(w, r)

--- a/backend/gateway/mux/mux.go
+++ b/backend/gateway/mux/mux.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
@@ -23,8 +24,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 
 	gatewayv1 "github.com/lyft/clutch/backend/api/config/gateway/v1"
 	"github.com/lyft/clutch/backend/service"
@@ -62,8 +61,8 @@ func copyHTTPResponse(resp *http.Response, w http.ResponseWriter) {
 }
 
 func (a *assetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if strings.HasSuffix(r.URL.Path, ".ico") || 
-		strings.HasSuffix(r.URL.Path, ".svg") || 
+	if strings.HasSuffix(r.URL.Path, ".ico") ||
+		strings.HasSuffix(r.URL.Path, ".svg") ||
 		strings.HasSuffix(r.URL.Path, ".webp") {
 		if !strings.Contains(r.URL.Path[1:], "/") {
 			if f, err := a.fileSystem.Open(r.URL.Path); err == nil {


### PR DESCRIPTION
Updated the `ServeHTTP` function in the `assetHandler` to add caching headers for `.ico`, `.svg`, and `.webp` files, serving these files with a `Cache-Control` header set to cache for one day.

This change bypasses the authentication middleware for favicon and icon assets in the root directory. The bypass is limited to image assets in the root path to maintain security.

Key changes:
- Added early path check for image file extensions (.ico, .svg, .webp)
- Added security check to only serve files from root directory
- Set Cache-Control header to cache assets for 24 hours
- Serve files directly without going through auth middleware