### PR TITLE
Use the correct form of `sha256.Sum256`.

### DIFF
--- a/backend/service/audit/audit.go
+++ b/backend/service/audit/audit.go
@@ -229,6 +229,6 @@ func (c *client) poll() {
 }
 
 func convertLockToUint32(lockID string) uint32 {
-	x := sha256.New().Sum([]byte(lockID))
-	return binary.BigEndian.Uint32(x)
+	x := sha256.Sum256([]byte(lockID))
+	return binary.BigEndian.Uint32(x[:])
 }

--- a/backend/service/audit/audit_test.go
+++ b/backend/service/audit/audit_test.go
@@ -206,17 +206,17 @@ func TestConvertLockToUint32(t *testing.T) {
 		{
 			id:     "key with chars",
 			input:  "audit:eventsink",
-			expect: 1635083369,
+			expect: 0xd8204ad5,
 		},
 		{
 			id:     "key with special chars",
 			input:  "*()#@&!*(#!@",
-			expect: 707275043,
+			expect: 0x7762da89,
 		},
 		{
 			id:     "key with numbers",
 			input:  "123123123",
-			expect: 825373489,
+			expect: 0x932f3c1b,
 		},
 	}
 

--- a/backend/service/topology/cache.go
+++ b/backend/service/topology/cache.go
@@ -79,8 +79,8 @@ func (c *client) tryAdvisoryLock(ctx context.Context, conn *sql.Conn, lockId uin
 }
 
 func convertLockIdToAdvisoryLockId(lockID string) uint32 {
-	x := sha256.New().Sum([]byte(lockID))
-	return binary.BigEndian.Uint32(x)
+	x := sha256.Sum256([]byte(lockID))
+	return binary.BigEndian.Uint32(x[:])
 }
 
 // This will check all services that are currently registered for the given clutch configuration

--- a/backend/service/topology/cache_test.go
+++ b/backend/service/topology/cache_test.go
@@ -28,12 +28,12 @@ func TestConvertLockIdToAdvisoryLockId(t *testing.T) {
 		{
 			id:     "key with chars",
 			input:  "topologycache",
-			expect: 1953460335,
+			expect: 0x6c80037f,
 		},
 		{
 			id:     "key with special chars",
 			input:  "*()#@&!*(#!@",
-			expect: 707275043,
+			expect: 0x7762da89,
 		},
 	}
 


### PR DESCRIPTION
### Description

`sha256.New().Sum(foo)` appends the SHA-256 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk

So I think the existing backend code grabbed a uint32 from the first few bytes of the `lockID` rather than its hash.

### Testing Performed

`cd backend; go test ./...`

### GitHub Issue
N/A

### TODOs

N/A