### PR TITLE
[frontend] Adding confirmation modal to destructive actions in k8s workflow

### DIFF
--- a/frontend/workflows/k8s/src/cordon-node.tsx
+++ b/frontend/workflows/k8s/src/cordon-node.tsx
@@ -98,7 +98,13 @@ const CordonNode: React.FC<WorkflowProps> = ({ heading, resolverType, notes = []
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <NodeIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
-      <NodeDetails name="Verify" />
+      <NodeDetails
+        name="Verify"
+        confirmActionSettings={{
+          title: "Cordon/Uncordon Node",
+          description: `You are about to cordon/uncordon a Node, are you sure to proceed?`,
+        }}
+      />
       <Confirm name="Result" />
     </Wizard>
   );

--- a/frontend/workflows/k8s/src/cordon-node.tsx
+++ b/frontend/workflows/k8s/src/cordon-node.tsx
@@ -8,6 +8,7 @@ import {
   MetadataTable,
   Resolver,
   Switch,
+  Typography,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
@@ -77,6 +78,16 @@ const Confirm: React.FC<ConfirmChild> = () => {
   );
 };
 
+const ConfirmCordonNode = () => {
+  const resourceData = useDataLayout("resourceData").value;
+
+  return (
+    <Typography variant="body1">{`You are about to ${
+      resourceData.node.unschedulable ? "uncordon" : "cordon"
+    } ${resourceData.node.name}, are you sure to proceed?`}</Typography>
+  );
+};
+
 const CordonNode: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     resolverInput: {},
@@ -102,7 +113,7 @@ const CordonNode: React.FC<WorkflowProps> = ({ heading, resolverType, notes = []
         name="Verify"
         confirmActionSettings={{
           title: "Cordon/Uncordon Node",
-          description: `You are about to cordon/uncordon a Node, are you sure to proceed?`,
+          description: <ConfirmCordonNode />,
         }}
       />
       <Confirm name="Result" />

--- a/frontend/workflows/k8s/src/cordon-node.tsx
+++ b/frontend/workflows/k8s/src/cordon-node.tsx
@@ -79,12 +79,12 @@ const Confirm: React.FC<ConfirmChild> = () => {
 };
 
 const ConfirmCordonNode = () => {
-  const resourceData = useDataLayout("resourceData").value;
+  const node = useDataLayout("resourceData").displayValue() as IClutch.k8s.v1.Node;
 
   return (
-    <Typography variant="body1">{`You are about to ${
-      resourceData.node.unschedulable ? "uncordon" : "cordon"
-    } ${resourceData.node.name}, are you sure to proceed?`}</Typography>
+    <Typography variant="body1">{`You are about to ${node.unschedulable ? "uncordon" : "cordon"} ${
+      node.name
+    }, are you sure to proceed?`}</Typography>
   );
 };
 

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -88,10 +88,11 @@ const Confirm: React.FC<ConfirmChild> = () => {
 };
 
 const ConfirmDeletePod = () => {
-  const deletionData = useDataLayout("deletionData").value;
+  const podData = useDataLayout("resourceData");
+  const { name } = podData.displayValue();
 
   return (
-    <Typography variant="body1">{`You are about to delete pod ${deletionData.pod.name}, are you sure to proceed?`}</Typography>
+    <Typography variant="body1">{`You are about to delete pod ${name}, are you sure to proceed?`}</Typography>
   );
 };
 

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -107,7 +107,14 @@ const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <PodIdentifier name="Lookup" resolverType={resolverType} notes={notes} />
-      <PodDetails name="Verify" notes={notes} />
+      <PodDetails
+        name="Verify"
+        notes={notes}
+        confirmActionSettings={{
+          title: "Delete pod",
+          description: `You are about to delete a pod, are you sure to proceed?`,
+        }}
+      />
       <Confirm name="Result" />
     </Wizard>
   );

--- a/frontend/workflows/k8s/src/delete-pod.tsx
+++ b/frontend/workflows/k8s/src/delete-pod.tsx
@@ -11,6 +11,7 @@ import {
   NotePanel,
   Resolver,
   SimpleFeatureFlag,
+  Typography,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
@@ -86,6 +87,14 @@ const Confirm: React.FC<ConfirmChild> = () => {
   );
 };
 
+const ConfirmDeletePod = () => {
+  const deletionData = useDataLayout("deletionData").value;
+
+  return (
+    <Typography variant="body1">{`You are about to delete pod ${deletionData.pod.name}, are you sure to proceed?`}</Typography>
+  );
+};
+
 const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     resolverInput: {},
@@ -112,7 +121,7 @@ const DeletePod: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
         notes={notes}
         confirmActionSettings={{
           title: "Delete pod",
-          description: `You are about to delete a pod, are you sure to proceed?`,
+          description: <ConfirmDeletePod />,
         }}
       />
       <Confirm name="Result" />

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -11,6 +11,7 @@ import {
   NoteConfig,
   NotePanel,
   Resolver,
+  Typography,
   useWizardContext,
 } from "@clutch-sh/core";
 import { useDataLayout } from "@clutch-sh/data-layout";
@@ -221,6 +222,14 @@ const Confirm: React.FC<ConfirmChild> = ({ notes }) => {
   );
 };
 
+const ConfirmResizeHPA = () => {
+  const hpaData = useDataLayout("hpaData").value;
+
+  return (
+    <Typography variant="body1">{`You are about to resize HPA ${hpaData.name}, are you sure to proceed?`}</Typography>
+  );
+};
+
 const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] }) => {
   const dataLayout = {
     hpaData: {},
@@ -261,7 +270,7 @@ const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
         notes={notes}
         confirmActionSettings={{
           title: "Resize HPA",
-          description: `You are about to resize HPA, are you sure to proceed?`,
+          description: <ConfirmResizeHPA />,
         }}
       />
       <Confirm name="Result" notes={notes} />

--- a/frontend/workflows/k8s/src/resize-hpa.tsx
+++ b/frontend/workflows/k8s/src/resize-hpa.tsx
@@ -256,7 +256,14 @@ const ResizeHPA: React.FC<WorkflowProps> = ({ heading, resolverType, notes = [] 
   return (
     <Wizard dataLayout={dataLayout} heading={heading}>
       <HPAIdentifier name="Lookup" resolverType={resolverType} />
-      <HPADetails name="Modify" notes={notes} />
+      <HPADetails
+        name="Modify"
+        notes={notes}
+        confirmActionSettings={{
+          title: "Resize HPA",
+          description: `You are about to resize HPA, are you sure to proceed?`,
+        }}
+      />
       <Confirm name="Result" notes={notes} />
     </Wizard>
   );


### PR DESCRIPTION
Delete Pod
![Screenshot 2025-03-26 at 2 54 53 p m](https://github.com/user-attachments/assets/f50793e1-009c-4626-b0e2-5c17a511ac75)

Cordon/Uncordon node
![Screenshot 2025-03-26 at 2 54 18 p m](https://github.com/user-attachments/assets/0f3edac5-00ad-4757-b03c-3ee7762b5f76)


Resize HPA
![Screenshot 2025-03-26 at 2 22 38 p m](https://github.com/user-attachments/assets/17ca7883-532a-470e-b1d0-38997225c5a3)

